### PR TITLE
知識ベース型Agent Skills記事に画像リンクを追加

### DIFF
--- a/skills/igapyon-qiita-writer/index.json
+++ b/skills/igapyon-qiita-writer/index.json
@@ -15,8 +15,8 @@
       "path": "references/general/20260429-general.md",
       "ext": "md",
       "dir": "references/general",
-      "size": 12807,
-      "summary": "掲載先情報"
+      "size": 13100,
+      "summary": "--- title: 知識ベース型 Agent Skills は、静的 Markdown だけでも育てられる（SKILL.md + references/ 設計） tags: mikuku 生成AI AgentSkills Markdown AI駆動開発 author: igapyon slide: false ---"
     },
     {
       "name": "20260412-miku-abc-player-intro.md",

--- a/skills/igapyon-qiita-writer/references/general/20260429-general.md
+++ b/skills/igapyon-qiita-writer/references/general/20260429-general.md
@@ -1,8 +1,3 @@
-## 掲載先情報
-
-- 掲載先: Qiita
-- URL: https://qiita.com/igapyon/items/94de2bee0ebdf25ecd6c
-
 ---
 title: 知識ベース型 Agent Skills は、静的 Markdown だけでも育てられる（SKILL.md + references/ 設計）
 tags: mikuku 生成AI AgentSkills Markdown AI駆動開発
@@ -18,6 +13,8 @@ slide: false
 たとえば、文章の文体、設計方針、過去の判断、よく使う構成、避けたい表現、対象領域の背景などは、毎回の会話で一から説明するには少し重たい情報です。
 
 最初は、Markdown を大量に持ち歩き、状況に応じて ON/OFF しながらプロンプトに含めるような運用を考えていました。ちなみに、この ON/OFF はファイルコピーとファイル削除でやっていました。
+
+![はじめに](https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/105739/fe49df01-f0c0-4b93-a8dc-779bc15635e1.png)
 
 しかし、この方法は長続きしにくいです。
 
@@ -115,6 +112,8 @@ knowledge-based-skill/
 過去記事、スタイルガイド、構成パターン、設計メモ、README、作業ログ、よく使う言い回し、失敗例、注意点などを入れておくと、生成AIが参照できる前提知識が増えます。
 
 ## 「賢くなる」の意味
+
+![「賢くなる」の意味](https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/105739/de56a505-c793-427e-bbd4-9df231c6d7b2.png)
 
 Agent Skills に `references/` を増やしていくと、感覚としては skill が少しずつ賢くなっていくように見えます。
 
@@ -240,6 +239,8 @@ Agent Skills に `references/` を増やしていくと、感覚としては ski
 このようにしておくと、大量の知識でカバーしつつ、少量の高品質な知識で判断を安定させやすくなります。さらに `index.json` によって、生成AIが読む必要のある情報を絞り込みやすくなることも期待できます。
 
 ## おわりに
+
+![終わりに](https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/105739/f7f00c85-47cb-4ce2-91c6-b8abc1244432.png)
 
 知識ベース型 Agent Skills は、CLI や実行ファイルを同梱しなくても作れます。
 


### PR DESCRIPTION
## 概要

`igapyon-qiita-writer` の一般記事参照「知識ベース型 Agent Skills は、静的 Markdown だけでも育てられる（SKILL.md + references/ 設計）」を更新し、Qiita画像リンクを追加しました。

## 変更内容

- 記事冒頭付近に `はじめに` の画像リンクを追加
- `「賢くなる」の意味` セクションに画像リンクを追加
- `おわりに` セクションに画像リンクを追加
- 記事冒頭の掲載先情報ブロックを削除し、Qiita front matter から始まる形に整理
- `igapyon-qiita-writer/index.json` の対象記事サイズと summary を更新

## 確認事項

- `miku-indexgen` による `index.json` 更新: 実施済み
- テスト実行: 未実施
- 理由: Markdown参照記事と索引更新のみのため