### PR TITLE
リポジトリ運用ルール用の Agent Skill を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@
 - repo 全体の運用ルールはこの `README.md` に書く
 - 作業メモは repo 直下の `TODO.md` に集約する
 - skill ごとの `index.json` は `miku-indexgen` で生成する
+- ローカル作業用に `workplace/` を置き、`workplace/.gitkeep` だけを Git 管理下に入れる
+- Java / Maven 開発では `.mvn/jvm.config` を repo に含める
+
+## .gitignore の扱い
+
+macOS が生成する `.DS_Store` は Git 管理対象外とするため、repo 側の `.gitignore` に記載します。
+
+`workplace/` は clone した外部リポジトリ、展開した zip、生成物、検証用ファイルなどを置くローカル作業フォルダです。  
+`workplace/` 配下の作業物は Git 管理対象外とし、ディレクトリを維持するための `workplace/.gitkeep` だけを Git 管理下に入れます。
+
+`.codex/skills/` は Codex から利用するためのローカル配備先です。  
+この repo では `skills/` 配下を正本として管理し、`.codex/skills/` 配下のコピーは Git 管理対象外とします。
+
+## Java / Maven の扱い
+
+Java / Maven を使う repo では、実行時の JVM 設定を repo 側で明示するため、`.mvn/jvm.config` を Git 管理下に入れます。
+
+この repo では、ローカル環境での名前解決やネットワーク挙動を安定させるため、IPv4 を優先する JVM オプションを `.mvn/jvm.config` に記載しています。
 
 ## references の扱い
 
@@ -38,8 +56,11 @@
 │  │  └─ references/
 │  ├─ igapyon-companion-techpost-writer/
 │  │  └─ SKILL.md
-│  └─ igapyon-companion-musicpost-writer/
-│     └─ SKILL.md
+│  ├─ igapyon-companion-musicpost-writer/
+│  │  └─ SKILL.md
+│  └─ igapyon-repo-conventions/
+│     ├─ SKILL.md
+│     └─ references/
 ├─ pom.xml
 ├─ TODO.md
 └─ README.md
@@ -63,12 +84,22 @@
 
   音楽系日本語投稿の伴走、最小整理、全文再構成向け
 
+- `igapyon-repo-conventions`
+
+  Git / GitHub repository の `.gitignore`、`workplace/`、`.codex/skills/`、Java / Maven 設定、README 運用ルールの整理向け
+
 ## index.json の更新
 
 各 skill の `index.json` を更新する場合は、次のコマンドで `skills/` 配下をまとめて再生成します。
 
 ```sh
 mvn generate-resources
+```
+
+ビルド全体とあわせて更新する場合は、次のコマンドでも `index.json` を更新できます。
+
+```sh
+mvn clean package
 ```
 
 生成された `index.json` は、skill と一緒にコミットします。

