### PR TITLE
知識ベース型Agent Skills記事の公開情報を更新

### DIFF
--- a/skills/igapyon-qiita-writer/index.json
+++ b/skills/igapyon-qiita-writer/index.json
@@ -15,7 +15,7 @@
       "path": "references/general/20260429-general.md",
       "ext": "md",
       "dir": "references/general",
-      "size": 12473,
+      "size": 12522,
       "summary": "掲載先情報"
     },
     {

--- a/skills/igapyon-qiita-writer/references/general/20260429-general.md
+++ b/skills/igapyon-qiita-writer/references/general/20260429-general.md
@@ -1,15 +1,14 @@
 ## 掲載先情報
 
 - 掲載先: Qiita
-- URL: 未公開
+- URL: https://qiita.com/igapyon/items/94de2bee0ebdf25ecd6c
 
 ---
 title: 知識ベース型 Agent Skills は、静的 Markdown だけでも育てられる（SKILL.md + references/ 設計）
-tags: 生成AI AgentSkills Markdown AI駆動開発
+tags: mikuku 生成AI AgentSkills Markdown AI駆動開発
 author: igapyon
 slide: false
 ---
-
 ## はじめに
 
 生成AIを良い感じに動作させるには、コンテキストとなる知識ベースをどう渡すかがかなり重要になります。


### PR DESCRIPTION
## 概要

`igapyon-qiita-writer` の一般記事参照「知識ベース型 Agent Skills は、静的 Markdown だけでも育てられる（SKILL.md + references/ 設計）」について、Qiita公開情報を更新しました。

## 変更内容

- `references/general/20260429-general.md` のURLを未公開からQiita記事URLへ更新
- Qiita front matter の tags に `mikuku` を追加
- front matter 後の空行を整理
- `igapyon-qiita-writer/index.json` の対象記事サイズを更新

## 確認事項

- `miku-indexgen` による `index.json` 更新: 実施済み
- テスト実行: 未実施
- 理由: Markdown参照記事と索引更新のみのため