### PR TITLE
知識ベース型Agent Skills記事のindex.json例をmiku-indexgen形式に修正

### DIFF
--- a/skills/igapyon-qiita-writer/index.json
+++ b/skills/igapyon-qiita-writer/index.json
@@ -15,7 +15,7 @@
       "path": "references/general/20260429-general.md",
       "ext": "md",
       "dir": "references/general",
-      "size": 12522,
+      "size": 12807,
       "summary": "掲載先情報"
     },
     {

--- a/skills/igapyon-qiita-writer/references/general/20260429-general.md
+++ b/skills/igapyon-qiita-writer/references/general/20260429-general.md
@@ -202,16 +202,24 @@ Agent Skills に `references/` を増やしていくと、感覚としては ski
 
 ```json
 {
+  "generator": "miku-indexgen",
+  "basePath": ".",
   "files": [
     {
+      "name": "style-guide.md",
       "path": "references/style-guide.md",
-      "description": "文体と表現ルール",
-      "priority": "high"
+      "ext": "md",
+      "dir": "references",
+      "size": 4463,
+      "summary": "Style Guide"
     },
     {
+      "name": "past-articles.md",
       "path": "references/past-articles.md",
-      "description": "過去の記事例",
-      "priority": "low"
+      "ext": "md",
+      "dir": "references",
+      "size": 12000,
+      "summary": "過去の記事例"
     }
   ]
 }
@@ -219,9 +227,9 @@ Agent Skills に `references/` を増やしていくと、感覚としては ski
 
 ここで重要なのは、単にファイル一覧を持たせることだけではありません。
 
-どの資料が何のためのものか、どの資料を優先すべきかを、AIが判断しやすい形にしておくことです。
+どの資料がどこにあり、どのような概要を持っているのかを、AIが判断しやすい形にしておくことです。
 
-さらに `SKILL.md` 側に、読み順や優先順位を書いておくとよいです。
+なお、`miku-indexgen` が生成する `index.json` は地図です。どの資料を優先すべきか、どの順番で読むべきかは、`SKILL.md` 側に書いておくとよいです。
 
 たとえば、次のような方針です。
 


### PR DESCRIPTION
## 概要

`igapyon-qiita-writer` の一般記事参照「知識ベース型 Agent Skills は、静的 Markdown だけでも育てられる（SKILL.md + references/ 設計）」について、本文中の `index.json` サンプルを `miku-indexgen` の出力形式に合わせて修正しました。

## 変更内容

- `index.json` サンプルに `generator` と `basePath` を追加
- `files` 配下の項目を `miku-indexgen` の形式に合わせて更新
  - `name`
  - `path`
  - `ext`
  - `dir`
  - `size`
  - `summary`
- `description` / `priority` を使ったサンプルを削除
- `index.json` は地図であり、資料の優先順位や読み順は `SKILL.md` 側に書く説明へ修正
- `igapyon-qiita-writer/index.json` の対象記事サイズを更新

## 確認事項

- `miku-indexgen` による `index.json` 更新: 実施済み
- テスト実行: 未実施
- 理由: Markdown参照記事と索引更新のみのため