--- a/skills/igapyon-qiita-writer/index.json
+++ b/skills/igapyon-qiita-writer/index.json
@@ -51,6 +51,22 @@
       "summary": "--- title: [miku-soft] 生成AI時代の local-first ツール群アーキテクチャ topic bank tags: 生成AI ソフトウェアアーキテクチャ AgentSkills MCP CLI author: igapyon slide: false ---"
     },
     {
+      "name": "20260502-general-repository-engineering.md",
+      "path": "references/general/20260502-general-repository-engineering.md",
+      "ext": "md",
+      "dir": "references/general",
+      "size": 16315,
+      "summary": "掲載先情報"
+    },
+    {
+      "name": "20260503-general-miku-soft-agent-skills.md",
+      "path": "references/general/20260503-general-miku-soft-agent-skills.md",
+      "ext": "md",
+      "dir": "references/general",
+      "size": 5279,
+      "summary": "掲載先情報"
+    },
+    {
       "name": "20260412-miku-abc-player-intro.md",
       "path": "references/miku-abc-player/20260412-miku-abc-player-intro.md",
       "ext": "md",

--- a/skills/igapyon-repo-conventions/SKILL.md
+++ b/skills/igapyon-repo-conventions/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: igapyon-repo-conventions
+description: Use when applying igapyon's repository conventions to a local Git or GitHub repository, including repo-side .gitignore rules, .DS_Store exclusion, workplace/.gitkeep setup, .codex/skills exclusion, Java/Maven .mvn/jvm.config handling, and README documentation of repository operation rules.
+---
+
+# igapyon-repo-conventions
+
+This skill helps Codex apply igapyon's standard repository conventions to a local Git repository.
+
+Use it when the user wants to set up, inspect, or document repository-level conventions rather than implement product behavior.
+
+## Core Workflow
+
+1. Inspect the repository before editing.
+2. Preserve unrelated user changes.
+3. Read [references/repository-rules.md](references/repository-rules.md) before applying concrete conventions.
+4. Document repository operation rules in `README.md` when appropriate.
+5. Verify the final diff and report any pre-existing unrelated changes.
+
+Prefer existing repository patterns over introducing a new structure.
+
+## Reference Use
+
+Use [references/repository-rules.md](references/repository-rules.md) for the concrete rules covering `.gitignore`, `.DS_Store`, `workplace/`, `.codex/skills/`, Java / Maven `.mvn/jvm.config`, and README documentation.
+
+Use files under [references/template/](references/template/) when creating or updating root convention documents such as `CONTRIBUTING.md`, `CONTRIBUTORS.md`, or `THIRD_PARTY_NOTICES.md`.
+Do not leave template placeholders such as `PROJECT_NAME`, `NAME_OR_HANDLE`, or `DEPENDENCY_NAME` in committed files. If required information is unknown, either defer creating the file or create a minimal accurate document without placeholder text.
+
+Use `index.json` when you need to discover the available bundled files, but treat `SKILL.md` and files under `references/` as the source of truth.
+
+Keep this `SKILL.md` lean. Put detailed conventions and examples in `references/` unless they are required to decide whether the skill should run.
+
+## Verification
+
+Before finishing:
+
+- run `git diff -- README.md TODO.md .gitignore .mvn/jvm.config workplace/.gitkeep CONTRIBUTING.md CONTRIBUTORS.md THIRD_PARTY_NOTICES.md`
+- run `git status --short`
+- mention any unrelated modified files that were already present or not touched
+
+Do not revert unrelated changes.

--- a/skills/igapyon-repo-conventions/index.json
+++ b/skills/igapyon-repo-conventions/index.json
@@ -1,0 +1,46 @@
+{
+  "generator": "miku-indexgen",
+  "basePath": ".",
+  "files": [
+    {
+      "name": "repository-rules.md",
+      "path": "references/repository-rules.md",
+      "ext": "md",
+      "dir": "references",
+      "size": 3680,
+      "summary": "Repository Rules"
+    },
+    {
+      "name": "CONTRIBUTING.md",
+      "path": "references/template/CONTRIBUTING.md",
+      "ext": "md",
+      "dir": "references/template",
+      "size": 1501,
+      "summary": "Contributing to PROJECT_NAME"
+    },
+    {
+      "name": "CONTRIBUTORS.md",
+      "path": "references/template/CONTRIBUTORS.md",
+      "ext": "md",
+      "dir": "references/template",
+      "size": 161,
+      "summary": "Contributors"
+    },
+    {
+      "name": "THIRD_PARTY_NOTICES.md",
+      "path": "references/template/THIRD_PARTY_NOTICES.md",
+      "ext": "md",
+      "dir": "references/template",
+      "size": 392,
+      "summary": "Third-Party Notices"
+    },
+    {
+      "name": "SKILL.md",
+      "path": "SKILL.md",
+      "ext": "md",
+      "dir": "",
+      "size": 2310,
+      "summary": "--- name: igapyon-repo-conventions description: Use when applying igapyon's repository conventions to a local Git or GitHub repository, including repo-side .gitignore rules, .DS_Store exclusion, workplace/.gitkeep setup, .codex/skills exclusion, Java/Maven"
+    }
+  ]
+}

--- a/skills/igapyon-repo-conventions/references/repository-rules.md
+++ b/skills/igapyon-repo-conventions/references/repository-rules.md
@@ -1,0 +1,118 @@
+# Repository Rules
+
+Detailed repository conventions for `igapyon-repo-conventions`.
+
+## .gitignore
+
+Manage common local files in the repo-side `.gitignore`.
+
+### Common
+
+Include `.DS_Store` so macOS metadata files are excluded for every clone.
+
+### Node.js / frontend
+
+For Node.js or frontend repositories, include dependency and build output directories:
+
+```gitignore
+node_modules/
+.npm-cache/
+dist/
+bundle/
+coverage/
+*.log
+npm-debug.log*
+```
+
+If a repository intentionally commits generated distribution files, document that exception in `README.md`.
+
+### Java / Maven
+
+For Java or Maven repositories, include Maven build output:
+
+```gitignore
+target/
+```
+
+### VS Code MCP
+
+Ignore local VS Code MCP configuration by default:
+
+```gitignore
+.vscode/mcp.json
+```
+
+If MCP settings should be shared, place a sanitized example such as `.vscode/mcp.example.json` or documentation under `docs/` instead of committing the local `.vscode/mcp.json`.
+
+### workplace/
+
+For local work areas, use `workplace/` with a tracked `.gitkeep`:
+
+```gitignore
+workplace/*
+!workplace/.gitkeep
+```
+
+Create `workplace/.gitkeep` if `workplace/` is part of the repository convention and the file does not exist.
+
+## workplace/
+
+Treat `workplace/` as a local scratch area for cloned external repositories, extracted archives, generated files, and verification artifacts.
+
+Do not add `workplace/` contents to Git, except for `workplace/.gitkeep`.
+
+## .codex/skills/
+
+Treat `.codex/skills/` as a local deployment or copy destination for Codex skills.
+
+When the repository keeps skill source files elsewhere, such as `skills/`, keep `.codex/skills/` out of Git. The source directory remains the canonical copy.
+
+## Java / Maven
+
+For Java or Maven repositories, keep `.mvn/jvm.config` under Git when JVM runtime settings are part of the user's local development standard.
+
+When IPv4 preference is needed, use:
+
+```text
+-Djava.net.preferIPv4Stack=true
+-Djava.net.preferIPv6Addresses=false
+```
+
+Do not add Java/Maven settings to non-Java repositories unless the user explicitly asks.
+
+## Repository Documents
+
+Create `README.md` as a basic repository file unless the repository has a clear reason not to use it.
+
+Create `TODO.md` when the repository already uses it, when the user asks for a repository-level work log, or when there are concrete follow-up items that should be kept outside issue trackers and source files. Do not create an empty or speculative `TODO.md` just to satisfy the convention.
+
+Keep these files at the repository root:
+
+- `README.md`
+- `TODO.md`
+- `LICENSE`
+- `CONTRIBUTING.md`
+- `CONTRIBUTORS.md`
+- `THIRD_PARTY_NOTICES.md`
+
+For templates for `CONTRIBUTING.md`, `CONTRIBUTORS.md`, and `THIRD_PARTY_NOTICES.md`, see [template/](template/).
+
+Use `docs/` for developer-oriented documentation, design notes, implementation notes, operational details, and other supporting documents.
+
+Keep the repository root tidy. Do not place too many standalone documents at the root when they can live under `docs/`.
+
+Use `README.md` for concise repository overview and operational rules. When changing repository conventions, update `README.md`.
+
+Typical README topics:
+
+- where canonical skill or source files live
+- how `workplace/` is used
+- what is intentionally ignored by Git
+- how generated files are regenerated
+- Java / Maven runtime settings, when applicable
+
+Keep the README focused on repository operation. Avoid broad tutorials.
+
+Use `TODO.md` as the repository-level place for working notes, pending tasks, and follow-up items.
+
+Keep `TODO.md` practical and lightweight. Do not scatter long-running repository task notes across unrelated files when `TODO.md` is the established location.

--- a/skills/igapyon-repo-conventions/references/template/CONTRIBUTING.md
+++ b/skills/igapyon-repo-conventions/references/template/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to PROJECT_NAME
+
+Thank you for contributing to `PROJECT_NAME`.
+
+This project accepts bug reports, feature requests, documentation fixes, tests, and pull requests.
+
+## Before You Open an Issue or Pull Request
+
+- Check whether the topic is already covered by an existing issue or pull request.
+- For behavior changes, describe the expected behavior and the current behavior clearly.
+- For code changes, include or update tests when practical.
+- Keep changes focused. Small, reviewable pull requests are preferred.
+
+## Development Notes
+
+- Edit source files instead of generated output unless regeneration is intentionally part of the change.
+- Run relevant tests before submitting a pull request when possible.
+- When adding or replacing a third-party library, confirm the license and update `THIRD_PARTY_NOTICES.md` when notice is needed.
+
+## Pull Request Guidelines
+
+- Explain what changed and why.
+- Mention any user-visible behavior change.
+- Mention any specification or documentation updates if they are part of the change.
+- If a change is incomplete or intentionally deferred, say so explicitly.
+
+## Contribution License
+
+By submitting an issue, pull request, comment, documentation change, code change, or other material intended for inclusion in this project, you agree that your contribution is provided under the license used by this repository.
+
+## Code of Collaboration
+
+- Be specific.
+- Be respectful.
+- Prefer concrete repro steps, fixtures, and tests over vague reports.

--- a/skills/igapyon-repo-conventions/references/template/CONTRIBUTORS.md
+++ b/skills/igapyon-repo-conventions/references/template/CONTRIBUTORS.md
@@ -1,0 +1,6 @@
+# Contributors
+
+This project includes contributions, feedback, and improvement suggestions from the following people.
+
+- NAME_OR_HANDLE
+  - CONTRIBUTION_SUMMARY

--- a/skills/igapyon-repo-conventions/references/template/THIRD_PARTY_NOTICES.md
+++ b/skills/igapyon-repo-conventions/references/template/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,19 @@
+# Third-Party Notices
+
+This document lists third-party software and reference materials used or referred to by `PROJECT_NAME`.
+
+## Third-party software
+
+### DEPENDENCY_NAME
+
+- Usage: HOW_THIS_DEPENDENCY_IS_USED
+- License: LICENSE_NAME
+- Source: SOURCE_URL
+
+## Reference materials
+
+### REFERENCE_NAME
+
+- Usage: HOW_THIS_REFERENCE_IS_USED
+- License: LICENSE_NAME_OR_POLICY
+- Source: SOURCE_URL


### PR DESCRIPTION
## 概要

`igapyon-repo-conventions` skill を追加し、Git / GitHub リポジトリの運用ルールを整理するための Agent Skill と参照資料を追加しました。

## 変更内容

- `skills/igapyon-repo-conventions/` を追加
  - `SKILL.md` を追加
  - `references/repository-rules.md` を追加
  - `references/template/CONTRIBUTING.md` を追加
  - `references/template/CONTRIBUTORS.md` を追加
  - `references/template/THIRD_PARTY_NOTICES.md` を追加
  - `index.json` を追加

- `repository-rules.md` に以下のリポジトリ運用ルールを追加
  - `.DS_Store` の除外
  - Node.js / frontend 向けの `.gitignore` 例
  - Java / Maven 向けの `target/` 除外
  - `.vscode/mcp.json` の除外
  - `workplace/` と `workplace/.gitkeep` の扱い
  - `.codex/skills/` の扱い
  - `.mvn/jvm.config` の扱い
  - `README.md`、`TODO.md`、`CONTRIBUTING.md`、`CONTRIBUTORS.md`、`THIRD_PARTY_NOTICES.md` などの repository document の配置方針

- `README.md` を更新
  - `workplace/`、`.codex/skills/`、`.mvn/jvm.config` の運用方針を追加
  - 構成例に `igapyon-repo-conventions` を追加
  - 現在の skill 一覧に `igapyon-repo-conventions` を追加
  - `index.json` は `mvn generate-resources` または `mvn clean package` で更新できることを記載

- `skills/igapyon-qiita-writer/index.json` を更新
  - `references/general/20260502-general-repository-engineering.md`
  - `references/general/20260503-general-miku-soft-agent-skills.md`

## 確認事項

- テスト実行: 未確認