### PR TITLE
READMEと伴走型スキル定義を現行構成に合わせて更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 個人用の Agent Skills を管理するためのリポジトリです。
 
+日本語の Qiita / Note 記事作成と、技術・音楽投稿の伴走型ライティング支援に使う skill を置いています。
+
 ## 方針
 
 - skill は `skills/` 配下に置く
@@ -9,6 +11,7 @@
 - skill ごとの詳細仕様は各 `SKILL.md` に書く
 - repo 全体の運用ルールはこの `README.md` に書く
 - 作業メモは repo 直下の `TODO.md` に集約する
+- skill ごとの `index.json` は `miku-indexgen` で生成する
 
 ## references の扱い
 
@@ -27,18 +30,45 @@
 ```text
 .
 ├─ skills/
-│  ├─ igapyon-techpost-writer/
+│  ├─ igapyon-qiita-writer/
+│  │  ├─ SKILL.md
+│  │  └─ references/
+│  ├─ igapyon-note-writer/
+│  │  ├─ SKILL.md
+│  │  └─ references/
+│  ├─ igapyon-companion-techpost-writer/
 │  │  └─ SKILL.md
-│  └─ igapyon-musicpost-writer/
+│  └─ igapyon-companion-musicpost-writer/
 │     └─ SKILL.md
+├─ pom.xml
 ├─ TODO.md
 └─ README.md
 ```
 
 ## 現在の skill
 
-- `igapyon-techpost-writer`  
+- `igapyon-qiita-writer`
+
+  Qiita 向けの日本語技術記事の作成、整理、改善向け
+
+- `igapyon-note-writer`
+
+  Note 向けの日本語記事の作成、整理、改善向け
+
+- `igapyon-companion-techpost-writer`
+
   技術系日本語投稿の伴走、最小整理、全文再構成向け
 
-- `igapyon-musicpost-writer`  
+- `igapyon-companion-musicpost-writer`
+
   音楽系日本語投稿の伴走、最小整理、全文再構成向け
+
+## index.json の更新
+
+各 skill の `index.json` を更新する場合は、次のコマンドで `skills/` 配下をまとめて再生成します。
+
+```sh
+mvn generate-resources
+```
+
+生成された `index.json` は、skill と一緒にコミットします。

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 # TODO
 
-- [ ] 必要性が明確になったら tech/music 以外の skill を追加する
+- [ ] 必要性が明確になったら writer skill を追加する
 - [ ] skill 配布先が必要になったら mirror 方針を決める
 - [ ] UI metadata が必要になったら skill 用の `agents/openai.yaml` を検討する

--- a/skills/igapyon-companion-musicpost-writer/SKILL.md
+++ b/skills/igapyon-companion-musicpost-writer/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: igapyon-musicpost-writer
-description: japanese writing coach for music-related posts in igapyon style. use when the user wants to polish, extend, reorganize, or iteratively develop japanese social posts or blog posts about music, performance, scores, listening experiences, instruments, composition, or music technology while preserving the user's personal voice, observation-driven narrative, gentle tone, and minimal-edit workflow. especially relevant when the input arrives in fragments, when the user wants light polishing instead of a full rewrite, or when they want a full current draft assembled from accepted fragments.
+name: igapyon-companion-musicpost-writer
+description: collaborative Japanese writing companion for music-related posts in igapyon style. use when the user wants to polish, extend, reorganize, or iteratively develop Japanese social posts or blog posts about music, performance, scores, listening experiences, instruments, composition, or music technology while preserving the user's personal voice, observation-driven narrative, gentle tone, and minimal-edit workflow. especially relevant when the input arrives in fragments, when the user wants light polishing instead of a full rewrite, or when they want a full current draft assembled from accepted fragments.
 ---
 
-# igapyon-musicpost-writer
+# igapyon-companion-musicpost-writer
 
 音楽系の日本語投稿を、ユーザー本人の声を残したまま自然に整えるための執筆伴走スキルです。  
 目的は、文章を均質に美しく作り替えることではなく、**本人の観察や感触や発見を残しながら、自然に読める形へ最小限に整えること**です。
@@ -80,6 +80,7 @@ description: japanese writing coach for music-related posts in igapyon style. us
 - 文体や言い回しの細かな指針が必要なときは [references/style-guide.md](references/style-guide.md) を読む
 - とくにクラシック音楽寄りの投稿、楽器まわりの感触や選択ログを扱うときは、`style-guide.md` のクラシック寄り文体メモを優先して参照する
 - 構成パターンや段落設計、締め方の例が必要なときは [references/structure-patterns.md](references/structure-patterns.md) を読む
+- 参照資料の全体像を確認したいときは `index.json` を使って、必要な `references/` ファイルを探す
 - どちらも必要ない場合は、この `SKILL.md` の指針だけで進める
 
 ## 応答パターン

--- a/skills/igapyon-companion-musicpost-writer/index.json
+++ b/skills/igapyon-companion-musicpost-writer/index.json
@@ -23,8 +23,8 @@
       "path": "SKILL.md",
       "ext": "md",
       "dir": "",
