### PR TITLE
skill 設計改善のための `TODO.md` を追加

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+# TODO
+
+- `igapyon-tech-post-coach` と `igapyon-music-post-coach` の `SKILL.md` を見直し、毎回必要な指針だけを残す
+- 長い文体ルール、構成パターン、具体例は `references/` に分離する
+- `SKILL.md` から `references/` の参照タイミングが分かるように導線を書く
+- 必要になった段階で `agents/openai.yaml` の追加を検討する


### PR DESCRIPTION
## 概要

skill の今後の整理方針を明文化するため、リポジトリ直下に `TODO.md` を追加します。

## 変更内容

- `TODO.md` を新規追加
- 既存 skill の `SKILL.md` を軽量化する方針を記載
- 長い文体ルールや構成パターン、具体例を `references/` へ分離する方針を記載
- `SKILL.md` から `references/` への導線整備を TODO として追加
- 必要に応じて `agents/openai.yaml` を追加検討する旨を記載

## 目的

- skill の肥大化を防ぎ、保守しやすい構成に近づける
- 毎回必要な指針と、必要時のみ参照する詳細情報を分離する
- 今後の skill 改善作業の優先事項を明確にする

## 影響範囲

- ドキュメント追加のみ
- 既存 skill の挙動や同期処理への直接的な変更はなし