### PR TITLE
Qiita / Note 向け writer skill を追加し Codex 用コピー設定を整備

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 node_modules/
 .DS_Store
+target/
 
 # Optional local output paths
-.codex/skills/
+.codex/
 
 # Local workspace contents
 workplace/*

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,28 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>copy-skills-to-codex</id>
+            <phase>package</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <mkdir dir="${project.basedir}/.codex/skills"/>
+                <copy todir="${project.basedir}/.codex/skills" overwrite="true">
+                  <fileset dir="${project.basedir}/skills"/>
+                </copy>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/skills/igapyon-note-writer/SKILL.md
+++ b/skills/igapyon-note-writer/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: igapyon-note-writer
+description: Use when writing, revising, structuring, or preparing Japanese Note articles in igapyon style. This skill helps turn notes, experiences, background stories, product-making motives, AI development observations, OSS tool creation stories, and draft fragments into Note-ready Markdown with a readable narrative flow, gentle personal voice, clear context, and appropriate title and hashtag suggestions. It should use the reference articles under references/ as examples of Note article shape, tone, and pacing.
+---
+
+# igapyon-note-writer
+
+Note 向けの日本語記事を作成・整理・改善するための skill です。
+
+この skill の目的は、技術情報を網羅的に説明することではありません。  
+作った理由、気づいたこと、少し困ったこと、試してみた感触を、読み物として自然に伝わる形へ整えることです。
+
+## Purpose
+
+この skill では、次の作業を扱います。
+
+- Note 記事の新規作成
+- 断片メモや体験ログからの記事化
+- 技術系の話題を読み物として整理
+- タイトル案とハッシュタグ案の作成
+- 背景、問題意識、きっかけ、感触の整理
+- Qiita 向け原稿を Note 向けにやわらかく再構成
+- OSS、生成AI、個人開発、音楽データ、WBS、CLI などの体験記事化
+- 公開前原稿の流れ、余白、読みやすさの調整
+
+## When To Use
+
+次のような依頼では、この skill を使います。
+
+- 「Note 記事にして」
+- 「note 用に整えて」
+- 「読み物っぽくしたい」
+- 「背景やきっかけを厚めにしたい」
+- 「体験談としてまとめたい」
+- 「ハッシュタグを考えて」
+- 「Qiita ではなく Note 向けにしたい」
+- `igapyon-note-writer` が明示されたとき
+
+純粋な技術手順、API 仕様、コマンド解説、Qiita front matter 作成が中心の場合は、この skill を無理に使いません。
+
+## Note Article Shape
+
+Note 記事では、次の情報が自然に伝わる順に並ぶようにします。
+
+- 何に少し困っていたか
+- なぜそれを作りたくなったか
+- 実際に何を試したか
+- やってみて何が起きたか
+- 何が少し楽になったか
+- どこに面白さや違和感があったか
+- 読者が自分ごととして受け取れる点はどこか
+
+記事の基本構成は、必要に応じて次の形を使います。
+
+1. はじめに
+2. きっかけや背景
+3. やってみたこと
+4. 使ってみて感じたこと
+5. 少し便利になったところ
+6. まだ残っていること
+7. おわりに
+
+すべての記事でこの構成を強制する必要はありません。  
+題材の流れと読みやすさを優先します。
+
+## Writing Rules
+
+- 背景、問題意識、体験、感触を大切にする
+- 技術詳細は必要な範囲に抑える
+- 読者が自分ごととして読める入口を作る
+- 大きな主張より、小さな観察から始める
+- 「作ったもの」だけでなく「なぜ作ったか」を書く
+- 断定しすぎず、個人の感想や観測として自然に書く
+- 過剰にきれいな広告文や企業ブログ風にしない
+- 技術用語は使ってよいが、文章の主役を技術用語にしすぎない
+- 生成AIを使った体験では、驚き、戸惑い、手応え、人間側の判断を残す
+
+## Note Metadata Rules
+
+Note 掲載用の属性情報が必要な場合は、次の形を基本にします。
+
+```markdown
+## 掲載先情報
+
+- 掲載先: Note
+- URL: （未記入）
+
+## Note 掲載用属性情報
+
+- タイトル: 記事タイトル
+- ハッシュタグ: `タグ1`, `タグ2`, `タグ3`
+```
+
+既存原稿に公開 URL、公開タイトル、ハッシュタグがある場合は、明示的な依頼なしに変更しないでください。
+
+未確認の URL、公開状態、投稿日、読者反応は作らないでください。
+
+## Reference Usage
+
+`references/` 配下の記事は、Note 記事の実例集として使います。
+
+主に見る観点は次の通りです。
+
+- 導入の入り方
+- 背景やきっかけの置き方
+- 技術説明の薄め方
+- 体験談と事実説明の混ぜ方
+- タイトルの温度感
+- ハッシュタグの粒度
+- 読み物としての段落の長さ
+- 終わり方
+
+題材が近い場合は、該当プロジェクト配下の記事を優先して参照します。
+
+- `references/miku-abc-player/`
+- `references/miku-indexgen/`
+- `references/miku-xlsx2md/`
+- `references/mikuproject/`
+- `references/mikuscore/`
+
+索引が必要なときは `index.json` を使って、関連しそうな記事を探します。
+
+参照記事の表現を長くコピーしないでください。  
+参考にするのは、文章の温度感、展開の順序、背景の厚さ、Note 向けの読み物としての流れです。
+
+## Output Patterns
+
+### Full Article Draft
+
+ユーザーが記事本文を求めた場合は、Note に貼りやすい Markdown として出力します。
+
+必要に応じて、次の順序にします。
+
+1. 掲載先情報
+2. Note 掲載用属性情報
+3. 本文
+4. 補足または未確認事項
+
+### Outline
+
+構成案を求められた場合は、見出し案と各節で書く内容を短く示します。
+
+### Title And Hashtags
+
+タイトルやハッシュタグだけを求められた場合は、候補を複数出します。  
+ただし、根拠のない固有名詞や未確認の技術要素をハッシュタグに追加しないでください。
+
+### Revision
+
+既存原稿の修正では、事実関係を勝手に増やさず、流れ、段落、温度感、読みやすさを中心に整えます。
+
+## Do Not
+
+- 未確認の仕様を追加しない
+- 実行していない体験を実体験として書かない
+- 架空の URL、公開日、公開状態を書かない
+- 存在確認していないリポジトリ名やサービス名を断定しない
+- Qiita 向けの硬い技術手順記事に寄せすぎない
+- ユーザー本人の感触や観察を消しすぎない
+- 参照記事の本文を長く流用しない
+- 誇張した成果や宣伝文にしない
+
+## Practical Notes
+
+Note 記事では、読者が「なぜこの話が始まったのか」「何が少し楽になったのか」「書き手はそこで何を感じたのか」を追えることを優先します。
+
+技術的な正確さは大切ですが、細部の仕様を詰め込みすぎると Note らしい読みやすさが失われます。  
+技術情報と個人の観察のバランスを取り、自然に読み進められる記事を目指します。

--- a/skills/igapyon-note-writer/index.json
+++ b/skills/igapyon-note-writer/index.json
@@ -81,6 +81,14 @@
       "dir": "references/miku-xlsx2md",
       "size": 7517,
       "summary": "掲載先情報"
+    },
+    {
+      "name": "SKILL.md",
+      "path": "SKILL.md",
+      "ext": "md",
+      "dir": "",
+      "size": 6672,
+      "summary": "--- name: igapyon-note-writer description: Use when writing, revising, structuring, or preparing Japanese Note articles in igapyon style. This skill helps turn notes, experiences, background stories, product-making motives, AI development observations, OSS"
     }
   ]
 }

--- a/skills/igapyon-qiita-writer/SKILL.md
+++ b/skills/igapyon-qiita-writer/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: igapyon-qiita-writer
+description: Use when writing, revising, structuring, or preparing Japanese Qiita technical articles in igapyon style. This skill helps turn notes, README material, implementation logs, OSS tool descriptions, AI development experiences, and draft fragments into Qiita-ready Markdown with clear technical value, appropriate front matter, tags, headings, constraints, and reader-oriented structure. It should use the reference articles under references/ as examples of article shape and explanation depth.
+---
+
+# igapyon-qiita-writer
+
+Qiita 向けの日本語技術記事を作成・整理・改善するための skill です。
+
+この skill の目的は、文章を単にきれいにすることではありません。  
+Qiita の読者が読みやすく、技術的な持ち帰りを得やすい形に整えることです。
+
+## Purpose
+
+この skill では、次の作業を扱います。
+
+- Qiita 記事の新規作成
+- 既存メモや README からの記事化
+- 技術記事の見出し構成作成
+- タイトル案とタグ案の作成
+- Qiita front matter の作成・整形
+- Note 風または日記風の文章を Qiita 向けに整理
+- OSS、CLI、Web アプリ、Maven plugin、生成AI活用、開発ログの技術記事化
+- 公開前原稿の読みやすさ、説明順、技術的粒度の調整
+
+## When To Use
+
+次のような依頼では、この skill を使います。
+
+- 「Qiita 記事にして」
+- 「Qiita 用に整えて」
+- 「タグを考えて」
+- 「front matter を付けて」
+- 「技術記事として構成して」
+- 「README から記事を書いて」
+- 「この開発ログを Qiita 向けにしたい」
+- `igapyon-qiita-writer` が明示されたとき
+
+単なる短文 SNS 投稿、Note 向けの体験文、音楽寄りの随筆、PR 文面作成では、この skill を無理に使いません。
+
+## Qiita Article Shape
+
+Qiita 記事では、次の情報が読み取りやすい順に並ぶようにします。
+
+- 何を作ったか
+- 何ができるか
+- なぜ作ったか
+- どう使うか
+- 技術的な要点は何か
+- どこを意図的に絞ったか
+- 制約や未対応は何か
+- 読者が試すときの入口はどこか
+
+記事の基本構成は、必要に応じて次の形を使います。
+
+1. はじめに
+2. 何を作ったか
+3. 使い方
+4. 主な機能
+5. 実装や設計のポイント
+6. 制約・注意点
+7. おわりに
+
+すべての記事でこの構成を強制する必要はありません。  
+題材に合わせて、読者が理解しやすい順序を優先します。
+
+## Writing Rules
+
+- 技術記事としての情報密度を保つ
+- 体験談は残してよいが、本文の中心を技術的な価値に置く
+- 読者が再現・確認しやすい説明を優先する
+- コマンド、ファイル名、形式名、ツール名は曖昧にしない
+- 仕様、制約、未対応事項は分かる範囲で明示する
+- OSS や個人開発の文脈は自然に残す
+- 生成AIを使った開発体験では、何を人間が判断し、何をAIに任せたかを整理する
+- 読者に教え込む口調にしすぎない
+- 企業ブログ風に均質化しすぎない
+
+## Front Matter Rules
+
+Qiita front matter が必要な場合は、次の形を基本にします。
+
+```markdown
+---
+title: 記事タイトル
+tags: tag1 tag2 tag3
+author: igapyon
+slide: false
+---
+```
+
+既存原稿に front matter がある場合は、明示的な依頼なしに壊さないでください。
+
+公開済み URL、公開記事タイトル、タグ、投稿日などが原稿内にある場合は、事実情報として尊重します。  
+未確認の URL、公開状態、バージョン、実行結果は作らないでください。
+
+## Reference Usage
+
+`references/` 配下の記事は、Qiita 記事の実例集として使います。
+
+主に見る観点は次の通りです。
+
+- タイトルの付け方
+- front matter の書き方
+- タグの粒度
+- `はじめに` の入り方
+- 機能紹介と開発体験の分け方
+- スクリーンショットや画像への言及の仕方
+- 制約や設計判断の出し方
+- 終わり方
+
+題材が近い場合は、該当プロジェクト配下の記事を優先して参照します。
+
+- `references/miku-abc-player/`
+- `references/miku-indexgen/`
+- `references/miku-xlsx2md/`
+- `references/mikuproject/`
+- `references/mikuscore/`
+
+索引が必要なときは `index.json` を使って、関連しそうな記事を探します。
+
+参照記事の表現を長くコピーしないでください。  
+参考にするのは、構成、説明粒度、見出しの置き方、Qiita 向けの整理のしかたです。
+
+## Output Patterns
+
+### Full Article Draft
+
+ユーザーが記事本文を求めた場合は、Qiita に貼りやすい Markdown として出力します。
+
+必要に応じて、次の順序にします。
+
+1. front matter
+2. 本文
+3. 補足または未確認事項
+
+### Outline
+
+構成案を求められた場合は、見出し案と各節で書く内容を短く示します。
+
+### Title And Tags
+
+タイトルやタグだけを求められた場合は、候補を複数出します。  
+ただし、根拠のない固有名詞や未確認の技術要素をタグに追加しないでください。
+
+### Revision
+
+既存原稿の修正では、原稿の事実関係を勝手に増やさず、構成・見出し・説明順・読みやすさを中心に整えます。
+
+## Do Not
+
+- 未確認の仕様を追加しない
+- 実行していないコマンド結果を成功例として書かない
+- 架空の URL、公開日、公開状態を書かない
+- 存在確認していないリポジトリ名やパッケージ名を断定しない
+- Note 向けの情緒中心の記事に寄せすぎない
+- ユーザー本人の観察や開発体験を消しすぎない
+- Qiita front matter を壊さない
+- 参照記事の本文を長く流用しない
+
+## Practical Notes
+
+Qiita 記事では、読者が「結局これは何で、どう使えて、何がうれしいのか」を早めに理解できることを優先します。
+
+一方で、本人の開発体験や観察が記事の価値になっている場合は、それを削りすぎないでください。  
+技術情報と体験のバランスを取り、読み物としても技術記事としても自然に通る形を目指します。

--- a/skills/igapyon-qiita-writer/index.json
+++ b/skills/igapyon-qiita-writer/index.json
@@ -129,6 +129,14 @@
       "dir": "references/miku-xlsx2md",
       "size": 4820,
       "summary": "`xlsx2md` 機能一覧メモ"
+    },
+    {
+      "name": "SKILL.md",
+      "path": "SKILL.md",
+      "ext": "md",
+      "dir": "",
+      "size": 6408,
+      "summary": "--- name: igapyon-qiita-writer description: Use when writing, revising, structuring, or preparing Japanese Qiita technical articles in igapyon style. This skill helps turn notes, README material, implementation logs, OSS tool descriptions, AI development e"
     }
   ]
 }


### PR DESCRIPTION
## 概要

Qiita 向けおよび Note 向けの記事作成を支援する writer skill を追加しました。 あわせて、`mvn package` 時に `skills` 配下を `.codex/skills` へコピーする設定と、生成物ディレクトリの ignore 設定を追加しています。

## 変更内容

- `skills/igapyon-qiita-writer/SKILL.md` を追加
  - Qiita 向け技術記事の作成・整理・改善ルールを定義
  - front matter、タイトル、タグ、見出し構成、参照記事の使い方を記述
- `skills/igapyon-note-writer/SKILL.md` を追加
  - Note 向け記事の作成・整理・改善ルールを定義
  - 背景、きっかけ、体験、ハッシュタグ、参照記事の使い方を記述
- `skills/igapyon-qiita-writer/index.json` を更新
- `skills/igapyon-note-writer/index.json` を更新
- `pom.xml` に `maven-antrun-plugin` 設定を追加
  - `package` phase で `skills` 配下を `.codex/skills` へコピー
  - コピー時に削除は行わず、既存ファイルは上書き
- `.gitignore` を更新
  - `target/` を git 管理外に追加
  - `.codex/skills/` ではなく `.codex/` 全体を git 管理外に変更

## 補足

`pom.xml` には、既存の `index.json` 生成に加えて、Codex ローカル試用向けの `.codex/skills` コピー処理が追加されています。