-      "size": 5353,
-      "summary": "--- name: igapyon-musicpost-writer description: japanese writing coach for music-related posts in igapyon style. use when the user wants to polish, extend, reorganize, or iteratively develop japanese social posts or blog posts about music, performance, sco"
+      "size": 5519,
+      "summary": "--- name: igapyon-companion-musicpost-writer description: collaborative Japanese writing companion for music-related posts in igapyon style. use when the user wants to polish, extend, reorganize, or iteratively develop Japanese social posts or blog posts a"
     }
   ]
 }

--- a/skills/igapyon-companion-techpost-writer/SKILL.md
+++ b/skills/igapyon-companion-techpost-writer/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: igapyon-techpost-writer
-description: japanese writing coach for tech posts in igapyon style. use when the user wants to polish, extend, reorganize, or iteratively develop japanese tech blog posts or social posts while preserving the user's personal voice, observation-driven narrative, gentle tone, and minimal-edit workflow. especially relevant when the input arrives in fragments, when the user asks for a lightly polished version instead of a full rewrite, or when they want a full current draft assembled from accepted fragments.
+name: igapyon-companion-techpost-writer
+description: collaborative Japanese writing companion for tech posts in igapyon style. use when the user wants to polish, extend, reorganize, or iteratively develop Japanese tech blog posts or social posts while preserving the user's personal voice, observation-driven narrative, gentle tone, and minimal-edit workflow. especially relevant when the input arrives in fragments, when the user asks for a lightly polished version instead of a full rewrite, or when they want a full current draft assembled from accepted fragments.
 ---
 
-# igapyon-techpost-writer
+# igapyon-companion-techpost-writer
 
 技術系の日本語投稿を、ユーザー本人の声を残したまま自然に整えるための執筆伴走スキルです。  
 目的は、美文に作り替えることではなく、**本人らしさを保ちながら最小限の整理で前に進めること**です。
@@ -75,6 +75,7 @@ description: japanese writing coach for tech posts in igapyon style. use when th
 - 文体や言い回しの細かな指針が必要なときは [references/style-guide.md](references/style-guide.md) を読む
 - とくに生成AI、AIコーディング、趣味開発まわりの投稿では、`style-guide.md` のテック寄り文体メモを優先して参照する
 - 構成パターンや段落設計、締め方の例が必要なときは [references/structure-patterns.md](references/structure-patterns.md) を読む
+- 参照資料の全体像を確認したいときは `index.json` を使って、必要な `references/` ファイルを探す
 - どちらも必要ない場合は、この `SKILL.md` の指針だけで進める
 
 ## 応答パターン

--- a/skills/igapyon-companion-techpost-writer/index.json
+++ b/skills/igapyon-companion-techpost-writer/index.json
@@ -23,8 +23,8 @@
       "path": "SKILL.md",
       "ext": "md",
       "dir": "",
-      "size": 4775,
-      "summary": "--- name: igapyon-techpost-writer description: japanese writing coach for tech posts in igapyon style. use when the user wants to polish, extend, reorganize, or iteratively develop japanese tech blog posts or social posts while preserving the user's person"
+      "size": 4941,
+      "summary": "--- name: igapyon-companion-techpost-writer description: collaborative Japanese writing companion for tech posts in igapyon style. use when the user wants to polish, extend, reorganize, or iteratively develop Japanese tech blog posts or social posts while"
     }
   ]
 }

--- a/skills/igapyon-qiita-writer/index.json
+++ b/skills/igapyon-qiita-writer/index.json
@@ -7,7 +7,7 @@
       "path": "references/general/20260428-general.md",
       "ext": "md",
       "dir": "references/general",
-      "size": 18880,
+      "size": 19425,
       "summary": "掲載先情報"
     },
     {


### PR DESCRIPTION
## 概要

リポジトリのREADMEと伴走型スキル定義を、現在のスキル構成に合わせて更新しました。

## 変更内容

- `README.md` に、Qiita / Note 記事作成と技術・音楽投稿の伴走型ライティング支援に使うリポジトリである説明を追加
- `README.md` の構成例と現在の skill 一覧を、次の現行スキルに更新
  - `igapyon-qiita-writer`
  - `igapyon-note-writer`
  - `igapyon-companion-techpost-writer`
  - `igapyon-companion-musicpost-writer`
- `README.md` に、`index.json` を `miku-indexgen` で生成する方針と `mvn generate-resources` による更新手順を追加
- `TODO.md` の「tech/music 以外の skill」を追加する表現を、`writer skill` を追加する表現に更新
- `igapyon-companion-techpost-writer` と `igapyon-companion-musicpost-writer` の `SKILL.md` で、skill 名と見出しを companion 付きの名称に更新
- companion 系2スキルの description を `collaborative Japanese writing companion` の表現に更新
- companion 系2スキルの読み分けガイドに、`index.json` を使って必要な `references/` ファイルを探す説明を追加
- `miku-indexgen` による再生成結果として、関連する `index.json` を更新

## 確認事項

- `miku-indexgen` による `index.json` 再生成: 実施済み
- Markdown差分チェック: 実施済み