### PR TITLE
igapyon-miku-soft-developer skill を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ skill を利用する際は、`SKILL.md` を入口とし、具体ルール、例
 │  ├─ igapyon-github-writer/
 │  │  ├─ SKILL.md
 │  │  └─ references/
+│  ├─ igapyon-miku-soft-developer/
+│  │  ├─ SKILL.md
+│  │  └─ references/
 │  ├─ igapyon-mikuku-agent/
 │  │  ├─ SKILL.md
 │  │  ├─ assets/
@@ -102,6 +105,10 @@ skill を利用する際は、`SKILL.md` を入口とし、具体ルール、例
 - `igapyon-github-writer`
 
   GitHub PR、GitHub Release、GitHub About に貼る文章の作成向け。明示的に指定した場合に利用する。
+
+- `igapyon-miku-soft-developer`
+
+  miku-soft project の新規作成・既存保守ワークフロー向け。skill の利用を明示的に指定した場合のみ利用し、miku-soft 作成・保守の相談だけでは存在案内に留める。
 
 - `igapyon-mikuku-agent`
 

--- a/skills/igapyon-miku-soft-developer/SKILL.md
+++ b/skills/igapyon-miku-soft-developer/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: igapyon-miku-soft-developer
+description: Use only when the user explicitly asks to use igapyon-miku-soft-developer or explicitly asks to apply the miku-soft developer skill. If the user says they want to create a new miku-soft project, maintain an existing miku-soft project, organize a repo as miku-soft, or proceed with a miku-soft creation/maintenance workflow, mention this skill as an available option but do not apply it until the user explicitly asks to use it. Do not use for generic app development, CLI/MCP/Java work, repository cleanup, architecture discussion, or article writing.
+---
+
+# igapyon-miku-soft-developer
+
+This skill supports explicit miku-soft project creation and maintenance workflows.
+
+Use it only after the user explicitly asks to use `igapyon-miku-soft-developer` or explicitly asks to apply the miku-soft developer skill. For activation details and the non-activation reply, see [references/activation-policy.md](references/activation-policy.md).
+
+## Modes
+
+After the skill is explicitly active, choose one mode:
+
+- New project mode: create a new miku-soft project or initialize a repository as a miku-soft project.
+- Maintenance mode: inspect, update, or repair an existing miku-soft project.
+
+If the mode is unclear after explicit activation, ask a brief clarification before editing.
+
+## Core Workflow
+
+Prerequisite: use `igapyon-repo-conventions` as the repository-conventions baseline for every workflow.
+
+1. Read [references/activation-policy.md](references/activation-policy.md) if activation behavior is relevant.
+2. Read [references/architecture-rules.md](references/architecture-rules.md).
+3. For new project work, read [references/new-project-workflow.md](references/new-project-workflow.md).
+4. For existing project work, read [references/maintenance-workflow.md](references/maintenance-workflow.md).
+5. Read [references/repo-operations.md](references/repo-operations.md) for miku-soft-specific additions.
+6. Inspect the target repository before editing.
+7. Preserve unrelated user changes.
+8. Keep product behavior in the product core or upstream runtime artifacts, not in the skill instructions.
+
+Use `index.json` when you need to discover the available bundled reference files, but treat `SKILL.md` and files under `references/` as the source of truth.
+
+Keep this `SKILL.md` lean. Put detailed policy, architecture rules, and operational steps in `references/`.
+
+## Verification
+
+Before finishing:
+
+- run relevant tests, builds, or focused regression commands when the repository provides them and the requested change warrants them
+- run `git status --short`
+- review the final diff for unrelated changes
+- mention any verification that could not be run
+
+Do not revert unrelated changes.

--- a/skills/igapyon-miku-soft-developer/index.json
+++ b/skills/igapyon-miku-soft-developer/index.json
@@ -1,0 +1,102 @@
+{
+  "generator": "miku-indexgen",
+  "basePath": ".",
+  "files": [
+    {
+      "name": "activation-policy.md",
+      "path": "references/activation-policy.md",
+      "ext": "md",
+      "dir": "references",
+      "size": 1187,
+      "summary": "miku-soft Developer Activation Policy"
+    },
+    {
+      "name": "architecture-rules.md",
+      "path": "references/architecture-rules.md",
+      "ext": "md",
+      "dir": "references",
+      "size": 2019,
+      "summary": "miku-soft Architecture Rules"
+    },
+    {
+      "name": "maintenance-workflow.md",
+      "path": "references/maintenance-workflow.md",
+      "ext": "md",
+      "dir": "references",
+      "size": 1147,
+      "summary": "Existing miku-soft Maintenance Workflow"
+    },
+    {
+      "name": "miku-soft-00-overview-design-v20260427.md",
+      "path": "references/miku-soft-basic/miku-soft-00-overview-design-v20260427.md",
+      "ext": "md",
+      "dir": "references/miku-soft-basic",
+      "size": 14059,
+      "summary": "Miku Software Overview Design v20260427"
+    },
+    {
+      "name": "miku-soft-10-mainapp-design-v20260501.md",
+      "path": "references/miku-soft-basic/miku-soft-10-mainapp-design-v20260501.md",
+      "ext": "md",
+      "dir": "references/miku-soft-basic",
+      "size": 59100,
+      "summary": "Miku Software Main Application Design v20260425"
+    },
+    {
+      "name": "miku-soft-20-javaapp-design-v20260501.md",
+      "path": "references/miku-soft-basic/miku-soft-20-javaapp-design-v20260501.md",
+      "ext": "md",
+      "dir": "references/miku-soft-basic",
+      "size": 41407,
+      "summary": "Miku Software Java Application Design v20260426"
+    },
+    {
+      "name": "miku-soft-30-straight-conversion-v20260425.md",
+      "path": "references/miku-soft-basic/miku-soft-30-straight-conversion-v20260425.md",
+      "ext": "md",
+      "dir": "references/miku-soft-basic",
+      "size": 55702,
+      "summary": "Miku Software Straight Conversion Guide v20260425"
+    },
+    {
+      "name": "miku-soft-40-agentskills-design-v20260501.md",
+      "path": "references/miku-soft-basic/miku-soft-40-agentskills-design-v20260501.md",
+      "ext": "md",
+      "dir": "references/miku-soft-basic",
+      "size": 39734,
+      "summary": "Miku Software Agent Skills Design v20260425"
+    },
+    {
+      "name": "miku-soft-50-mcp-design-v20260501.md",
+      "path": "references/miku-soft-basic/miku-soft-50-mcp-design-v20260501.md",
+      "ext": "md",
+      "dir": "references/miku-soft-basic",
+      "size": 41214,
+      "summary": "Miku Software MCP Design v20260501"
+    },
+    {
+      "name": "new-project-workflow.md",
+      "path": "references/new-project-workflow.md",
+      "ext": "md",
+      "dir": "references",
+      "size": 1874,
+      "summary": "New miku-soft Project Workflow"
+    },
+    {
+      "name": "repo-operations.md",
+      "path": "references/repo-operations.md",
+      "ext": "md",
+      "dir": "references",
+      "size": 1189,
+      "summary": "miku-soft Repository Operations"
+    },
+    {
+      "name": "SKILL.md",
+      "path": "SKILL.md",
+      "ext": "md",
+      "dir": "",
+      "size": 2744,
+      "summary": "--- name: igapyon-miku-soft-developer description: Use only when the user explicitly asks to use igapyon-miku-soft-developer or explicitly asks to apply the miku-soft developer skill. If the user says they want to create a new miku-soft project, maintain a"
+    }
+  ]
+}

--- a/skills/igapyon-miku-soft-developer/references/activation-policy.md
+++ b/skills/igapyon-miku-soft-developer/references/activation-policy.md
@@ -1,0 +1,27 @@
+# miku-soft Developer Activation Policy
+
+Use this policy for `igapyon-miku-soft-developer` activation behavior.
+
+## Strict Activation
+
+Activate this skill only after the user explicitly asks to use `igapyon-miku-soft-developer` or explicitly asks to apply the miku-soft developer skill.
+
+Do not activate this skill merely because the user mentions one of these intents:
+
+- `miku-soft を新規作成したい`
+- `miku-soft プロジェクトを作りたい`
+- `既存 miku-soft をメンテしたい`
+- `この repo を miku-soft として整備したい`
+- `miku-soft の作成/保守ワークフローで進めたい`
+
+For those requests, mention this skill as an available option and wait for an explicit instruction to use it.
+
+## Non-Activation Reply
+
+When the user describes a miku-soft creation or maintenance intent but has not explicitly asked to use this skill, reply briefly in Japanese:
+
+```text
+この用途には `igapyon-miku-soft-developer` skill が使えます。使う場合は「igapyon-miku-soft-developer を使って」と明示してください。
+```
+
+Do not inspect files, plan changes, or perform the workflow until the user explicitly asks to use the skill.

--- a/skills/igapyon-miku-soft-developer/references/architecture-rules.md
+++ b/skills/igapyon-miku-soft-developer/references/architecture-rules.md
@@ -1,0 +1,24 @@
+# miku-soft Architecture Rules
+
+This file is the short entry point for explicit `igapyon-miku-soft-developer` workflows.
+
+Detailed miku-soft design rules live under [miku-soft-basic/](miku-soft-basic/). Do not duplicate those rules here.
+
+Do not create or rely on a synchronization script for these documents. When a task requires copying or updating them, perform the copy as part of the explicit workflow and report the source and destination files.
+
+## Basic Document Selection
+
+Read only the document needed for the current task:
+
+- [miku-soft-basic/miku-soft-00-overview-design-v20260427.md](miku-soft-basic/miku-soft-00-overview-design-v20260427.md): overall miku-soft stance and product-type overview
+- [miku-soft-basic/miku-soft-10-mainapp-design-v20260501.md](miku-soft-basic/miku-soft-10-mainapp-design-v20260501.md): main application, Web UI, CLI, local-first behavior, diagnostics, and shared conventions
+- [miku-soft-basic/miku-soft-20-javaapp-design-v20260501.md](miku-soft-basic/miku-soft-20-javaapp-design-v20260501.md): Java CLI, Maven, Java runtime boundary, packaging, and Java-side maintenance
+- [miku-soft-basic/miku-soft-30-straight-conversion-v20260425.md](miku-soft-basic/miku-soft-30-straight-conversion-v20260425.md): Node.js / TypeScript to Java straight conversion
+- [miku-soft-basic/miku-soft-40-agentskills-design-v20260501.md](miku-soft-basic/miku-soft-40-agentskills-design-v20260501.md): Agent Skills versions and agent-facing local workflow packages
+- [miku-soft-basic/miku-soft-50-mcp-design-v20260501.md](miku-soft-basic/miku-soft-50-mcp-design-v20260501.md): MCP server versions, tools, resources, prompts, transport, and protocol adapter boundaries
+
+When multiple basic documents have the same numbered topic, prefer the file with the newest `-v2026...` suffix.
+
+## Short Rule
+
+Keep product semantics in the product core or upstream runtime artifacts. Treat Web UI, CLI, Java CLI, Agent Skills, and MCP as entrypoints or adapters unless the relevant basic document says otherwise.

--- a/skills/igapyon-miku-soft-developer/references/maintenance-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/maintenance-workflow.md
@@ -1,0 +1,28 @@
+# Existing miku-soft Maintenance Workflow
+
+Use this short workflow only after `igapyon-miku-soft-developer` has been explicitly activated.
+
+Detailed maintenance principles live under [miku-soft-basic/](miku-soft-basic/). Keep this file as the inspection and execution order.
+
+## First Reads
+
+Inspect durable repository context before planning edits:
+
+1. `README.md`
+2. `TODO.md` if present
+3. relevant files under `docs/`
+4. relevant generated indexes if present
+5. relevant `workplace/` files only when repository instructions point there
+
+Then inspect git status.
+
+## Change Checklist
+
+1. Identify the owning layer: product core, entrypoint adapter, docs, tests, packaging, or repository operation.
+2. Read the relevant basic document selected by [architecture-rules.md](architecture-rules.md).
+3. Make the smallest change that preserves the documented boundary.
+4. Update README, docs, TODO, tests, or indexes when the change affects them.
+5. Run relevant verification.
+6. Review git diff and status before finishing.
+
+Do not update only one entrypoint when repository evidence shows the requested behavior belongs to shared product semantics.

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-00-overview-design-v20260427.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-00-overview-design-v20260427.md
@@ -1,0 +1,227 @@
+# Miku Software Overview Design v20260427
+
+This memo is the entry point for the shared design documents of the `miku` software series.
+
+The initial versions of the related tools were created by `Mikuku` and Toshiki Iga.
+
+The current contents are based on the main-application design memo, Java application design memo, straight-conversion guide, Agent Skills design memo, and MCP design memo checked on 2026-04-27.
+
+## Design Summary
+
+The `miku` software series can be summarized as follows.
+
+> A family of small, local-first bridge tools that expose domain files and domain data through human-facing Web Apps, scriptable CLI runtimes, agent-facing skill packages, Java runtime artifacts, and MCP protocol adapters while preserving each product's semantic center.
+
+The series is not organized around a single UI, runtime, or protocol. It is organized around a layered product shape.
+
+- Keep each upstream product's semantic center clear
+- Provide human-facing Single-file Web Apps where useful
+- Provide Node.js CLI surfaces as normal main-application surfaces
+- Provide Java 1.8 CLI runtimes through straight conversion as a normal follow-up deliverable
+- Package Agent Skills with instructions, operation maps, references, and executable CLI runtime artifacts
+- Provide MCP servers in Node.js / TypeScript when there is no product-specific reason to avoid them
+- Keep Java versions, Agent Skills, and MCP servers downstream of the upstream product semantics
+- Preserve artifact roles, diagnostics, local execution, and runtime traceability across layers
+
+## Role of This Document
+
+This document is not a replacement for the detailed design documents. It explains how those documents fit together and records the product-family shape that sits above them.
+
+The detailed documents define the behavior and conventions of each layer. This overview explains the order, responsibility split, and intended relationship among those layers.
+
+When a specification is unclear, read this overview as the product-family map, then use the layer-specific document for detailed decisions.
+
+## Document Set
+
+This overview is the entry point for the shared miku software design document set.
+
+The detailed documents are organized by layer and concern.
+
+- `docs/miku-soft-00-overview-design-v*.md`
+  - provides the top-level product-family overview and explains how the design documents relate to each other
+- `docs/miku-soft-10-mainapp-design-v*.md`
+  - describes the main application layer, including the Single-file Web App and Node.js CLI as normal first-class product surfaces
+- `docs/miku-soft-20-javaapp-design-v*.md`
+  - describes Java application versions, especially Java 1.8 CLI/runtime artifacts, packaging, testing, and build integration
+- `docs/miku-soft-30-straight-conversion-v*.md`
+  - describes how TypeScript / Node.js products are converted into Java while preserving upstream traceability and behavior
+- `docs/miku-soft-40-agentskills-design-v*.md`
+  - describes Agent Skills packages, including local instructions, operation maps, references, and bundled CLI runtime artifacts for AI agents
+- `docs/miku-soft-50-mcp-design-v*.md`
+  - describes Node.js / TypeScript MCP server versions that expose product operations to MCP clients through tools, resources, and prompts
+
+## Layered Product Shape
+
+The miku software series can be understood through three facing layers.
+
+1. Human-facing layer
+2. Agent-facing layer
+3. MCP-facing layer
+
+These are facing layers, not independent product semantics. The upstream product owns the semantic center. Downstream runtime, skill, and protocol layers should expose that product meaning without becoming replacement implementations.
+
+## Human-Facing Layer
+
+A miku main application normally has two first-class surfaces: a Single-file Web App for human users and a Node.js CLI for automation, agents, and repeatable local workflows.
+
+The Single-file Web App is the human-facing surface when a product benefits from interactive loading, preview, diagnostics, and download. It is usually created in Node.js / TypeScript, has a Web UI, and runs locally in a browser without requiring server setup.
+
+The Node.js CLI is also a normal main-application surface. It exposes the same product core for scripts, repeatable local workflows, downstream Agent Skills, and later runtime adapters.
+
+Some main applications may be CLI-only when that is the natural product shape. In that case, the product is still a main application if it stands as the primary upstream product, accepts real local input, and produces verifiable artifacts.
+
+The human-facing layer should keep the following properties.
+
+- local-first execution
+- no server requirement for core functionality
+- clear canonical source or semantic base
+- structured outputs that scripts and AI agents can reuse
+- human-reviewable outputs such as HTML, Markdown, SVG, XLSX, XML, or ZIP when useful
+- shared core behavior behind UI, CLI, tests, and downstream adapters where practical
+
+## Java Runtime Layer
+
+A Java 1.8 CLI runtime is treated as a normal follow-up deliverable for miku products, implemented through straight conversion from the TypeScript / Node.js product unless there is a clear reason not to.
+
+The Java runtime should not be a Java-first redesign. Its first responsibility is to preserve upstream semantics, vocabulary, file-boundary traceability, CLI behavior, diagnostics, and artifact roles while making the product easier to run in Java-centered local and build environments.
+
+The Java runtime layer usually emphasizes:
+
+- Java 1.8 source and binary compatibility
+- CLI runtime jar
+- batch execution where it has clear operational value
+- Maven and build-tool integration when useful
+- deterministic artifact generation
+- public core APIs callable from CLI, tests, Maven plugins, and automation
+- distribution artifacts such as executable jars, sources jars, and distribution zips
+
+The TypeScript / Node.js CLI and Java CLI are peer runtime surfaces when both exist. Differences caused by runtime constraints should be documented rather than hidden.
+
+## Straight Conversion Layer
+
+Straight conversion is the bridge from the TypeScript / Node.js upstream product to the Java runtime.
+
+It is not a separate user-facing product layer. It is the reproducible method used to create and maintain Java versions without losing the ability to follow upstream changes.
+
+Straight conversion fixes the following direction.
+
+- Do not start from Java-first redesign
+- Keep upstream file boundaries and vocabulary traceable
+- Keep upstream tests and Java tests mapped
+- Keep the Node.js CLI contract close where a CLI exists
+- Treat Java-side extensions as separate contracts
+- Keep the Web UI out of the Java runtime unless explicitly required
+
+The output of straight conversion is a Java application version that remains understandable as a downstream runtime of the upstream product.
+
+## Agent-Facing Layer
+
+The agent-facing layer packages the product for AI agents.
+
+Agent Skills are not only instruction documents. They are agent-facing packages that combine local instructions, constraints, operation maps, references, and executable CLI runtime artifacts.
+
+The normal first runtime is the TypeScript / Node.js CLI artifact produced by the main application. A Java CLI runtime is also a normal runtime path when the Java version exists. As the target shape, miku Agent Skills should receive runtime artifacts as simple files under the skill package.
+
+Typical runtime artifacts are:
+
+- a single JavaScript CLI file for the Node.js runtime path
+- a single jar for the Java CLI runtime path
+
+Both runtime paths belong to the same skill product. Their presence should not split the skill name, activation rules, workflow vocabulary, artifact roles, or product boundary.
+
+Agent Skills should use upstream public APIs, documented CLI commands, stable global APIs, or bundled runtime artifacts before writing skill-local product logic. If the upstream product does not expose a needed capability, the preferred direction is to add or stabilize that capability upstream, then let the skill call it.
+
+The agent-facing layer should especially preserve:
+
+- explicit activation boundaries
+- product-specific operation maps
+- distinction between canonical source, state, draft, patch, projection, report, and diagnostics artifacts
+- local file workflow discipline
+- hard-error and soft-warning reporting
+- runtime lookup through declared skill-local artifacts before broad repository search
+
+## MCP-Facing Layer
+
+The MCP-facing layer is a normal extension target, not a replacement for Agent Skills.
+
+When there is no product-specific reason to avoid it, a miku product should provide an MCP server for MCP clients. The standard implementation choice for miku MCP servers is Node.js / TypeScript, using the MCP SDK and keeping the server as a thin protocol adapter.
+
+The MCP server exposes product operations through tools, resources, and prompts. It should remain a protocol adapter over the product runtime, not a replacement implementation.
+
+The MCP server may execute the TypeScript / Node.js runtime, the Java runtime, or both as product runtime artifacts. This runtime choice is separate from the MCP server implementation language. When both runtime artifacts are available, the MCP server should treat runtime choice as an execution policy, not as a change in product semantics.
+
+Java should not be treated as a default second MCP server implementation. A Java-side directory in an MCP repository may exist as a placeholder, but it should remain a placeholder unless a concrete future distribution or runtime constraint justifies maintaining a Java MCP server.
+
+The MCP-facing layer should keep the following properties.
+
+- product-prefixed tools with structured input schemas
+- structured tool results and diagnostics
+- resources for reusable state, specifications, reports, generated files, and diagnostics
+- small product-specific prompts when useful
+- local stdio transport as the first implementation target
+- HTTP transport as an additional deployment form with explicit session, storage, authentication, and isolation boundaries
+- shared tool names and result shapes across local and server variants
+
+MCP servers and Agent Skills should stay aligned around upstream product vocabulary, operation maps, artifact roles, and runtime contracts. Neither layer should become the semantic owner of the product.
+
+## Normal Product Flow
+
+The usual product flow for the miku software series is as follows.
+
+1. Create or maintain the TypeScript / Node.js main application.
+2. Provide the Single-file Web App when human-facing UI is useful.
+3. Provide the Node.js CLI as a normal product surface.
+4. Produce a single-file Node.js CLI runtime artifact for downstream use.
+5. Create the Java 1.8 CLI runtime through straight conversion unless there is a clear reason not to.
+6. Package Agent Skills with instructions, operation maps, references, and bundled runtime artifacts.
+7. Provide a Node.js / TypeScript MCP server when there is no product-specific reason to avoid it.
+
+This flow is a default direction, not a reason to blur responsibilities. Each layer must keep the upstream product boundary visible.
+
+## Responsibility Split
+
+The preferred responsibility split is as follows.
+
+- Main application
+  - owns product semantics, canonical source or semantic base, primary conversions, core APIs, Web UI when present, and Node.js CLI
+- Java application
+  - owns Java runtime packaging, Java CLI, Java-side batch or build integration, and Java-side tests while preserving upstream behavior
+- Straight conversion guide
+  - owns the method for creating and maintaining Java versions from TypeScript / Node.js upstreams
+- Agent Skills package
+  - owns agent-facing instructions, activation rules, workflow maps, local file discipline, runtime lookup, and bundled runtime artifact wiring
+- MCP server
+  - owns MCP tools, resources, prompts, transport handling, session or workspace policy, and protocol result formatting
+  - is normally implemented in Node.js / TypeScript; Java runtime artifacts remain runtime inputs, not a default second MCP server
+
+The semantic center should remain with the upstream main application. Runtime, skill, and protocol layers should expose or adapt that center rather than redefining it.
+
+## Shared Artifact Discipline
+
+Across all layers, miku products distinguish artifact roles.
+
+Common roles include:
+
+- canonical source or semantic base
+- internal product state
+- AI-facing projection
+- draft or patch returned by AI
+- primary exchange output
+- human-facing report
+- generated bundle
+- diagnostics and warnings
+- temporary scratch output
+
+These roles should not be collapsed only because the artifacts share a file extension or can all be represented as JSON or files.
+
+For example, a structural workbook `XLSX`, a human-facing `WBS XLSX`, a workbook JSON state file, and a Patch JSON document may all participate in one product workflow, but they are not the same contract.
+
+Keeping artifact roles visible makes UI, CLI, Java runtime, Agent Skills, and MCP server behavior easier to align.
+
+## Summary
+
+The miku software series starts from small local products, usually implemented in TypeScript / Node.js, and then exposes the same product meaning through multiple surfaces.
+
+The main application provides the upstream semantic center and normally exposes both a Single-file Web App and a Node.js CLI. Java versions provide Java 1.8 CLI runtimes through straight conversion. Agent Skills package instructions and executable runtime artifacts for AI agents. MCP servers expose product operations through a standard protocol for MCP clients and are normally implemented in Node.js / TypeScript.
+
+The important point is not to multiply implementations. It is to keep one product meaning usable from human UI, local CLI, Java runtime, agent package, and MCP protocol without losing traceability, diagnostics, or artifact discipline. In particular, a Java runtime artifact does not imply that a Java MCP server should also be implemented.

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-10-mainapp-design-v20260501.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-10-mainapp-design-v20260501.md
@@ -1,0 +1,922 @@
+# Miku Software Main Application Design v20260425
+
+This memo organizes design characteristics commonly seen across the software series whose names start with `miku`.
+
+The initial versions of these tools were created by `Mikuku` and Toshiki Iga.
+
+The current contents are based on this repository and public `igapyon` GitHub repositories checked on 2026-04-25.
+
+## Design Summary
+
+The `miku` software series can be summarized as follows.
+
+> A family of small, local-first conversion / bridge tools that turn existing domain files into AI-friendly, script-friendly, human-reviewable structured outputs.
+
+What characterizes this series is not a specific technology stack or UI style. It is a repeated set of product constraints.
+
+- Keep each tool small enough to understand
+- Run locally whenever possible
+- Expose structured data
+- Make AI and automation easier
+- Do not pretend to replace full specialist software
+- Prefer practical conversion and review workflows over visual fidelity
+
+## Role of This Document
+
+This document is not a strict specification for any individual repository. It is a cross-repository memo that organizes design decisions common to main applications in the miku software series.
+
+This document separates the following levels.
+
+- **Cross-cutting principles**: design policies that should generally be kept for new main applications and major feature additions.
+- **Recommended conventions**: implementation, distribution, and documentation shapes that make maintenance easier when shared across many main applications.
+- **Observed tendencies**: design habits and decisions visible in existing miku repositories.
+- **Product-specific notes**: design decisions for specific products, recorded as concrete examples of the cross-cutting principles.
+
+When a specification is unclear, read the cross-cutting principles before individual implementation convenience. However, the way a principle appears can differ depending on each product's canonical source, target format, users, and existing assets.
+
+This document is not a replacement for README files. A README is the user-facing entry point, individual files under `docs/` are detailed technical specifications, and this document is a higher-level memo for aligning design decisions across the series.
+
+## Scope
+
+The series whose names start with `miku` includes small tools such as the following.
+
+Main applications:
+
+- `miku-abc-player`
+- `miku-docx2md`
+- `miku-indexgen`
+- `miku-unicode-guard`
+- `miku-xlsx2md`
+- `mikuproject`
+- `mikuscore`
+
+Java straight-conversion versions:
+
+- `miku-indexgen-java`
+- `miku-xlsx2md-java`
+
+Agent Skills versions:
+
+- `mikuproject-skills`
+- `mikuscore-skills`
+
+Projects with the `-java` suffix are positioned as straight Java conversions of the original suffixless tools.
+
+Projects with the `-skills` suffix are positioned as Agent Skills versions that make the original products easier for AI agents to use.
+
+Main applications in the miku series, excluding Java versions and Agent Skills versions, are generally implemented as Node.js applications. When they have a Web UI, they use the `lht-cmn` Web Components as shared UI components.
+
+## Shared Direction
+
+This series is naturally understood as a set of small, practical bridge tools.
+
+Each tool converts, extracts, inspects, or normalizes existing files or domain data, then bridges that information into forms that humans, scripts, and AI agents can handle more easily.
+
+The shared direction is as follows.
+
+- local-first processing
+- small and understandable implementation shape
+- machine-readable output
+- data exchange that is easy to pass to AI agents
+- human-readable companion output when useful
+- no server dependency for core functionality
+- reproducibility where practical
+
+## Role of Main Applications
+
+In this document, a main application means an application in the miku series that is neither a Java straight-conversion version nor an Agent Skills version, and that uses Node.js as its basic runtime.
+
+Main applications may be Web UI applications, CLI-only applications, or applications that provide both. A Web UI is common but not required. A CLI-only tool such as an index generator is still a main application when it stands as the primary product, accepts real local input, and produces verifiable artifacts.
+
+Main applications are practical tools for safely reading existing files in a local environment, structuring them, and passing them to another representation.
+
+Main applications are not mere demos or libraries. They should stand as products that have a UI or CLI directly usable by humans, accept real files as input, and produce verifiable artifacts.
+
+At the same time, main applications do not aim to fully replace specialist software. Their primary role is to stand between existing specialist software, file formats, AI agents, and scripts, then bridge information into easier-to-handle forms.
+
+## Cross-Cutting Principles
+
+miku main applications emphasize the following cross-cutting principles.
+
+1. Handle inputs locally, and do not make server communication a prerequisite for core functionality.
+2. Do not aim to fully replace specialist software; make format bridging and inspection the main role.
+3. Choose a canonical source or semantic base for each target domain, and do not confuse it with derived views.
+4. Prefer reusable structured output and traceability over perfect visual reproduction.
+5. Make unconvertible content, fallback, loss, and unsupported areas visible as diagnostics.
+6. Push processing called from UI, CLI, tests, and Agent Skills toward the same core as much as possible.
+7. Treat AI agents and scripts as first-class users, and do not make them depend on brittle screen operations or string parsing.
+8. Make artifacts savable, comparable, and rerunnable as files.
+
+The following sections elaborate these cross-cutting principles from the viewpoints of data design, conversion quality, distribution, UI, CLI, and individual products.
+
+### Basic Philosophy of Main Applications
+
+Main applications emphasize the following philosophy.
+
+- Process input files on the user's machine
+- Complete processing without sending files to a server
+- Keep Web UI applications distributable as Single-file Web Apps
+- Extract as much semantic structure as practical from existing files
+- Prefer reusable structured output over perfect visual reproduction
+- Provide representations that both AI agents and humans can verify
+- Do not hide unconvertible content or lost information
+- Keep implementation small, understandable, and maintainable
+- Implement core processing from scratch where practical
+- Add dependencies only when the user value and maintenance reason are clear
+- Respect both automation-friendly CLI usage and human-checkable UI usage
+
+The value of a main application is not universality. It is the ability to reliably run a specific conversion, extraction, or inspection workflow locally.
+
+### Common Principles for Main Applications
+
+Main applications use the following principles as defaults.
+
+- Use Node.js as the basic runtime
+- Use `lht-cmn` Web Components when a Web UI exists
+- Distribute Web UI applications as Single-file Web Apps
+- Do not require server communication for core functionality
+- Accept input from local files, CLI arguments, or standard text/JSON representations
+- Generate output as files that are easy to pass to other tools, such as Markdown, JSON, XML, SVG, XLSX, or ZIP
+- Build UI flow around load, preview, diagnostics, and export
+- Make CLI usable for batch processing, tests, and AI agent workflows
+- Make major artifacts savable as files
+- Treat warning, diagnostics, and summary as structured data where possible
+- State conversion limitations and unsupported areas clearly
+- Try to obtain the same output from the same input and same settings
+
+Main applications keep the user flow short: load, verify, export, and pass to another tool or AI.
+
+### Scratch Implementation and Dependency Principles
+
+Main applications implement core processing from scratch where practical.
+
+This does not mean that external libraries must never be used. In cases such as `mikuscore`, third-party libraries may be necessary because of domain complexity or the need to connect with existing assets.
+
+External libraries are also appropriate when specification compliance is too large or risky for a small tool, when implementing the behavior ourselves would create security risk, or when integration with an existing ecosystem is the main user value. Examples include complex media rendering, archive or cryptographic correctness, format parsing whose edge cases are security-sensitive, and domain-specific engines maintained by a broader ecosystem.
+
+However, the central conversion policy, data model, diagnostics, output assembly, and AI-facing view generation should remain under our control as much as possible.
+
+This principle appears in decisions such as the following.
+
+- Do not delegate the meaning of conversion entirely to an external library
+- Read and write the necessary parts of file formats ourselves where practical
+- Even when ZIP input/output is needed, avoid heavy general-purpose libraries if the use case is limited
+- Even when Excel input/output is needed, avoid handing the whole process to large libraries such as Apache POI; handle the required workbook structure on the miku side
+- Implement XLSX, XML, SVG, Markdown, JSON, and similar generation with a clear scope limited to the purpose
+- Use third-party libraries to realistically reduce implementation burden or compatibility risk, not to hide general processing
+- Place miku-series data models and diagnostics around adopted libraries
+- Be cautious about adopting dependencies when they make output or behavior opaque
+
+Even when `mikuproject` handles ZIP or XLSX-like artifacts, the core assembly should remain understandable. Even for Excel input/output, processing should not be handed wholesale to comprehensive libraries such as Apache POI; the required workbook structure should be handled on the miku side. Even when `mikuscore` needs third-party libraries around music formats or rendering, the miku-side value should remain in format bridging, diagnostics, normalization, and handoff to AI workflows.
+
+The point of reducing dependencies is not simply to reduce package count. It is to keep the meaning, constraints, and failure modes of processing understandable and explainable to users and AI agents.
+
+### Data Design Principles
+
+Main applications emphasize internal and output data design.
+
+In particular, they prioritize the following ideas.
+
+- Place a canonical format or semantic base for each target domain
+- Treat surrounding formats as views derived from that canonical format
+- Separate human-facing output and AI-facing output when useful
+- Make JSON easy for AI and programs to handle
+- Use Markdown as context that humans can read and AI can also consume
+- Treat SVG, XLSX, ZIP, and similar formats as artifacts or reports
+- Expose warnings and loss that occur during conversion as diagnostics
+
+Data design prefers meaningful structure, diffability, reuse, and reimportability over visual reproduction.
+
+### Canonical Source, Primary Output, and Derived View Principles
+
+Main applications declare what they treat as the canonical source for each target domain and design around it.
+
+The canonical source is the semantic center that the application must preserve. In extraction tools, it is often useful to call the original file or data being extracted the canonical input. The primary output is the artifact the user mainly wants from the tool, such as Markdown, JSON, XML, SVG, XLSX, or ZIP. Derived views are additional surfaces generated from the canonical source or from the primary output for inspection, handoff, reimport, or reporting.
+
+Input/output, internal models, UI, CLI, AI-facing views, and report outputs are positioned to preserve the canonical source and transfer its meaning to other uses.
+
+Examples:
+
+- `mikuscore` treats MusicXML as the semantic anchor
+- `mikuproject` treats MS Project XML as the semantic base and uses `ProjectModel` internally
+- `miku-xlsx2md` treats the Excel workbook as the canonical input, and Markdown as the primary extracted representation for design-document structure
+- `miku-docx2md` treats the Word document as the canonical input, and Markdown as the primary extracted representation for document structure
+
+Use-specific views are placed around the canonical source.
+
+- Markdown, SVG, and XLSX reports for humans
+- Projections, draft views, task edit views, and phase detail views for AI
+- Workbook JSON, patch JSON, summaries, and diagnostics for reimport and comparison
+- ZIP bundles for distribution and handoff
+
+The important point is not to confuse canonical source, canonical input, primary output, and derived views. Primary output is allowed to be the main user-visible result without becoming the canonical source. Derived views are useful work surfaces, but they should be generated only within the range that does not break the semantic center. When reimport is possible, the affected range must be explicit.
+
+When a design decision is unclear, prefer the option that best preserves the meaning of the canonical source. Appearance, convenient editing surfaces, and AI handoff are important, but they should not take priority when they would lose the meaning of the canonical source.
+
+### Product Boundary Principles
+
+Main applications clarify what the tool does and, just as importantly, what it does not do.
+
+Examples:
+
+- `mikuscore` is a score converter / handoff tool, not a powerful notation editor
+- `miku-abc-player` is a playback-first / preview-first ABC-centered app, not a broad score conversion workbench
+- `miku-xlsx2md` aims to turn design-document structure into Markdown, not to reproduce Excel appearance
+- `mikuproject` bridges MS Project XML with WBS / AI / reports, and does not replace every project-management feature
+
+This boundary is reflected in README, docs, UI copy, and CLI help. Even if a capability exists internally, it should not be placed too prominently if it is not central to the product.
+
+### Conversion Quality Principles
+
+Main applications do not evaluate conversion quality only by whether the result looks similar.
+
+The important axes are as follows.
+
+- Do not drift unnecessarily away from the semantic center or canonical format
+- Preserve existing information first, and do not over-infer ambiguous information
+- When full fidelity is difficult, make loss, fallback, and unsupported areas visible as diagnostics
+- Give conversion results traceability, leaving clues back to the original file / sheet / range / anchor / node
+- In round trips, prioritize semantic and structural stability over whitespace identity
+- For conversions that can round-trip, include round-trip cases in tests and verify that the original semantic structure can be recovered
+- Keep conversion bounded and local, avoiding unrelated global rewrites
+- Treat failing operations atomically so they do not leave partially broken state
+
+Quality assurance uses unit tests, golden tests, fixtures, and regression cases to fix quality while increasing known edge patterns.
+
+### Display Value and Internal Value Principles
+
+Main applications distinguish between values humans see and values kept internally.
+
+For conversions such as `miku-xlsx2md`, standard output is biased toward Excel display values. This is because, when humans share existing file contents with AI, it is important that the values seen on screen and the values in Markdown are close.
+
+At the same time, raw values, resolution paths, fallback reasons, and unsupported reasons are kept as internal information or diagnostics when needed.
+
+This principle satisfies both of the following.
+
+- Humans and AI can more easily share the same visible interpretation
+- Implementers and automation tools can trace the origin of values and conversion decisions
+
+### Small Impact Radius Principles
+
+Main applications separate the impact radius of import, edit, and AI integration.
+
+Representative categories are as follows.
+
+- `replace`: replace the whole state
+- `merge`: reflect only limited columns or limited regions into the existing state
+- `patch`: validate and apply only local differences returned by AI or similar tools
+
+When safely modifying existing data, local projections and patches are preferred over whole replacement. Inputs passed to AI are also cut down into necessary overviews, task edits, phase details, and similar small pieces rather than whole bundles.
+
+This design keeps AI context small, makes returned changes easier to validate, and makes diffs easier for humans to review.
+
+### Artifact Pipeline for Generative AI Interactive Tools
+
+For miku software such as `mikuproject` and `mikuscore`, which have generative AI interaction or AI agent workflows, AI integration is not treated merely as a convenient UI feature. It is designed as a pipeline with intermediate artifacts.
+
+Inputs passed to AI, outputs returned by AI, validation results, applied state, and diffs are each made into units that can be saved, inspected, and rerun.
+
+A representative flow is as follows.
+
+- Output an AI-facing projection from the target state
+- AI returns structured JSON such as a draft, edit view, or patch
+- Validate the returned JSON's kind, schema, reference IDs, and impact radius
+- Apply only what passes validation to the state
+- Diff the applied state against the original state
+- Expand into human-facing artifacts such as XML, XLSX, Markdown, or SVG when needed
+
+This property does not appear with the same intensity in every miku main application. In tools whose main purpose is extraction or conversion, such as `miku-xlsx2md` and `miku-docx2md`, AI-readable output and diagnostics are central. In tools that edit existing state through interaction with AI, projection, patch, validate, apply, and diff move closer to the center of the product workflow.
+
+This pipeline may fit CLI and Agent Skills better than Web UI. When intermediate artifacts are JSON and staged validation or diff review is important, CLI and Agent Skills should be treated as regular paths rather than making the UI too heavy.
+
+Web UI is useful as a lightweight entry point for creating projections, checking import results, previewing, and downloading. The center of AI editing, however, is the ability to handle saved projections, patches, diagnostics, and diffs in order.
+
+## Recommended Conventions
+
+The following sections turn the cross-cutting principles into practical repository operations. They do not force every product into exactly the same shape, but new implementations and cleanups should first consider this shape as the default.
+
+### Distribution and Build Principles
+
+For main applications with a Web UI, split development-time source files from distribution-time single-file artifacts.
+
+Distribution artifacts should generally be designed as Single-file Web Apps. They should open in a Web browser, require no additional installation or server startup, and allow core functionality to be used offline.
+
+For Web distribution, the basic structure is to place `index.html` as a landing page and launch the actual main HTML from it. The main HTML is generated as a product-named single-file app, such as `miku-xlsx2md.html`, `miku-docx2md.html`, `mikuproject.html`, or `mikuscore.html`.
+
+The landing page generally displays the build date. Links from the landing page to the main HTML include URL parameters such as the build date so old single-file apps are less likely to be opened from the browser cache.
+
+The basic shape is as follows.
+
+- Place TypeScript source under `src/`
+- Edit source template HTML
+- Treat `index.html` as the landing page
+- Display the build date on the landing page
+- Generate the main HTML as a product-named single-file app
+- Add cache-busting parameters to URLs from the landing page to the main HTML
+- Bundle CSS / JS / required assets into a single HTML file during build
+- Do not directly edit generated single HTML artifacts
+- Make generated artifacts work as offline runtime
+- Keep required JS / CSS local or vendored
+- Make builds locally deterministic
+
+This shape balances development-time maintainability with ease of distribution for users.
+
+### `workplace/` Directory Principles
+
+The repository root of a main application contains a `workplace/` directory for local work.
+
+`workplace/` is a place for generated artifacts, temporary files, local verification data, local run results, and similar files. The directory itself is kept with `.gitkeep`, but its contents are generally outside git management.
+
+The expected repository shape is to keep `workplace/.gitkeep` under version control and ignore normal contents below `workplace/` through `.gitignore`. If a product needs a checked-in sample or fixture, it should be placed under an explicit fixture or docs directory rather than hidden inside `workplace/`.
+
+`workplace/` is not included as input or an inspection target for standard test, lint, or release checks. However, it may be used at the end of a build as an output destination for artifacts generated by the current product itself. This directory may contain sibling repository clones, real documents, verification outputs, and similar files; if standard commands pick them up, quality checks for the current product become mixed with the state of the local verification environment.
+
+The name is standardized as `workplace`. If past text or typos use `workspace`, those references should be moved to `workplace` over time.
+
+### Role Split Between README and docs
+
+`README.md` is an entry document for ordinary users.
+
+README should mainly contain the following.
+
+- What the software does
+- Representative usage
+- Installation or startup method
+- Major inputs and outputs
+- Major options
+- Links to additional information
+
+Developer details, design memos, internal structure, implementation specifications, test policy, and future notes are stored as Markdown under `docs/`.
+
+README may link to `docs/`, but its body should stay as the first explanation users read. Do not make README too heavy with internal design or developer details.
+
+### Managing External-Publishing Documents Under `docs/articles`
+
+Main applications may place drafts and outlines for external publishing under `docs/articles/`, separate from user-facing README and developer-facing docs.
+
+`docs/articles/` is not the product specification itself. It is a working area for organizing product introductions, development experience, implementation knowledge, and problem awareness for external media. Original manuscripts, article notes, outlines, and drafts for published articles are kept as Markdown.
+
+The basic shape is as follows.
+
+- Separate directories by medium
+- Use one Markdown file per article by default
+- Keep pre-publication thinking as Markdown
+- Keep original manuscripts or supplementary notes for published articles when useful
+- Provide article templates that organize topic, intended reader, constraints, and related links
+- Use filenames that expose date and topic, such as `YYYYMMDD-topic-outline.md`, `YYYYMMDD-topic-draft.md`, or `topic-memo.md`
+
+The roles of media-specific directories are also separated.
+
+- `docs/articles/qiita/` contains articles for developers or technically interested readers, such as technical background, implementation policy, usage, constraints, and development logs
+- `docs/articles/note/` contains articles that emphasize narrative flow, such as background, problem awareness, experience, and thinking
+
+This separation keeps technical articles and experience articles from mixing too much, even when they discuss the same subject. For example, feature introductions and Markdown output specifications for `miku-xlsx2md` can be organized for Qiita, while the experience of implementing and documenting with generative AI can be organized for Note.
+
+`docs/articles/` is not a replacement for README or specifications. Constraints, implementation knowledge, bugs, and improvement ideas found while writing articles are returned to README, formal docs, TODO, or test fixtures as needed. Article writing is external publishing, but it is also treated as a review workflow for making the product explainable.
+
+### Task Management With `TODO.md`
+
+In many cases, in-progress tasks, improvement ideas, unresolved topics, and next actions are recorded in `TODO.md`.
+
+`TODO.md` is not so much a replacement for an issue tracker as it is a lightweight work memo for keeping context inside the repository.
+
+More detailed design memos or specifications can be split into `docs/` as needed. `TODO.md` should contain short entry points to those files and lists of unfinished items.
+
+### Exceptions and Derived Relationships
+
+#### Exception for Derived Apps With Upstream
+
+miku main applications generally do not have another main application as upstream.
+
+`miku-abc-player` is a subset made by picking up ABC-related functionality from `mikuscore`. Its use of `mikuscore` as upstream is a special circumstance caused by this subset extraction. `mikuscore` itself also refers to another upstream in some parts, but this is treated as an exception among exceptions. Product-specific details for `miku-abc-player` are gathered in the product-specific notes below.
+
+Such upstream references and derived relationships are not the standard shape for main applications as a whole.
+
+Derived applications that exceptionally have an upstream emphasize the following.
+
+- Keep future intake from upstream easy
+- Prefer thin wrappers, thin adapters, and entry-point level customization
+- Narrow feature scope through UI surface, input mode, and product messaging
+- Do not delete upstream-derived code broadly only because the current UI does not use it
+- Prefer ease of upstream sync over visual local cleanup
+- Allow downstream-specific divergence only when the practical benefit is clear
+
+This policy permits a little extra code only when an upstream exists. Normal main applications do not assume upstream synchronization and instead prefer a small, understandable structure aligned with the application's own purpose.
+
+### Core and Thin Entry Principles
+
+Main applications push processing called from UI, CLI, tests, and Agent Skills toward the same core as much as possible.
+
+CLI and Web UI are designed as thin entry points that call a shared core, not as separate implementations.
+
+This principle appears in forms such as the following.
+
+- Separate the body of conversion, inspection, normalization, import, and export from UI
+- Implement CLI as a thin wrapper around core
+- Let Web UI display core results and handle file selection and saving
+- Write tests not only for UI but also for core APIs
+- Provide small public entry points that Agent Skills and external automation can call easily
+- Use the same defaults, diagnostics, and output policy in Web UI and CLI
+
+When adding a thin layer to publish a CLI, keep that layer responsible for option parsing, file I/O, stdout / stderr, and exit codes. Do not duplicate conversion meaning or business logic on the CLI side.
+
+### Public API Surface Principles
+
+Main applications provide a UI-independent public API surface when needed.
+
+The public API surface does not expose everything inside the application. It gathers operations needed by Agent Skills, CLI, tests, MCP, or future integrations as small, stable entry points.
+
+The public API surface emphasizes the following.
+
+- Provide format-aware import / export entry points
+- Put verification operations such as validate, summarize, diff, and apply on the core side
+- Make AI-facing specs and projections stably retrievable
+- Do not depend on UI DOM state
+- Structure input, output, and diagnostics
+- Do not turn the detailed internal module graph into an external contract
+
+This policy lets features built for Web UI be used with the same meaning from CLI and Agent Skills.
+
+### Runtime Difference Adapter Principles
+
+Main applications may run in both Web browsers and Node.js CLI.
+
+In that case, runtime-specific parts such as DOM, XML parser, file, Blob, download, encoding, and ZIP saving should not be scattered directly through core logic.
+
+Runtime differences are contained in adapters or loaders as follows.
+
+- Use browser standard APIs on Web
+- Inject required APIs through loaders or adapters in Node.js
+- Do not hard-code XML DOM or serializer to a global
+- Treat file I/O and download as separate responsibilities
+- Let core pass around bytes, text, document objects, and structured data
+
+This separation makes it easier to use the same core in both Single-file Web Apps and CLI.
+
+### Diagnostics and Summary Principles
+
+Main applications treat diagnostics and summaries as formal output surfaces, not as byproducts.
+
+Diagnostics are not mere error messages. They are information for users, developers, and AI agents to trace conversion decisions, fallback, unsupported areas, loss, warnings, suspicious input, and output constraints.
+
+Summaries are used to quickly understand the whole input or conversion result.
+
+The principles are as follows.
+
+- Diagnostics have code / message / severity / source location where practical
+- Source location is kept in a form suited to the target domain, such as file / sheet / range / anchor / node / command
+- CLI can output diagnostics to stderr or as structured diagnostics
+- Web UI provides a place to inspect diagnostics and summaries
+- AI-facing workflows use diagnostics as material for patch validation and diff decisions
+- Unsupported information is not silently discarded; it is kept as trace or metadata when useful
+- To keep normal primary output readable, detailed trace is emitted in debug / diagnostics mode
+- Debug trace is not a replacement for the body; it is supporting information for tracing conversion decisions and lost information
+
+This makes it possible to judge not only whether conversion succeeded, but also how trustworthy it is and where constraints remain.
+
+### Option and Mode Principles
+
+Main applications avoid adding too many options and modes.
+
+However, important trade-offs that users must choose because of the target conversion should be exposed as modes.
+
+Examples:
+
+- display / raw / both
+- plain / github
+- balanced / border / planner-aware
+- replace / merge / patch
+- diagnostics text / json
+
+When adding a mode, satisfy the following.
+
+- It is explainable what the mode switches
+- The meaning is aligned between UI and CLI
+- The default is appropriate for normal use
+- The mode can be traced from output filenames or summaries
+- Tests fix representative cases for each mode
+
+Modes are placed for users to choose conversion policy, not to expose internal convenience.
+
+### UI Design Principles
+
+Main applications with a Web UI use `lht-cmn` Web Components to keep consistency across the series.
+
+UI is centered on the actual work surface rather than an explanatory landing page.
+
+The basic UI flow is as follows.
+
+- Load an input file
+- Run conversion or analysis
+- Inspect results, summaries, and diagnostics
+- Save required artifacts
+
+The UI clearly treats processing as local so users do not mistakenly think their files are being sent to an external server.
+
+Even when a Web UI exists, the center of the main application is not the UI itself. It is the processing that reads local files, structures them, and outputs artifacts. Avoid states whose meaning exists only in the UI.
+
+- Do not create important information that exists only in UI state
+- Do not trap core logic inside DOM event handlers
+- Make the same processing callable from CLI and tests
+- Use UI copy to clarify product boundaries
+- Separate the landing page as an entry point from the main HTML as the work surface
+
+For this reason, miku main applications prefer reliable operations on real files and verifiable outputs over visual luxury.
+
+### CLI Design Principles
+
+Main applications with a CLI consider both batch workflows that replace manual work and invocation from AI agents.
+
+CLI emphasizes the following.
+
+- Keep commands and options few
+- Make input and output files explicit
+- Output text artifacts to stdout or specified files
+- Write binary artifacts such as XLSX and ZIP to specified files by default; use an explicit binary-safe mode such as Base64 when stdout is supported
+- Treat warnings and diagnostics as stderr or structured diagnostics
+- For long-running processing or processing where progress matters, make progress and timing output available through `--verbose` or similar options
+- Make success and failure judgeable by exit code
+- Make the same operation reproducible in tests and CI
+
+CLI is not a helper for UI. It is a formal entry point for AI agent workflows and automation.
+
+As in `miku-indexgen --verbose`, target, output destination, current scan location, discovered files, and timing breakdowns are emitted incrementally when useful, rather than only summarized at the end. This lets humans and AI agents notice stalls, incorrect target ranges, or unexpected input earlier during processing.
+
+This kind of progress / timing output is not confused with primary output or structured diagnostics. Text artifacts remain stable through file or stdout contracts, while binary artifacts remain stable through explicit file-output or documented binary-safe stdout contracts. Incremental logs use an easy-to-identify prefix such as `verbose:`, and representative lines are fixed in tests.
+
+## Common Patterns Observed Across the Series
+
+The following sections are not specifications for individual products. They organize tendencies observed across existing miku repositories. They are not as strong as cross-cutting principles, but new main applications should first consider whether the same shape can be reproduced.
+
+### AI and Automation as Users
+
+AI agents and programs are treated as first-class users.
+
+This is explicit in `miku-indexgen`: it is described as a tool for AI agents and programs to get an overview of available files before reading full file contents.
+
+Across the series, this appears in forms such as the following.
+
+- JSON views for AI handoff
+- Markdown output as model-readable context
+- Diagnostics and summaries for downstream tools
+- `*-skills` repositories that teach AI agents how to use tools
+- CLI surfaces that allow scripted use without depending on browser UI
+
+The design preference is not merely to produce human-readable output. It is to keep structures simple enough for other programs and agents to use without brittle parsing.
+
+### Local-first and Privacy
+
+Many tools run in the browser or as local CLI.
+
+This is important because input files often contain private or business-sensitive data.
+
+Representative inputs include the following.
+
+- Excel workbook
+- Word document
+- project plan
+- score file
+- source repository
+
+Across the series, core functionality does not assume hosted backends or server communication. Single-file Web Apps and local CLI keep processing complete inside the local environment by default.
+
+### Prefer Conversion Over Full Editing
+
+These tools usually do not try to replace full-featured specialist applications.
+
+Examples:
+
+- `mikuscore` is a score conversion and inspection tool, not a full engraving editor.
+- `miku-xlsx2md` extracts meaningful workbook content as Markdown rather than perfectly reproducing Excel appearance.
+- `miku-docx2md` is not a Word layout engine; it extracts document structure as Markdown.
+- `mikuproject` bridges MS Project XML, WBS reports, AI JSON, and visual output, but does not replace every project-management feature.
+
+The repeated pattern is not to promise complete round-trip fidelity. It is to preserve or expose meaningful structure and make information lost during conversion visible.
+
+### Canonical Format, Primary Output, and Companion Format
+
+Some projects choose a canonical format or central format and place companion formats around it.
+
+Examples:
+
+- `miku-indexgen`: flat `index.json` is canonical. `index.md` is optional companion output.
+- `mikuscore`: MusicXML is the central interchange format.
+- `mikuproject`: MS Project XML is the semantic base. AI JSON, workbook JSON, XLSX, Markdown, SVG, and Mermaid are surrounding views.
+- `miku-xlsx2md`: the Excel workbook is the canonical input. Markdown is the primary extracted text representation. Assets and summaries are companions.
+- `miku-docx2md`: the Word document is the canonical input. Markdown is the primary extracted text representation. Assets and summaries are companions.
+
+This design supports the formats needed for human verification and tool exchange while keeping the core model simple.
+
+Artifacts are separated by role.
+
+- primary output: the conversion result the user mainly wants. Examples: Markdown, XML, XLSX, SVG.
+- companion summary: a summary for quickly inspecting the input or conversion result.
+- sidecar asset: supporting files referenced by the primary output, such as images, attachments, or split outputs.
+- manifest: a machine-readable index of sidecar asset paths, media types, source traces, location information, and similar data.
+- debug / diagnostic trace: fallback, unsupported, and loss tracking information that is too detailed for normal output.
+
+When sidecar assets are emitted, a manifest is attached where practical. This does more than save files; it helps downstream tools and AI agents reinterpret which input element each asset came from and how it is referenced from primary output.
+
+### Small Tool Shape
+
+This document organizes shared design information across the miku software series, not development notes specific to an individual repository.
+
+Across the series, tools are kept small and direct.
+
+- Keep the whole project small enough to understand
+- Minimize dependencies
+- Prefer machine readability over human-facing decoration
+- Prefer structures that make downstream automation simple
+- Use straightforward input/output through CLI arguments and generated files
+
+Implementation shape differs by project, but the basic product shape is small, readable, and easy for other tools to call.
+
+### Browser and CLI Combination
+
+Several projects combine a browser UI with a CLI path.
+
+Excluding Java versions and Agent Skills versions, main applications use Node.js as the basic runtime. Even when a Web UI exists, build, CLI, tests, and distribution artifact generation are centered on the Node.js toolchain.
+
+Web UI uses `lht-cmn` Web Components to keep a common look and operation feel across the series. App-specific UI is added minimally on top.
+
+Browser UI is suited for the following.
+
+- Interactive local conversion
+- Preview
+- Human inspection
+- Download of generated artifacts
+
+CLI is suited for the following.
+
+- Batch conversion
+- Tests
+- Agent workflows
+- Integration with other tools
+- Reproducible command-line use
+
+This combination allows the same core functionality to be used for both human work and automated workflows.
+
+### Naming Pattern
+
+The `miku` prefix indicates this series of small tools.
+
+Names include both hyphenated names such as `miku-indexgen` and `miku-xlsx2md`, and non-hyphenated names that start with `miku`, such as `mikuscore` and `mikuproject`.
+
+The `-java` suffix indicates a Java straight-conversion version, and the `-skills` suffix indicates an Agent Skills version of the original product.
+
+Many repositories also have the `mikuku` topic, which appears to identify the broader software family.
+
+### License Choice
+
+`miku` repositories consistently use Apache License 2.0.
+
+This is positioned as a practical default for small reusable tools and companion libraries.
+
+## Observed Main-Application Character
+
+In addition to technology choices, miku main applications share common habits in how they are built. This section names tendencies observed from existing products so they can be reused in future specification work.
+
+### Center Artifacts
+
+Main applications are designed around savable artifacts rather than screen state or temporary operation results.
+
+Artifacts should be usable later in the same way by users, CLI, tests, AI agents, and other tools.
+
+For this reason, the following are emphasized.
+
+- Major results can be output as files
+- Output filenames and formats are predictable
+- Results seen in UI and results obtained by CLI do not diverge in meaning
+- Summaries, diagnostics, and manifests inspected in UI and saved by CLI come from the same core
+- Generated files can be placed under work areas such as `workplace/`
+- Input, mode, diagnostics, and summary can be traced from artifacts
+
+UI is an operation surface for producing artifacts, and CLI is an entry point for generating artifacts automatically. Both are aligned as different entry points to the same processing result.
+
+### Inspect Before Handoff
+
+Main applications do not treat conversion as the end. They emphasize workflows where humans or AI inspect conversion results before passing them onward.
+
+For this reason, output may include not only a single final file but also summaries, diagnostics, previews, and companion outputs for inspection.
+
+This idea appears as follows.
+
+- Do not simply push conversion results directly into external tools
+- Provide human-judgeable Markdown, SVG, XLSX reports, and similar outputs
+- Pass input structure and constraints to AI as summaries before AI handles details
+- Pass AI-returned changes through validate, diff, and patch
+- In areas that can round-trip, verify in tests whether they can be converted back
+
+This does not mean that AI or automation is not trusted. The design places inspectable structure before and after automation.
+
+### Keep Distance to the Canonical Source Short
+
+Main applications avoid drifting too far from the canonical source even when adding convenient views or editing surfaces.
+
+AI-facing JSON, Markdown, reports, previews, and patches are surfaces for easier work. They are not the canonical source itself.
+
+For this reason, avoid the following.
+
+- Editing only a derived view and leaving the path back to the canonical source unclear
+- Over-shaping data for AI convenience and losing constraints from the original data
+- Distorting the canonical format or internal model to prioritize UI appearance
+- Over-completing input-side meaning for the convenience of conversion results
+
+What is needed is to create human- and AI-friendly surfaces while separating what came from the canonical source from what is derived, inferred, or auxiliary.
+
+### Keep Input and Output Straightforward
+
+Main applications avoid relying too much on complex project state or implicit work environments. They keep the relationship between input files and output files straightforward.
+
+Typically, they prefer the following shape.
+
+- Explicit input file or input directory
+- Explicit output directory when needed
+- Explainable generated file types
+- Clear meaning for stdout, stderr, and exit code
+- Rerunnable with local files only
+- Same command reproducible in CI and local tests
+
+This straightforwardness applies not only to CLI but also to Web UI. In Web UI, the flow should remain short: load, inspect, save.
+
+### Keep Intermediate Representations Small
+
+Main applications avoid making internal models or AI-facing projections into huge models that fully reproduce the entire target domain.
+
+They provide intermediate representations for extracting necessary meaning, but those representations are not full clones of the target domain. They are limited to the range the product needs.
+
+This policy preserves the following.
+
+- Implementers can understand the whole
+- JSON passed to AI agents does not become overly large
+- Patch and diff impact radius can be limited
+- Unsupported information is not forced into the internal model
+- Added features do not unnecessarily fatten the canonical source or core model
+
+Even when the target domain is complex, the miku-side intermediate representation is designed according to the range the product takes responsibility for.
+
+### Include Failure in the Specification
+
+Main applications treat failures and partial support as part of the specification, not only successful output.
+
+File conversion inevitably encounters inputs that cannot be fully supported. In such cases, the design should not silently discard information, approximate vaguely, or warn only in UI.
+
+The principles are as follows.
+
+- Emit unsupported as unsupported
+- Preserve fallback reasons when fallback occurs
+- Show loss when loss exists
+- Treat suspicious input as warning
+- Attach source location when possible
+- Keep normal output at a granularity that does not obstruct reading, and increase trace in debug mode
+- Fix not only success cases but also failures, warnings, and partial support in tests
+
+By structuring failure information, humans can judge more easily and AI agents can choose next operations more safely.
+
+### Return Real-Data Observations to Fixtures and Specifications
+
+Main applications emphasize returning differences and bugs found in local real data to fixtures, tests, docs, and TODO, rather than ending with one-off fixes.
+
+Real data often contains private or business-sensitive content, so it may not be placed directly in shared fixtures. Even then, the observed feature should be reduced into a minimal `.xlsx`, `.docx`, XML, JSON, or similar fixture and brought into tests in a reproducible form.
+
+This policy appears as follows.
+
+- Organize focus areas using real data outside git management
+- Do not expose real-data filenames or contents too much in public docs
+- Reduce found problems into minimal fixtures
+- Do not leave absolute paths, creators, modifiers, creation timestamps, external links, or unnecessary embedded information in fixtures
+- Connect fixtures with test names, specification topics, and the symptoms they mainly verify
+- Return design decisions learned from real-data observation to README, docs, and TODO
+
+This flow makes quality checks shareable and reproducible while still allowing tools to be local-first and handle private data.
+
+### Preserve Reproducibility Down to Output Bytes
+
+Main applications emphasize reproducibility of saved artifact bytes where practical, not only appearance or strings.
+
+Especially when generating ZIP, XLSX, Markdown, SVG, JSON, and similar outputs, the priority is to obtain artifacts that are easy to compare from the same input and same settings each time.
+
+This policy appears in decisions such as the following.
+
+- Fix metadata unrelated to content, such as ZIP entry timestamps
+- Make output filenames predictable from input name and mode
+- Avoid automatically increasing mode suffixes too much; put necessary mode information in summaries or metadata
+- Explicitly handle save-time settings such as encoding, BOM, line endings, and escaping
+- Share the same save-processing layer across browser UI, CLI, and Markdown inside ZIP
+- Treat runtime-unavailable encoding or save features as constraints rather than silently approximating them
+
+Reproducibility is not only for easier testing. It lets AI agents and scripts diff artifacts, judge changes, and reprocess only what is necessary.
+
+### Stage Fallback
+
+When main applications handle complex input formats, they do not aim for complete compatibility from the start. They use the most reliable information first and stage fallback when something cannot be resolved.
+
+Representative ideas are as follows.
+
+- Prefer saved confirmed values or canonical data inside input files when available
+- Limit in-house parsers / evaluators to ranges that need missing-value handling or completion
+- Keep older resolvers or compatibility paths as safety nets in some cases
+- When resolution fails, preserve the original formula, raw metadata, and unsupported reason
+- Make fallback events traceable through diagnostics or summaries
+
+This design avoids expanding into a complete reimplementation of the target format while reducing practical information loss.
+
+## Product-Specific Notes
+
+This section records how cross-cutting principles appear in individual products. These notes are not the formal specifications of each product; they are memos for organizing design boundaries.
+
+### Notes Specific to `mikuscore`
+
+`mikuscore` is a score converter / handoff tool that uses MusicXML as its semantic anchor. It is positioned as a main application for handing score data among notation software, interchange formats, AI generation workflows, and human preview.
+
+For this kind of tool, the following boundaries are especially important.
+
+- Treat MusicXML as the central interchange format, and do not drift conversion or generation meaning away from the MusicXML structure unnecessarily
+- Treat ABC, MEI, MuseScore, MIDI, SVG, PNG, AI JSON, and similar formats as import / export / preview / handoff views around MusicXML
+- Do not aim to be a powerful notation editor or engraving editor; make conversion, inspection, normalization, and verification before and after specialist editors the main role
+- Place preservation of existing information first, and do not over-infer ambiguous durations, voices, ties, accidentals, ornaments, or layout information
+- For inputs where full fidelity is difficult, keep loss, fallback, unsupported areas, and source locations as diagnostics
+- Prefer consistency among MusicXML usable by downstream tools, structured views readable by AI, and preview checkable by humans over perfect musical visual reproduction
+- For AI score generation or editing, use structured intermediate artifacts such as measure details, AI JSON, diagnostics, and diffs rather than exchanging the whole score as free text
+- Treat UI as an entry point for import, preview, diagnostics, export, and AI handoff, not as a score editing screen
+- Treat CLI and Agent Skills as formal entry points for score conversion, validation, AI workflows, and regression tests
+- Use third-party libraries to reduce the realistic burden of score rendering and existing-format connections, while placing miku-side value in conversion policy, diagnostics, normalization, and handoff models
+
+What matters for `mikuscore` is not becoming a substitute for notation software. It is to keep MusicXML at the center, pass score data to other representations without breaking it, and let humans and AI agents verify the same conversion result.
+
+Therefore, feature priority is judged not by whether more editing can be done on screen, but by whether MusicXML-first conversion quality, diagnostics, round-trip stability, AI handoff, and external tool integration become stronger. Strengthening saved intermediate artifacts, conversion diffs, fixtures, golden tests, and format coverage is more `mikuscore`-like than adding deep editing UI.
+
+### Notes Specific to `miku-abc-player`
+
+`miku-abc-player` is a special main application in the miku series. It is a playback-first and preview-first ABC-centered app derived from `mikuscore`, rather than a fully independent application designed around its own separate conversion engine.
+
+For this kind of tool, the following boundaries are especially important.
+
+- Treat ABC preview and playback as the product center, not broad score conversion or deep notation editing
+- Accept supported non-ABC imports when they are opened into the ABC-centered workflow through inherited `mikuscore` / MusicXML-compatible processing
+- Keep inherited edit and export surfaces secondary, even when they remain available because preserving them reduces implementation or sync cost
+- Reuse `mikuscore` project structure, build model, UI conventions, ABC-related logic, playback logic, and lightweight edit / export surfaces where doing so keeps upstream intake practical
+- Prefer thin adapters, profile-like configuration, entry-point customization, UI visibility controls, and product wording over downstream rewrites of shared conversion behavior
+- Do not delete upstream-derived code broadly only because the current `abc-player` UI does not expose all of it
+- Treat changes to ABC parsing, ABC / MusicXML round-trip behavior, diagnostics, playback, and shared UI/runtime assumptions as upstream-sensitive changes
+- When local divergence becomes substantial, prefer asking for a general `mikuscore` profile / option hook rather than adding `abc-player`-specific fork logic
+- Keep user-facing messaging centered on load, preview, play, and small correction workflows
+
+What matters for `miku-abc-player` is not becoming a smaller clone of all `mikuscore` features. It is to provide a fast local ABC playback and preview entry point while staying close enough to `mikuscore` that improvements to shared score handling can continue to flow into the derived app.
+
+Therefore, feature priority is judged by whether the app becomes better at opening ABC, showing it, playing it, and safely inheriting upstream score-processing improvements. Preserving an easy upstream sync path can be more `miku-abc-player`-like than aggressively removing unused inherited surfaces for local neatness.
+
+### Notes Specific to `mikuproject`
+
+`mikuproject` is a project bridge tool that connects `MS Project XML` as its semantic base with WBS, generative AI, human-facing reports, and visual outputs. For this kind of tool, the following boundaries are especially important.
+
+- Treat `MS Project XML` as a near-canonical semantic base, and use `ProjectModel` internally as a neutral representation
+- Treat `.xlsx` and workbook JSON as surrounding representations for verification, visualization, and limited editing, not as replacement canonical sources for `MS Project XML`
+- Treat `WBS XLSX`, `WBS Markdown`, `SVG`, and `Mermaid` as report / presentation outputs for humans, and do not confuse them with import paths
+- Treat generative-AI-facing JSON as an editing representation separate from workbook JSON, and separate its purpose with an extension such as `.editjson` when useful
+- For safe modification of existing WBS, prefer the local edit pipeline `project-overview -> task-edit / phase-detail -> patch_json -> validate -> apply -> diff` over whole replacement
+- Allow `project_draft_view` as an entry point for drafting new plans, but treat it as a different workflow from local modification of existing WBS
+- In import, make `replace / merge / patch` explicit and reject invalid combinations of `format` and `operation`
+- Validate AI-returned patches for referenced tasks, updatable fields, structural changes, dependencies, assignments, and similar points before applying them
+- Use `CLI` and `Agent Skills` as the main path for the AI editing pipeline; treat Web UI as an entry point for loading, projection saving, preview, download, and result inspection
+- Provide small aggregation entry points as needed so the single-file web app, CLI, Agent Skills, and tests can call the same core
+- Contain differences between Web browser and Node.js CLI in adapters for XML DOM, file I/O, download, encoding, and similar areas
+- Align the meaning of derived artifacts from the same `ProjectModel`, such as `WBS XLSX`, `WBS Markdown`, `Daily SVG`, `Weekly SVG`, `Monthly Calendar SVG`, and `Mermaid`
+- Treat `WBS SVG` not as a replacement for `Mermaid`, but as a separate preview / download output whose appearance is easier to control
+- Align interpretation of date bands, business days, holidays, progress bands, and similar display semantics between `WBS XLSX` and `SVG` where practical
+- Treat bundles such as `ALL` ZIP as useful for sharing and inspection, but too heavy for normal AI editing; prefer local projections first
+
+What matters for `mikuproject` is not increasing project-management features for their own sake. It is to hand the same project information among `MS Project XML`, reports, visualization, AI editing, and CLI automation without breaking meaning.
+
+Therefore, feature priority is judged not by whether the product approaches an MS Project replacement, but by whether bridging, inspection, local editing, diff review, and artifact generation become stronger. Strengthening saved state, limited projections, patch validation, and report export is more `mikuproject`-like than adding heavy UI-contained editing features.
+
+### Notes Specific to `miku-xlsx2md`
+
+`miku-xlsx2md` is a design-document conversion tool that extracts Excel `.xlsx` into Markdown. For this kind of tool, the following boundaries are especially important.
+
+- Do not make complete reproduction of Excel screen layout, cell widths, colors, borders, or shape placement the primary goal
+- Treat `.xlsx` as `design document structure extraction -> Markdown`, extracting prose, tables, images, links, formula results, and auxiliary metadata
+- Convert the whole workbook, and do not assume manual sheet-by-sheet copy-and-paste
+- Prefer display values close to what humans see in Excel as the default for Markdown body text
+- Track raw values, formulas, resolution paths, and fallback reasons as internal information or diagnostics rather than in the body text
+- Do not rely only on Excel table definitions for table detection; also use borders, value density, connected components, header-like features, planner / calendar layouts, and similar clues
+- For layout-centered sheets, prefer decomposing into sections, narrative, tables, images, charts, and shapes rather than absorbing the whole sheet into one huge table
+- Do not aim for a fully Excel-compatible formula evaluator; reduce information loss in the order `cached value -> AST evaluator -> legacy resolver -> fallback_formula`
+- Separate rich text modes into `plain`, which drops decoration, and `github`, which moves toward GitHub Markdown plus some HTML
+- Prefer extracting semantic metadata from charts over image reproduction, and treat shapes as source data or SVG assets where practical
+- Bundle Markdown and assets as ZIP, and make image or shape assets referenceable from the body by relative paths
+- Treat save-time byte-level reproducibility, such as ZIP entry timestamp, Markdown encoding, and BOM, as part of the conversion specification
+
+This policy avoids expanding into redrawing Excel as another Excel-like view, and keeps focus on document content, table structure, auxiliary information, and AI handoff.
+
+### Notes Specific to `miku-docx2md`
+
+`miku-docx2md` is a document conversion tool that extracts Word `.docx` into Markdown. For this kind of tool, the following boundaries are especially important.
+
+- Do not make complete reproduction of Word page layout, floating objects, shape positioning, text box placement, or headers / footers the primary goal
+- Treat Markdown as the primary output for reading document structure and body text
+- Track embedded images and other binary content with sidecar assets and manifests rather than fully repositioning them in the body
+- Make unsupported Word elements inspectable through summaries or debug HTML comment traces without polluting normal Markdown body text
+- Preserve image alt text, relationship targets, document positions, and similar data as companion metadata usable by AI and downstream scripts
+
+This policy avoids expanding into reimplementing the `.docx` layout engine, and keeps focus on extracting document content, order, headings, lists, tables, links, and image references into a locally reusable form.

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-20-javaapp-design-v20260501.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-20-javaapp-design-v20260501.md
@@ -1,0 +1,974 @@
+# Miku Software Java Application Design v20260426
+
+This memo organizes design characteristics commonly expected for Java application versions in the `miku` software series.
+
+The initial versions of the related tools were created by `Mikuku` and Toshiki Iga.
+
+The current contents are based on current miku Java application examples, the main-application design memo, and the straight-conversion guide checked on 2026-04-25.
+
+## Design Summary
+
+The Java application versions in the `miku` software series can be summarized as follows.
+
+> Java CLI / batch / build-tool versions of miku main applications that preserve upstream semantics, remain easy to trace back to the Node.js / TypeScript upstream, and provide local, reproducible artifact generation for automation and build workflows.
+
+What characterizes Java application versions is not a Java-first redesign of the original products. It is a repeated set of constraints.
+
+- Keep the semantic center of the upstream main application
+- Preserve traceability from upstream files, vocabulary, CLI behavior, and tests
+- Prefer CLI, batch, Maven, and jar distribution over Web UI
+- Keep core processing independent of entrypoint adapters
+- Make automation and build integration first-class use cases
+- Distinguish upstream-derived behavior from Java-side original extensions
+- Keep outputs reproducible and easy to compare
+
+## Role of This Document
+
+This document is not a porting procedure. The procedure for creating a Java version from a Node.js / TypeScript miku main application is described in the straight-conversion guide.
+
+This document instead describes the resulting Java application design that should be preserved after such conversion work.
+
+Use the three shared design documents together as follows.
+
+- main-application design memo
+  - describes the design of upstream miku main applications
+- straight-conversion guide
+  - describes how to create a Java version from such an upstream
+- Java application design memo
+  - describes how Java application versions should be shaped and maintained
+
+This document separates the following levels.
+
+- **Cross-cutting principles**: design policies that should generally be kept for Java application versions.
+- **Recommended conventions**: implementation, packaging, testing, and documentation shapes that make maintenance easier across Java versions.
+- **Observed tendencies**: design habits visible in current Java conversion work.
+- **Product-specific notes**: design decisions for specific Java products, recorded as concrete examples.
+
+When a specification is unclear, first check whether the decision preserves upstream meaning and Java-side operational usefulness. Java convenience is important, but it should not make upstream-following ability, CLI contracts, or output reproducibility unclear.
+
+## Scope
+
+The series whose names start with `miku` includes several related product types.
+
+Main applications:
+
+- `miku-abc-player`
+- `miku-docx2md`
+- `miku-indexgen`
+- `miku-unicode-guard`
+- `miku-xlsx2md`
+- `mikuproject`
+- `mikuscore`
+
+Java application versions:
+
+- `miku-indexgen-java`
+- `mikuproject-java`
+- `miku-xlsx2md-java`
+
+Agent Skills versions:
+
+- `mikuproject-skills`
+- `mikuscore-skills`
+
+Projects with the `-java` suffix are positioned as Java application versions of the original suffixless tools. They are usually created through straight conversion from the Node.js / TypeScript upstream.
+
+Projects with the `-skills` suffix are positioned as Agent Skills versions that make the original products easier for AI agents to use.
+
+This document focuses on Java application versions. It does not define the Web UI conventions for upstream main applications, and it does not define the skill packaging conventions for Agent Skills repositories.
+
+## Shared Direction
+
+Java application versions continue the shared direction of the miku series: small local bridge tools that convert, extract, inspect, or normalize existing files and domain data.
+
+The Java version emphasizes the parts that fit Java particularly well.
+
+- local CLI execution
+- batch processing
+- Maven and build-tool integration
+- jar-based distribution
+- stable public core APIs
+- deterministic artifact generation
+- tests that can be run with standard Java tooling
+- long-term maintainability in environments where Java is already available
+
+The Java version should not become a different product merely because the runtime changed. It should carry forward the upstream application's canonical source, primary outputs, diagnostics, and product boundary as far as practical.
+
+## Relationship to Straight Conversion
+
+Most miku Java application versions are expected to start from the straight-conversion process.
+
+The straight-conversion guide fixes the migration stance:
+
+- do not begin with a Java-first redesign
+- keep upstream file boundaries and vocabulary traceable
+- keep upstream tests and Java tests mapped
+- keep the Node CLI contract close where a CLI exists
+- treat Java-side original extensions separately
+- do not bring in the Web UI itself
+
+This document takes those results as the foundation for Java application design.
+
+In other words, `straight conversion` explains how the Java version is created, while this document explains how the Java version should remain understandable, useful, and maintainable after it exists.
+
+## Role of Java Applications
+
+In this document, a Java application means a `miku` repository with a `-java` suffix that provides a Java runtime implementation of an upstream main application.
+
+A Java application is primarily a local execution tool. It usually exposes one or more of the following.
+
+- CLI runtime jar
+- Maven plugin
+- batch command
+- public core API
+- deterministic file output
+- distribution zip
+
+The Java application is not primarily a Web UI application. If the upstream main application has a Web UI, that UI is generally not brought into the Java version.
+
+The center of the Java version is reusable processing: read local input, create structured output, emit diagnostics, and make the result reproducible from CLI, tests, Maven plugins, or other automation.
+
+## Cross-Cutting Principles
+
+miku Java applications emphasize the following cross-cutting principles.
+
+1. Preserve the semantic center and product boundary of the upstream main application.
+2. Preserve traceability from upstream files, tests, vocabulary, CLI contracts, and artifacts.
+3. Use Java as a local CLI / batch / build integration runtime, not as a reason to redesign the product first.
+4. Keep core processing independent from CLI, Maven plugin, and other adapters.
+5. Treat Java-side original extensions as separate contracts.
+6. Prefer reproducible artifacts and deterministic tests over environment-dependent behavior.
+7. Keep diagnostics, summaries, warnings, and timing output structured enough for automation.
+8. Make maintenance against upstream changes explainable through mapping documents and focused regression commands.
+
+### Basic Philosophy of Java Applications
+
+Java application versions emphasize the following philosophy.
+
+- Run locally without server communication for core functionality
+- Keep the upstream product meaning recognizable
+- Keep the Java implementation small enough to inspect
+- Preserve upstream vocabulary where it helps traceability
+- Use Java packaging for reliable local distribution
+- Make CLI and build-tool execution first-class paths
+- Keep Web UI and browser-specific behavior out of scope unless explicitly required
+- Keep public entrypoints testable without invoking `System.exit`
+- Generate artifacts whose names, bytes, and diagnostics are predictable where practical
+- Record differences from upstream instead of hiding them inside implementation choices
+
+The value of a Java application version is not that it is more Java-like in the abstract. It is that the upstream tool becomes easier to run, package, test, and integrate in Java-centered local and build environments.
+
+### Common Principles for Java Applications
+
+Java applications use the following principles as defaults.
+
+- Use Java source and binary compatibility `1.8`
+- Use Maven as the build tool
+- Use JUnit Jupiter as the test framework
+- Use `mvn test` as the primary verification command
+- Package the runtime as a single executable fat jar
+- Add a distribution zip when it helps users handle runtime artifacts
+- Place runtime implementation in a runtime module when a multi-module repository is needed
+- Place Maven plugin implementation in a separate plugin module when provided
+- Keep core APIs callable from CLI, Maven plugin, and tests
+- Keep CLI stdout, stderr, output files, and exit codes clearly separated
+- Keep `workplace/` at the repository root for local upstream checkout and temporary work
+- Track only `workplace/.gitkeep` under `workplace/`
+- Keep upstream mapping and test mapping documents under `docs/`
+
+These are defaults for the miku Java series. Individual products may add product-specific conventions, but should not change these foundations casually.
+
+### Upstream-Following Principles
+
+Java applications preserve upstream-following ability.
+
+This means the Java side should make it easy to answer the following questions.
+
+- Which upstream file did this Java class or class group come from?
+- Which upstream test intent does this Java test cover?
+- Which CLI option or behavior corresponds to the upstream CLI?
+- Which behavior is an upstream-derived contract, and which behavior is a Java-side extension?
+- Which focused regression command should be run after changing this area?
+
+The following maintenance documents support that operation.
+
+- upstream class mapping
+- upstream test mapping
+- upstream follow-up log
+- remaining migration items
+
+These documents are not secondary paperwork. They are part of the maintainability design of the Java version.
+
+### Java Runtime Boundary Principles
+
+Java versions usually receive upstream core semantics, but not the upstream browser runtime.
+
+Main targets:
+
+- domain model
+- codec / import / export
+- validation
+- summary and diagnostics
+- CLI entrypoint
+- batch entrypoint
+- Maven plugin entrypoint where useful
+- report and artifact generation
+- runtime packaging
+
+Mainly out of scope:
+
+- Web UI itself
+- single-file Web App distribution
+- browser DOM event handling
+- browser preview surfaces
+- download UI behavior
+- UI-only helpers that do not represent product semantics
+
+The Java version translates the runtime environment into CLI, Maven, jar, and file-based workflows while preserving the upstream product meaning.
+
+### Core and Adapter Principles
+
+Java applications keep core processing separate from entrypoints.
+
+The preferred shape is as follows.
+
+- core API owns product processing and output decisions
+- CLI parses arguments, handles file I/O, prints stdout / stderr, and returns exit codes
+- Maven plugin maps plugin parameters to core API options
+- tests call core APIs directly where possible
+- batch helpers are shared by CLI and Maven plugin when both need them
+
+Do not pack real processing into `main(String[] args)`. The CLI main should delegate to a testable method such as `run(String[] args, PrintStream out, PrintStream err)` and confine `System.exit` to the outermost boundary.
+
+This keeps CLI behavior testable and prevents Maven plugin or future automation from reimplementing product logic.
+
+### Java-Side Extension Principles
+
+Java applications may add operationally useful Java-side extensions.
+
+Examples:
+
+- Maven plugin goals
+- batch / directory processing
+- public Java core API wrappers
+- fat jar packaging
+- distribution zip packaging
+- classpath-resource access to runtime markdown or prompt specs
+- Java-specific logging, timing, or progress integration
+
+These extensions are allowed because they make the Java runtime useful. However, they must be documented separately from upstream-derived behavior.
+
+When adding a Java-side extension, satisfy the following.
+
+- State that it is a Java-side extension
+- Keep it outside the upstream mapping unless it has a clear upstream source
+- Add focused tests for the extension itself
+- Do not let it obscure the upstream single-input or core conversion contract
+- Reuse core APIs rather than duplicating conversion logic
+
+Batch and directory processing are especially useful in Java because JVM startup cost and build-tool usage often make grouped execution more practical than launching one process per input.
+
+### Maven and Build Integration Principles
+
+Maven integration is a first-class path when the product naturally participates in build workflows.
+
+This does not mean every Java application version must provide a Maven plugin. A CLI-only or runtime-jar-only repository is acceptable when that is the natural product surface. When a Maven plugin is provided, it should be treated as a first-class adapter over the same core API.
+
+Examples include:
+
+- index generation
+- documentation artifact generation
+- validation
+- conversion
+- report generation
+
+When a Maven plugin is provided, the repository may use a multi-module Maven reactor.
+
+The recommended shape is as follows.
+
+- repository root is an aggregator parent project
+- runtime jar implementation lives under a runtime module
+- Maven plugin implementation lives under a plugin module
+- shared core contracts live in the runtime module or a core module
+- plugin code depends on core contracts
+- core code does not depend on plugin code
+- directory / batch helpers used by both CLI and plugin live on the runtime/core side
+
+Maven plugin lifecycle binding should remain opt-in. The plugin should work through explicit invocation first, and consuming projects can bind it to a lifecycle phase when appropriate.
+
+### Packaging and Distribution Principles
+
+Java applications package local runtime use explicitly.
+
+The default runtime artifact is a single executable fat jar.
+
+The normal Maven package should also attach a sources jar, such as `<artifactId>-<version>-sources.jar`. The sources jar is a traceability and publication artifact, not the executable runtime artifact.
+
+When a distribution zip is useful, it should contain the minimal runtime-user-facing items such as:
+
+- runtime jar
+- sources jar when publishing or downstream traceability needs it
+- `README.md`
+- `LICENSE`
+- CLI or runtime docs where useful
+
+Artifact names should be predictable and traceable from Maven coordinates.
+
+The basic naming direction is:
+
+- Maven `groupId`: `jp.igapyon`
+- Maven `artifactId`: product-derived artifact name
+- jar name: `<artifactId>-<version>.jar`
+- sources jar name: `<artifactId>-<version>-sources.jar`
+- distribution zip name: `<artifactId>-dist-<version>.zip` or a similarly traceable form
+
+Runtime artifacts should not depend on source-tree-relative paths. If runtime markdown, prompt specs, or templates are needed inside the jar, copy them to classpath resources and read them through `getResourceAsStream` or an equivalent jar-safe mechanism.
+
+### CLI Design Principles
+
+The CLI is a formal entrypoint for humans, scripts, build tools, and AI agents.
+
+CLI design emphasizes the following.
+
+- Keep command groups, subcommands, option names, and argument combinations close to upstream where applicable
+- Use explicit input and output paths
+- Use stdout for normal textual output or explicitly declared stream-friendly output
+- Use stderr for diagnostics, usage errors, progress, and verbose logs
+- Make success and failure judgeable by exit code
+- Keep verbose output available for progress and timing when useful
+- Keep binary output file-based by default, and use an explicit Base64 stdout option when stream-friendly binary exchange is needed
+- Test stdout, stderr, exit code, and generated files
+
+When the upstream has a CLI, the Java CLI should respect its interface as far as practical. This includes the command group structure, subcommand names, option names, stdin / stdout conventions, diagnostics options, and usage-error boundaries. Differences caused by Java runtime needs or Java-side automation extensions should be documented.
+
+CLI help, README usage, and tests should be synchronized closely enough that option descriptions do not drift.
+
+### Diagnostics and Logging Principles
+
+Diagnostics are part of the Java application contract.
+
+Java applications distinguish the following.
+
+- normal output
+- generated artifacts
+- warnings
+- structured result information
+- verbose progress
+- timing information
+- usage errors
+- fatal errors
+
+Warnings and changes that do not stop processing should be accumulated in result objects where practical. Entry contract violations and syntactically invalid inputs should move toward exceptions or explicit failure results.
+
+Verbose output should not be mixed into primary output. For example, progress and timing lines can be emitted to stderr by CLI and to Maven logs by Maven plugins, while the core result keeps structured timings and messages for tests or adapters.
+
+### Data and Artifact Principles
+
+Java applications inherit the upstream application's data design.
+
+They should preserve the distinction between:
+
+- canonical input or semantic base
+- primary output
+- companion output
+- diagnostics
+- debug trace
+- Java-side operational metadata
+
+Java implementation choices should not collapse these roles.
+
+For example, optional Markdown companion output should not become the canonical representation merely because it is easy to emit from Java. A Maven plugin parameter should not become a product semantic if it is only an execution convenience.
+
+When structures affect output order, use deterministic data structures or explicit sorting. `LinkedHashMap` and `LinkedHashSet` are appropriate when insertion order matters.
+
+Text artifacts should use explicit encodings. Binary artifacts should be handled as `byte[]` in core logic where practical, with file paths pushed to CLI, Maven plugin, and test boundaries.
+
+### Reproducibility Principles
+
+Java applications should make outputs reproducible from the same input and settings.
+
+This is especially important for:
+
+- JSON
+- Markdown
+- XML
+- SVG
+- XLSX
+- ZIP
+- distribution archives
+- generated indexes
+
+Reproducibility includes more than string equality.
+
+Consider:
+
+- stable output ordering
+- stable filenames
+- stable archive entry order
+- fixed archive timestamps where needed
+- explicit encoding
+- explicit final newline policy
+- avoiding temporary paths in artifacts
+- avoiding current dates unless they are part of a declared build artifact
+
+Deterministic artifacts are easier to test, diff, cache, and review by humans and AI agents.
+
+### Testing Principles
+
+Java applications use tests to preserve both upstream parity and Java-side contracts.
+
+Test coverage should include:
+
+- core API tests
+- CLI tests
+- Maven plugin tests when a plugin exists
+- encoding tests where text input/output matters
+- artifact tests
+- diagnostics tests
+- Java-side extension tests
+
+Verification grows in this order when building or strengthening a Java version.
+
+1. semantic parity
+2. fixture round-trip
+3. API / CLI regression
+4. deterministic output
+5. byte-level parity
+
+Focused regression commands should be recorded in docs and tied to upstream files, Java classes, and test classes.
+
+`mvn test` remains the primary verification command. Product-specific focused commands are supporting tools, not replacements for the primary command.
+
+### Documentation Principles
+
+Java applications keep README and docs roles separate.
+
+`README.md` is the user-facing entry point. It should explain:
+
+- what the tool does
+- how to run the jar
+- how to use the Maven plugin if provided
+- main inputs and outputs
+- major options
+- where to find development and migration information
+
+Detailed design, mapping, migration, and maintenance notes should live under `docs/`.
+
+Important Java application docs include:
+
+- development notes
+- straight conversion guide
+- upstream class mapping
+- upstream test mapping
+- follow-up log
+- remaining migration items
+- product-specific specifications
+
+Do not make README carry the whole migration history. Link from README to deeper docs instead.
+
+### `workplace/` Directory Principles
+
+Java repositories use `workplace/` for local upstream checkouts, temporary verification data, smoke inputs, generated outputs, and similar local work.
+
+Rules:
+
+- keep `workplace/.gitkeep` tracked
+- do not track normal files under `workplace/`
+- do not use `workplace/` as a source directory
+- do not hide fixtures that tests require under `workplace/`
+- use explicit fixture or testdata directories for checked-in reproducible test data
+
+When an upstream repository needs to be inspected, it may be cloned under `workplace/`. This keeps upstream reference work local without making the Java repository depend on a dirty checkout.
+
+## Recommended Conventions
+
+### Repository Shape
+
+A single-module Java application may be enough when only a runtime jar is needed.
+
+A multi-module Maven reactor is appropriate when the repository provides both runtime jar and Maven plugin.
+
+Representative shape:
+
+```text
+repository root
+  pom.xml
+  README.md
+  LICENSE
+  docs/
+  workplace/.gitkeep
+  <runtime-module>/
+    pom.xml
+    src/main/java/...
+    src/test/java/...
+  <maven-plugin-module>/
+    pom.xml
+    src/main/java/...
+    src/test/java/...
+```
+
+The aggregator root should not contain main Java source unless there is a clear reason.
+
+### Package and Naming Conventions
+
+Use `jp.igapyon.<project>` as the base Java package.
+
+Package and class names should preserve upstream vocabulary where practical.
+
+General direction:
+
+- upstream `kebab-case` file stem becomes Java `UpperCamelCase` class name
+- upstream responsibility names become subpackages where helpful
+- upstream `camelCase` function names remain Java `camelCase` method names where practical
+- large upstream files may be split into Java helper classes if mapping remains clear
+
+Examples:
+
+- `markdown.ts` -> `jp.igapyon.<project>.markdown.Markdown`
+- `json-summary.ts` -> `jp.igapyon.<project>.jsonsummary.JsonSummary`
+- `path-utils.ts` -> `jp.igapyon.<project>.pathutils.PathUtils`
+- `core-api-*.ts` -> `jp.igapyon.<project>.coreapi.*`
+- CLI entrypoint -> `jp.igapyon.<project>.cli.<Project>Cli`
+
+Helper suffixes should describe upstream-derived responsibilities:
+
+- `Public`
+- `Import`
+- `Export`
+- `Validate`
+- `Parse`
+- `Build`
+- `Util`
+- `Adapters`
+- `Registry`
+- `Result`
+- `Warning`
+
+The criterion is whether the split can be explained in the upstream class mapping document.
+
+### Java Compatibility Conventions
+
+Main source and binary compatibility are fixed to Java 1.8.
+
+Avoid APIs and syntax that require newer Java versions, such as:
+
+- `List.of`
+- `Map.of`
+- `record`
+- `var`
+- `Files.readString`
+- text blocks
+
+The compiler may run on a newer JDK, but the produced source and bytecode compatibility should remain aligned with the repository's Java 1.8 policy.
+
+### Public API Conventions
+
+Core APIs should expose stable entrypoints useful to CLI, Maven plugin, tests, and automation.
+
+Prefer:
+
+- options objects for operation settings
+- result objects for multi-artifact output, warnings, changes, and timings
+- direct return of `String`, `byte[]`, or model objects for simple operations
+- explicit defaults at public entrypoints
+
+During initial straight conversion, simple POJOs with public fields are acceptable when they preserve readability and mapping. More Java-style encapsulation can be considered later, but should not break traceability or public contracts without reason.
+
+### CLI Conventions
+
+CLI implementation should provide a testable entrypoint.
+
+Representative shape:
+
+```text
+public static void main(String[] args)
+  -> int run(String[] args, PrintStream out, PrintStream err)
+     -> core API
+```
+
+CLI tests should check:
+
+- parsed options
+- usage text
+- stdout
+- stderr
+- exit code
+- output files
+- no-overwrite or failure behavior where relevant
+
+For normal usage, output files are preferred for generated artifacts. Stdout should be used only when the command contract clearly states it. For binary artifacts, prefer `--out <path>` and use an explicit Base64 stdout option such as `--out-base64 -` when the upstream CLI defines that stream-friendly contract.
+
+### Maven Plugin Conventions
+
+Maven plugins should be thin adapters over the core API.
+
+Plugin parameters should map clearly to core options. Plugin code should not duplicate directory traversal, conversion, validation, or artifact assembly if those operations belong to the runtime module.
+
+Plugin tests should check:
+
+- parameter mapping
+- skip behavior
+- generated output
+- logging behavior where relevant
+- failure behavior
+
+### Mapping Document Conventions
+
+At minimum, keep an upstream class mapping document with this shape.
+
+```text
+upstream file:
+  <upstream-root>/src/<target>.ts
+
+java classes:
+  jp.igapyon.<project>.<package>.<ClassA>
+  jp.igapyon.<project>.<package>.<ClassB>
+
+notes:
+  - facade:
+  - helper split:
+  - Java-side extension:
+```
+
+`<upstream-root>` may be a vendored upstream snapshot, a local checkout under `workplace/`, or another repository-specific upstream reference location. The mapping should make the chosen reference method explicit without requiring this shared memo to fix the physical path.
+
+At minimum, keep an upstream test mapping document with this shape.
+
+```text
+upstream test / intent:
+  <upstream test name or behavior>
+
+java tests:
+  <JavaTestClass.testMethod>
+
+fixtures:
+  <fixture path>
+
+focused regression:
+  mvn test -Dtest=<JavaTestClass>
+```
+
+These mappings are used both during initial conversion and during maintenance.
+
+## Common Patterns Observed Across Java Versions
+
+### CLI and Maven as Peer Entrypoints
+
+For Java application versions, CLI and Maven plugin can both be first-class paths.
+
+The CLI is natural for direct local execution, scripts, CI, and AI agents.
+
+The Maven plugin is natural when generated artifacts belong to a Java project's build, documentation, validation, or reporting flow.
+
+Both should call the same core API.
+
+### Core API as the Center
+
+Java applications tend to place a clear core API at the center.
+
+A typical shape is a product-named facade or core class that receives an options object, executes the main operation, and returns structured results or generated artifacts.
+
+That shape lets:
+
+- CLI convert arguments into options
+- Maven plugin convert parameters into options
+- tests call the same operation directly
+- batch behavior be shared instead of duplicated
+
+This is the Java counterpart of the main-application principle that UI, CLI, tests, and Agent Skills should call the same core where possible.
+
+### Upstream Traceability Over Java Redesign
+
+Java applications do not initially optimize for the most idiomatic Java architecture.
+
+They first optimize for:
+
+- easy upstream comparison
+- stable mapping
+- clear responsibility correspondence
+- test intent preservation
+- explainable diffs
+
+Later Java-side cleanup is allowed, but should be done only after the upstream-following path is secure.
+
+### Local Batch Workflows
+
+Java applications often benefit from batch and directory workflows.
+
+This is practical because:
+
+- Java process startup has cost
+- Maven plugins usually work over project directories
+- generated artifacts often need to be produced for many inputs
+- build and CI workflows prefer one invocation per task group
+
+Batch workflows should be documented as Java-side extensions unless they already exist in the upstream contract.
+
+### Reproducible Outputs for Automation
+
+Java applications are often used in environments where generated artifacts are checked, compared, cached, or committed.
+
+Therefore deterministic output is more than a testing convenience. It is part of the user value.
+
+Stable byte output lets users and AI agents answer:
+
+- Did the generated artifact actually change?
+- Which input caused the change?
+- Can this output be reviewed in a normal diff?
+- Can the command be rerun in CI?
+
+## Product-Specific Notes
+
+### Notes Specific to `miku-indexgen-java`
+
+`miku-indexgen-java` is a Java implementation of `miku-indexgen`.
+
+It scans a directory and generates `index.json`. When Markdown output is enabled, it also generates `index.md`.
+
+The Java version currently has two main execution paths.
+
+- runtime jar / CLI
+- Maven plugin
+
+The central core API is:
+
+- `jp.igapyon.mikuindexgen.coreapi.Indexgen.createIndexes(IndexgenOptions)`
+
+CLI and Maven plugin layers map their inputs into `IndexgenOptions` and call the same core API.
+
+Important design points:
+
+- `index.json` is the primary structured output
+- `index.md` is optional companion output
+- directory scanning behavior is shared by CLI and Maven plugin through runtime-side code
+- verbose progress and timing information are kept separate from primary output
+- Maven plugin goals are Java-side extensions
+- child-directory batch mode is a Java-side extension and should not be confused with the upstream single-input contract
+- upstream class and test mappings are recorded under `docs/`
+
+#### Child-Directory Batch Mode in `miku-indexgen-java`
+
+`miku-indexgen-java` has a Java-side child-directory batch mode.
+
+This mode is specific to `miku-indexgen-java` and should not be read as a cross-cutting requirement for all miku Java applications. The cross-cutting principle is only that Java versions may add batch / directory processing when it is useful and documented as a Java-side extension.
+
+The current contract is as follows.
+
+- CLI option `--input-parent-directory <dir>` selects a parent directory
+- Maven plugin goal `index-child-directories` selects a parent directory through `inputParentDirectory`
+- the parent directory itself is not indexed as one input base
+- each direct child directory under the parent is processed independently
+- direct child files under the parent are ignored
+- hidden child directories are skipped
+- recursive scanning still means recursion inside each selected child directory
+- when `--output-directory` or plugin `outputDirectory` is omitted, outputs are written under each child directory
+- when an output directory is specified, outputs are written under child-specific paths such as `<outputDirectory>/<child>/index.json`
+- the same core API, `Indexgen.createIndexes(IndexgenOptions)`, handles both single-directory mode and child-directory batch mode
+
+This feature exists because `miku-indexgen-java` is often useful for generating many small directory indexes in one Java process or Maven execution. It is therefore an operational extension on the Java side, not a change to the upstream `miku-indexgen` single-directory contract.
+
+The repository is a multi-module Maven reactor.
+
+- root aggregator project
+- `miku-indexgen/` runtime jar and CLI implementation
+- `miku-indexgen-maven-plugin/` Maven plugin implementation
+
+This shape is appropriate because the runtime jar and Maven plugin are separate deliverables but use the same core API.
+
+### Notes Specific to `mikuproject-java`
+
+`mikuproject-java` is positioned as a Java version of `mikuproject`.
+
+The upstream product treats `MS Project XML` as the semantic base and uses `ProjectModel` as the internal neutral representation for validation, workbook exchange, AI-facing views, patch application, and report generation.
+
+#### Runtime Entrypoints in `mikuproject-java`
+
+The Java version currently emphasizes the following execution paths.
+
+- runtime jar / CLI
+- public core API facades
+- deterministic report and exchange artifact generation
+- distribution zip for runtime users
+
+Unlike `miku-indexgen-java` and `miku-xlsx2md-java`, the current `mikuproject-java` repository is a single-module Maven project. It does not currently expose a Maven plugin module. This is acceptable because the current Java-side product surface is centered on CLI, core API, report generation, and distribution packaging rather than build-lifecycle integration.
+
+#### Core Facades in `mikuproject-java`
+
+The Java-side public surface is organized around `jp.igapyon.mikuproject.coreapi` facades.
+
+Representative facade groups include:
+
+- `CoreApiPublic` / `CoreApi`
+- `CoreApiMsproject`
+- `CoreApiWorkbook`
+- `CoreApiImport`
+- `CoreApiReport`
+- `CoreApiMsprojectAi`
+- `CoreApiAiJson`
+
+These facades are Java-side aggregation points. They should remain traceable to upstream responsibilities such as MS Project XML import/export, workbook JSON / XLSX exchange, patch JSON, AI-facing views, report generation, and external import. They should not become a reason to hide upstream file boundaries or replace upstream vocabulary with unrelated Java-only abstractions.
+
+#### Product Boundary in `mikuproject-java`
+
+Important design points:
+
+- preserve the upstream goal of bridging `MS Project XML`, WBS reports, workbook exchange, and AI workflows
+- keep Java CLI command groups, subcommands, option names, stdin / stdout behavior, diagnostics options, and usage-error boundaries aligned with the Node.js upstream where practical
+- keep `MS Project XML` and `ProjectModel` as the semantic center
+- treat workbook JSON, `.xlsx`, AI JSON, patch JSON, Markdown, SVG, Mermaid, and WBS XLSX as exchange, editing, report, or inspection surfaces around that center
+- keep browser Web UI behavior out of scope
+- keep AI-facing workflows artifact-based, such as project overview, phase detail, task edit, draft request, patch JSON, validate, apply, and diff-oriented outputs
+- keep report outputs such as WBS Markdown, daily / weekly / monthly SVG, Mermaid, WBS XLSX, report directory, and report bundle as derived artifacts, not canonical project state
+- keep XLSX / ZIP and other binary CLI artifacts file-based by default; when stream-friendly exchange is needed, follow the upstream `--in-base64 -` / `--out-base64 -` convention rather than writing raw binary to stdout
+- make report bundle and report directory outputs deterministic enough for byte-level comparison where practical
+- keep CLI help, README command lists, mapping documents, and focused tests synchronized
+
+#### Java-Side CLI Extensions in `mikuproject-java`
+
+`mikuproject-java` may add Java-side CLI extensions for local automation when they have clear operational value.
+
+These commands are operational extensions for local automation. They can be useful when project report and import/export workflows need to process several XML, workbook, JSON, or patch files in one JVM invocation.
+
+This extension surface should be read as Java-side behavior, not as a change to the upstream `mikuproject` single-operation product contract.
+
+The current direction is:
+
+- keep single-input commands as the clearest counterpart to upstream behavior
+- use `*-batch` names for Java-side multi-input commands
+- keep output root / input / name pair handling explicit
+- reject invalid argument combinations at the CLI boundary
+- test usage errors, command failures, stdout / stderr, and generated files
+- avoid adding more batch commands merely for symmetry when the current operational value is not clear
+
+#### Repository Shape in `mikuproject-java`
+
+The repository currently uses a single Maven project.
+
+The expected runtime artifacts are:
+
+- `target/mikuproject.jar`
+- `target/mikuproject-sources.jar`
+- `target/mikuproject-dist.zip`
+
+The distribution zip contains the runtime jar, sources jar, and minimal runtime-facing documentation such as `README.md`, `LICENSE`, and CLI documentation.
+
+This single-module shape should remain acceptable while there is no Maven plugin deliverable. If a Maven plugin is added later, the repository should be reconsidered as a multi-module Maven reactor so that plugin code remains a thin adapter over the runtime / core API rather than a second implementation.
+
+#### Maintenance Focus in `mikuproject-java`
+
+Because `mikuproject-java` has a broad product surface, maintenance should be organized by upstream file and by major responsibility group.
+
+Practical groups are:
+
+- `MS Project XML` / `ProjectModel` / validation
+- workbook JSON and project XLSX
+- patch JSON and AI JSON import
+- AI-facing project views
+- report outputs such as WBS Markdown, SVG, Mermaid, WBS XLSX, report directory, and report bundle
+- CLI and Java-side batch extensions
+
+For upstream-following work, first use the upstream class mapping and upstream test mapping documents to find the affected Java classes and tests. CLI batch behavior, distribution packaging, and report directory / bundle conveniences should be recorded as Java-side extensions when they do not have direct upstream counterparts.
+
+### Notes Specific to `miku-xlsx2md-java`
+
+`miku-xlsx2md-java` is positioned as a Java version of `miku-xlsx2md`.
+
+The upstream product treats the Excel workbook as canonical input and Markdown as the primary extracted representation for design-document structure.
+
+#### Runtime Entrypoints in `miku-xlsx2md-java`
+
+The Java version currently exposes the following main execution paths.
+
+- runtime jar / CLI
+- Maven plugin
+- Java-side directory batch conversion shared by CLI and Maven plugin
+- selected Node / Java Markdown byte-level comparison script for upstream fixtures
+
+#### Core Facade in `miku-xlsx2md-java`
+
+The central runtime facade is:
+
+- `jp.igapyon.mikuxlsx2md.core.Core`
+
+The main core operations are:
+
+- `Core.parseWorkbook(byte[], String)`
+- `Core.convertWorkbookToMarkdownFiles(ParsedWorkbook, MarkdownOptions)`
+- `Core.convertSheetToMarkdown(ParsedWorkbook, ParsedSheet, MarkdownOptions)`
+- `Core.toExportWorkbook(ParsedWorkbook)`
+
+CLI and Maven plugin layers should remain thin adapters over this runtime side. Directory conversion is implemented as a Java-side operational extension through `jp.igapyon.mikuxlsx2md.directoryconverter.DirectoryConverter`, so that CLI and Maven plugin directory workflows do not duplicate workbook conversion logic.
+
+#### Product Boundary in `miku-xlsx2md-java`
+
+Important design points:
+
+- preserve the upstream goal of workbook-to-Markdown extraction
+- do not turn the Java version into a full Excel renderer
+- treat Excel `.xlsx` workbooks as canonical input
+- treat Markdown as the primary extracted representation
+- keep Markdown, ZIP assets, summaries, formula diagnostics, and Java-side operational metadata separated by role
+- prefer local CLI / batch / build integration over Web UI behavior
+- keep workbook parsing and output generation traceable to upstream responsibilities
+- avoid adopting broad dependencies in a way that hides conversion meaning
+- make ZIP / asset / Markdown output reproducible where practical
+- keep CLI help, README usage, Maven plugin parameters, and tests synchronized
+
+#### Repository Shape in `miku-xlsx2md-java`
+
+The repository is a multi-module Maven reactor.
+
+- root aggregator project
+- `miku-xlsx2md/` runtime jar and CLI implementation
+- `miku-xlsx2md-maven-plugin/` Maven plugin implementation
+
+This shape is appropriate because the runtime jar and Maven plugin are separate deliverables but use the same runtime conversion implementation.
+
+#### Directory Batch Conversion in `miku-xlsx2md-java`
+
+`miku-xlsx2md-java` has Java-side directory batch conversion.
+
+This mode is specific to Java runtime and build-tool operation. It should not be read as a change to the upstream workbook-to-Markdown single-input product contract.
+
+The current contract is as follows.
+
+- CLI option `--input-directory <dir>` selects directory conversion
+- Maven plugin goal `convert-directory` selects directory conversion through `miku-xlsx2md.inputDirectory`
+- `--recursive` and `miku-xlsx2md.recursive` control recursive scanning
+- only files whose names end with `.xlsx` are processed
+- when output directory is omitted, Markdown files are written next to the input workbooks
+- when output directory is specified, relative input paths are mirrored under the output directory
+- ZIP output is not part of directory conversion
+- verbose mode reports processing workbook paths to stderr in CLI and Maven logs in the plugin
+
+This feature exists because workbook conversion often needs to run over many local files in one Java process or Maven execution. It is therefore an operational extension on the Java side, not a replacement for the upstream single-workbook conversion contract.
+
+## Maintenance Policy
+
+After initial conversion, Java applications are maintained by comparing against upstream deliberately.
+
+The maintenance workflow should include:
+
+- check upstream changes by upstream file
+- update mapping documents when responsibility changes
+- update test mapping when upstream test intent changes
+- record known diffs and follow-up items
+- run focused regression commands for affected areas
+- run `mvn test` before release-level confidence
+- keep README, CLI help, and plugin docs synchronized when those surfaces exist
+
+When an upstream bug is found, record it separately from Java-side implementation work. Do not silently redesign the Java side so far that the difference can no longer be explained.
+
+When a Java-side extension is added, test and document it as Java-specific behavior.
+
+## Summary
+
+miku Java application versions are not independent rewrites of the upstream tools.
+
+They are local Java runtimes that preserve upstream product meaning while making CLI, Maven, batch, testing, packaging, and reproducible artifact generation stronger.
+
+The central design question is:
+
+> Can this Java behavior be traced back to upstream meaning, or clearly explained as a Java-side extension?
+
+When the answer remains clear, Java versions can be useful as practical local tools while staying maintainable against their Node.js / TypeScript upstreams.

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-30-straight-conversion-v20260425.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-30-straight-conversion-v20260425.md
@@ -1,0 +1,1022 @@
+# Miku Software Straight Conversion Guide v20260425
+
+## Purpose
+
+This document is a memo that summarizes the `straight conversion migration` policy used when moving Node.js / TypeScript upstream projects in the miku series to Java.
+
+Each repository should keep this document as a set of shared principles. The canonical implementation details and current status for each repository should be checked in that repository's `README.md`, progress tracking documents, upstream mapping tables, and test mapping tables.
+This document exists to preserve the reasoning behind why this conversion approach was chosen.
+
+This document also aims to align the workflow and artifact granularity closely enough that straight conversion work can be reproduced in another miku-series project.
+
+## How to Use This Document
+
+Use this document not merely as a policy collection, but as a procedure manual from the start of straight conversion through the maintenance phase.
+However, this document fixes shared principles. It is not the canonical source for repository-specific progress or current status.
+
+The basic usage is as follows.
+
+1. Review the decision criteria in `Basic Stance` and `Why Choose Straight Conversion`
+2. Fill in `What to Fix at the Start` and `Start Checklist`
+3. Follow `Reproducible Work Procedure` to inventory, map, implement, and verify
+4. Reflect `Artifacts to Keep` in documents and tests at each stage
+5. After implementation, operate according to `Handling in the Maintenance Phase` and `Docs and Upstream-Following Operation`
+
+When asking a generative AI to read this document, assume the following reading order.
+
+1. Read `What to Fix at the Start` as fixed policy, including the decision rationale
+2. Read `Start Checklist` as a short pre-execution confirmation
+3. Read `Reproducible Work Procedure` as the actual work order
+4. Read the later individual policies as decision criteria when implementation choices are unclear
+
+The same policy may appear repeatedly in this document as fixed policy, checklist item, and reproducible procedure.
+This is intentional, so that generative AI is less likely to miss important premises even when it references only one section. Do not remove these repetitions too aggressively as simple duplication.
+
+Read the strength of wording as follows.
+
+- `fix`, `fixed`, `must`, `out of scope`, and `do not` indicate fixed policy to align first in that miku Java version
+- `basically`, `principle`, and `prefer` indicate the default policy when in doubt
+- `may`, `allow`, and `can choose` indicate acceptable patterns as long as upstream-following ability is not broken
+- `tendency`, `finding`, `example`, and `visible in this repository` indicate decision material, not rules to force directly onto other miku-series projects
+- `fixed in this repository` indicates an application example in `mikuproject-java`; distinguish it from the shared principle itself
+
+## Basic Stance
+
+Java conversion here does not mean a port that first redesigns the project for Java.
+The first goal is `straight conversion`: moving the Node.js / TypeScript upstream into a form that remains trackable on Java.
+
+`Straight conversion` here does not mean simple mechanical translation.
+The important points are as follows.
+
+- Make upstream file boundaries and responsibility divisions easy to follow
+- Make upstream vocabulary and naming easy to trace on the Java side
+- Make it explainable where to compare when upstream changes
+- Avoid drifting too far into a Java-only redesign that looks like a different product
+
+Therefore, in the initial porting stage, upstream-following ability was prioritized over the neatness of Java-style abstraction or reorganization.
+
+## Why Choose Straight Conversion
+
+Many miku-series upstream projects have clear file boundaries, responsibility divisions, vocabulary, and input/output contracts.
+If this structure is rebuilt into a different architecture from the beginning on the Java side, the following problems tend to occur.
+
+- It becomes hard to tell which upstream file an implementation came from
+- It becomes hard to understand the impact range of upstream changes
+- The work tends to become a reimplementation rather than a port
+- It becomes hard to distinguish whether a difference found on the Java side is a specification difference or a design difference
+
+For this reason, the adopted order is to first establish a Java version in a form that can faithfully trace upstream, then consider Java-side reorganization later if needed.
+
+## What to Fix at the Start
+
+At the start of straight conversion, fix at least the following items first.
+
+- Confirm that the source upstream for straight conversion is organized enough to support porting
+- Fix target Java compatibility to `1.8` for both source and binary compatibility
+- Fix the build tool to `Maven`
+- Fix the test framework to `JUnit Jupiter`
+- Fix the primary test entrypoint to `mvn test`
+- Fix runtime packaging to a single fat jar
+- Decide whether to adopt a distribution zip depending on the processing target
+- Create `workplace/` at the repository root, and track only `workplace/.gitkeep` in Git
+- Exclude all files under `workplace/` except `workplace/.gitkeep` from Git tracking
+- Do not add new features during straight conversion
+- Do not perform Java-first redesign before conversion
+- Respect upstream file boundaries and responsibility divisions
+- Make it possible to trace `upstream file -> Java class group`
+- Use `jp.igapyon.<project>` as the base Java package, and decide subpackages from upstream Node-side file names and responsibilities
+- Translate class names into Java conventions while preserving upstream vocabulary
+- If an upstream function name is `camelCase`, keep the Java-side method name basically unchanged
+- Do not bring in the GUI; the Java-side target is basically the CLI runtime
+- For upstream projects that have a CLI, make the Java-side CLI respect the Node CLI interface as much as possible
+- Treat Java-side original extensions that do not exist upstream separately from the main contract
+- Even when an upstream bug is found, first record it as a communication item and continue conversion as-is
+
+If naming, responsibility boundaries, CLI contracts, and out-of-scope areas are left vague at this stage, upstream-following ability becomes hard to recover later.
+Similarly, if the Java version, build tool, test framework, and packaging are changed midstream, effort tends to be spent on absorbing runtime environment differences rather than on the port itself.
+If new features are added during porting, the boundary between straight conversion and original extension becomes unclear, making it hard to explain what is upstream support and what is added specification.
+Likewise, if porting stops every time an upstream bug is found, straight conversion becomes too dependent on waiting for upstream fixes.
+
+Among the items above, the environment premises are fixed in the following sense for miku-series Java versions.
+
+- target Java compatibility
+  - Fix the source version and binary target version to `1.8`
+  - The actual compiler does not necessarily have to be `JDK 1.8`
+  - Users may use a newer Java runtime
+- build tool
+  - Fix to `Maven`
+- test framework
+  - Fix to `JUnit Jupiter`
+- primary test entrypoint
+  - Fix to `mvn test`
+- runtime packaging
+  - Fix to a single fat jar
+  - Add a distribution zip depending on the processing target
+- local workspace
+  - Place `workplace/` at the repository root
+  - Track `workplace/.gitkeep` in Git
+  - Exclude all other files under `workplace/` from Git tracking
+
+The important point is not to later shift toward what looks optimal in general terms, but to fix the foundation used by that straight conversion at the beginning.
+
+It is also important that upstream itself is sufficiently organized before porting.
+If upstream file boundaries or responsibility divisions are still unstable, it is better to refactor upstream before moving it to Java.
+
+For CLI / batch / report-centered tools of this kind, target Java compatibility should be fixed as low as maintainably possible so that a wide range of user runtime environments can be supported.
+For this reason, miku-series Java versions fix source / binary compatibility to `1.8`.
+
+## Start Checklist
+
+When starting straight conversion, fill in at least the following.
+
+- The source upstream for straight conversion has been sufficiently organized and refactored at least for the porting unit
+- Target Java compatibility has been fixed to `1.8` for both source and binary compatibility
+- The build tool has been fixed to `Maven`
+- The test framework has been fixed to `JUnit Jupiter`
+- The primary test entrypoint has been fixed to `mvn test`
+- Runtime packaging has been fixed to a single fat jar
+- Whether to create a distribution zip has been decided depending on the processing target
+- The policy to create `workplace/` at the repository root and track only `.gitkeep` in Git has been confirmed
+- The scope for not bringing in the GUI has been decided
+- If a CLI exists, how far the Node interface will be respected has been decided
+- The source file list has been obtained
+- The test file / fixture list has been obtained
+- The import / export / report artifact list has been obtained
+- The location of the `upstream file -> Java class` mapping table has been decided
+- The location of the `upstream test intent -> Java test` mapping table has been decided
+- The location of the follow-up log has been decided
+- The location of focused regression commands has been decided
+
+If the source upstream for straight conversion is not yet organized, the Java side easily ends up carrying both `porting` and `upstream-side structural cleanup` at the same time.
+In that state, the `upstream file -> Java class` mapping becomes unstable, and the work tends to become redesign rather than straight conversion.
+Therefore, before starting, the upstream-side files to be ported should be organized enough to be cleanly traceable.
+
+## Reproducible Work Procedure
+
+When reproducing straight conversion in another miku-series project, proceed at least in the following order.
+
+### 1. Fix the Premises
+
+First fix the following.
+
+- The source upstream for straight conversion is sufficiently organized
+- target Java compatibility
+  - Fix both source and binary compatibility to `1.8`
+  - Do not limit the actual compiler to `JDK 1.8`
+- build tool
+  - Fix to `Maven`
+- test framework
+  - Fix to `JUnit Jupiter`
+- primary test entrypoint
+  - Fix to `mvn test`
+- runtime packaging
+  - Fix to a single fat jar
+  - Add a distribution zip depending on the processing target
+- local workspace
+  - Create `workplace/` at the repository root
+  - Track only `workplace/.gitkeep` in Git
+  - Exclude all other files under `workplace/` from Git tracking
+- Do not add new features during straight conversion
+- Where to record upstream bugs and how to handle them
+- Do not bring in the GUI
+- Compatibility policy when a CLI exists
+- Basic rules for class names / method names / package names
+  - Use `jp.igapyon.<project>` as the package base name
+  - Decide subpackages from upstream Node-side file names and responsibilities
+
+Artifacts at this stage:
+
+- Confirmation that upstream is in a state that can support starting the port
+- Basic policy in the repository top README
+- Reference to this guide
+- Build file with the development foundation fixed
+- Agreement that new feature additions are outside the porting scope
+- Location for keeping upstream bugs as communication items
+
+### 2. Decide How to Reference Upstream
+
+For miku-series Java versions, use one of the following three upstream reference methods.
+
+1. Include upstream wholesale by subtree
+2. Connect to upstream as a Git remote without keeping the upstream body in the repository
+3. Clone upstream under `workplace/` when needed and obtain the latest version
+
+Across the miku series, subtree is often preferred because it can keep an upstream snapshot in the repository.
+On the other hand, for straight conversion work, cloning under `workplace/` as needed is also often preferred because it is easy to compare against the latest upstream without dirtying it.
+
+Usage guidelines:
+
+- Use subtree when you want to keep the source snapshot in the repository and be able to revisit the same file set at any time
+- Use Git remote only when you do not want to bring the upstream body into the repository and want to check diffs or history with Git operations
+- Use as-needed clones under `workplace/` when you want to temporarily check the latest upstream or avoid leaving the upstream body in the main repository
+
+Whichever method is chosen, keep `upstream file -> Java class` and `upstream test intent -> Java test` traceable in documents.
+Also, upstream cloned under `workplace/` is a temporary reference, and files other than `workplace/.gitkeep` should not be tracked in Git.
+
+### 3. Inventory Upstream
+
+List the following.
+
+- source files
+- public APIs / facades
+- CLI commands / options
+- test files
+- fixtures / testdata
+- import / export / report artifacts
+
+Artifacts at this stage:
+
+- `upstream file` list
+- main fixture list
+- Java-side target scope and out-of-scope items
+
+### 4. Create Mapping Tables First
+
+Before implementation or at the initial implementation stage, fix at least the following in documents.
+
+- `upstream file -> Java class / package`
+- `upstream test intent -> Java test`
+- `upstream CLI -> Java CLI`
+
+Artifacts at this stage:
+
+- class mapping document
+- test mapping document
+- CLI mapping document or README section if needed
+
+### 5. Implement from Core
+
+The basic implementation order is as follows.
+
+1. domain model
+2. codec / import / export
+3. validation
+4. report / artifact
+5. CLI
+6. packaging
+
+Here, prioritize receiving responsibilities for each upstream file over rebuilding for Java.
+
+Artifacts at this stage:
+
+- Java classes
+- minimal round-trip
+- focused unit tests
+
+### 6. Align the CLI and Public Entrypoints
+
+Once the core implementation starts working, organize the CLI and public entrypoints.
+
+Important points:
+
+- Bring Node CLI commands / options / argument order close enough that the same wording can be used in descriptions and usage markdown
+- Treat Java-side original extensions separately from upstream straight conversion
+- Align help / README / test wording
+- Synchronize README / docs / CLI help deeply enough to reuse not only command and option names but also descriptions
+- Align AI-facing prompt markdown as an API / CLI retrieval contract, not as a source file reference
+- Even when adding Java-side original directory / batch processing, state it as an additional contract instead of mixing it with the upstream CLI single-input contract
+
+Artifacts at this stage:
+
+- Java CLI entrypoint
+- help / usage contract
+- AI-facing prompt markdown retrieval contract
+- CLI regression tests
+- regression tests for Java-side original extensions
+
+### 7. Strengthen Verification Gradually
+
+Verification is easier to grow in the following order.
+
+1. semantic parity
+2. fixture round-trip
+3. API / CLI regression
+4. deterministic output
+5. byte-level parity
+
+Byte-level parity is especially effective when first applied to final artifacts such as reports and archives.
+
+Artifacts at this stage:
+
+- focused regression commands
+- parity tests
+- determinism tests
+
+### 8. Move to Maintenance Operation
+
+Once the main paths are aligned, move the focus from new implementation to upstream-following operation.
+
+Important points:
+
+- Check diffs by `upstream file`
+- Record diff check results in documents
+- Treat docs-only updates and code changes separately
+- Fix the necessary regression units
+- Record upstream bugs separately from Java-side temporary workarounds
+
+Artifacts at this stage:
+
+- remaining items document
+- follow-up log
+- focused regression list
+
+## Minimal Document Templates
+
+To improve reproducibility, document granularity should also be aligned.
+
+### 1. class mapping
+
+At minimum, keep the following shape.
+
+```text
+upstream file:
+  vendor/<project>/src/ts/<target>.ts
+
+java classes:
+  <package>.<ClassA>
+  <package>.<ClassB>
+
+notes:
+  - facade:
+  - helper split:
+  - Java-side extension:
+```
+
+### 2. test mapping
+
+At minimum, keep the following shape.
+
+```text
+upstream test / intent:
+  <upstream test name or behavior>
+
+java tests:
+  <JavaTestClass.testMethod>
+
+fixtures:
+  <fixture path>
+
+focused regression:
+  <command>
+```
+
+### 3. follow-up log
+
+At minimum, keep the following shape.
+
+```text
+upstream file:
+  vendor/<project>/src/ts/<target>.ts
+
+java classes:
+  <package>.<ClassA>
+  <package>.<ClassB>
+
+tests:
+  <RelatedTest1>
+  <RelatedTest2>
+
+diff summary:
+  behavior differences:
+  naming differences:
+  unported differences:
+  Java-side original extensions:
+
+follow-up:
+  - checks performed:
+  - fixture:
+  - next check viewpoint:
+```
+
+### 4. remaining items
+
+At minimum, keep the following.
+
+- current position
+- `done / maintenance check / pending`
+- focused regression list
+- latest passing result
+- next unit to check
+
+## Basic Conversion Method
+
+The basic porting unit is the upstream source file set.
+
+- Translate `kebab-case` upstream file names into Java `UpperCamelCase` class names
+- Use `jp.igapyon.<project>` as the base package name
+- Decide subpackage names from upstream Node-side file names and responsibilities
+- If an upstream function name is `camelCase`, keep the Java-side method name as much as possible
+- Basically receive one upstream file with one Java class, but splitting into helper classes is allowed to preserve readability in Java
+- Even in that case, make upstream responsibilities inferable from the split class names
+
+Generalized examples:
+
+- `feature-a.ts` -> `FeatureA`
+- `feature-b.ts` -> `FeatureB`, `FeatureBHelper`, `FeatureBValidate`
+- `core-api-x.ts` -> `CoreApiX`, `CoreApiXImport`, `CoreApiXPublic`
+- `excel-io.ts` -> `jp.igapyon.<project>.excelio.ExcelIo`
+- `excel-io-normalize.ts` -> `jp.igapyon.<project>.excelio.ExcelIoNormalize`
+
+This policy keeps the verification unit as `upstream file -> Java class group`, even if the Java side splits classes.
+Also, by placing responsibility packages derived from upstream file names under the project name, such as `jp.igapyon.mikuproject.excelio`, the upstream verification unit is easier to trace from Java packages.
+
+Examples of naming patterns visible in this repository:
+
+These naming pattern examples are not meant to be forced directly onto other miku-series projects.
+However, when the same file names, responsibilities, and vocabulary appear, they are strong initial values for preserving upstream-following ability.
+
+- The `kebab-case` upstream file stem becomes lowercase concatenation in packages
+- Example: `wbs-svg.ts` -> `jp.igapyon.<project>.wbssvg`
+- Example: `wbs-xlsx.ts` -> `jp.igapyon.<project>.wbsxlsx`
+- Example: `project-xlsx.ts` -> `jp.igapyon.<project>.projectxlsx`
+- Example: `project-workbook-json.ts` -> `jp.igapyon.<project>.projectworkbookjson`
+- Example: `project-patch-json.ts` -> `jp.igapyon.<project>.projectpatchjson`
+- Example: close responsibility groups such as `msproject-xml.ts` / `msproject-codec.ts` / `msproject-validate.ts` -> `jp.igapyon.<project>.msprojectxml`
+- Example: `core-api-*.ts` -> `jp.igapyon.<project>.coreapi`
+
+For class-name vocabulary conversion, preserve upstream vocabulary while moving toward Java `UpperCamelCase`.
+In this repository, at least the following translations are implicitly used.
+
+- `wbs` -> `Wbs`
+- `xlsx` -> `Xlsx`
+- `xml` -> `Xml`
+- `svg` -> `Svg`
+- `json` -> `Json`
+- `ai` -> `Ai`
+- `io` -> `Io`
+- `msproject` -> `MsProject`
+
+When one upstream file is large, the Java side may split classes with responsibility suffixes.
+In that case, suffixes should not be based only on Java-side convenience; they should use vocabulary that lets the responsibilities inside the upstream file be traced.
+
+- `Public`: public facade / public wrapper
+- `Import`: import-side processing
+- `Export`: export-side processing
+- `Validate`: validate-side processing
+- `Parse`: parse-side processing
+- `Build`: build / serialize-side processing
+- `Util`: small helper processing
+- `Helpers`: helpers for validation or conversion
+- `Adapters`: bridge between core API and individual implementations
+- `Registry`: registration / facade that groups public APIs
+- `Result`: API result object
+- `Warning`: warning object
+- `Document`: external exchange document object
+- `Operation`: patch / edit operation object
+- `Zip`: archive / zip artifact processing
+
+Examples:
+
+- `wbs-svg.ts` -> `WbsSvg`, `WbsSvgPublic`, `WbsSvgRender`, `WbsSvgCalendar`, `WbsSvgZip`
+- `wbs-xlsx.ts` -> `WbsXlsx`, `WbsXlsxExport`, `WbsXlsxLayout`, `WbsXlsxCells`, `WbsXlsxPublic`
+- `project-xlsx.ts` -> `ProjectXlsx`, `ProjectXlsxImport`, `ProjectXlsxExport`, `ProjectXlsxImportProject`, `ProjectXlsxExportCalendars`
+- `project-workbook-json.ts` -> `ProjectWorkbookJson`, `ProjectWorkbookJsonImport`, `ProjectWorkbookJsonExport`, `ProjectWorkbookJsonValidate`
+- `project-patch-json.ts` -> `ProjectPatchJson`, `ProjectPatchJsonCore`, `ProjectPatchJsonTasks`, `ProjectPatchJsonUpdates`
+- `core-api-report.ts` -> `CoreApiReport`, `CoreApiReportAdapters`, `CoreApiReportPublic`
+- `core-api-import.ts` -> `CoreApiImport`, `CoreApiExternalImport`, `CoreApiExternalDocument`, `CoreApiExternalBinary`
+- `msproject-validate.ts` -> `MsProjectValidate`, `MsProjectValidateHelpers`
+
+When scratch-implementing replacements for external libraries or browser APIs, minimal compatibility wrappers may be placed with a `Like` suffix.
+This is not to reproduce the entire upstream dependency API, but to make only the range needed for straight conversion explainable.
+Even in areas such as xlsx where Apache POI comes to mind easily, the miku series may avoid assuming even POI, scratch-implement only the needed range, and create minimal compatibility with `Like` wrappers.
+
+- `XlsxWorkbookLike`
+- `XlsxSheetLike`
+- `XlsxRowLike`
+- `XlsxCellLike`
+- `XlsxColumnLike`
+- `XlsxFreezePaneLike`
+- `XlsxDataValidationLike`
+
+Internal models are placed in the `model` package in principle, and are separated from external representations and packages derived from upstream file names.
+Model classes use a `Model` suffix, such as `ProjectModel`, `TaskModel`, `ResourceModel`, `AssignmentModel`, and `CalendarModel`.
+On the other hand, external exchange documents / warnings / operations / results prioritize suffixes that express their responsibilities, and do not necessarily move toward `Model`.
+
+Notes:
+
+- These are not naming rules for freely redesigning the Java side; they are practical rules for preserving correspondence with upstream files / responsibilities / tests
+- When adding suffixes, use whether they can be explained in `docs/upstream-class-mapping.md` as `upstream file -> Java class group` as the criterion
+- Even if the same simple name such as `ImportChange` appears in multiple packages, it is acceptable when responsibility packages are separated and the upstream correspondence can be explained
+
+Other viewpoints derived from this repository:
+
+This section summarizes fixed policies, default policies, acceptable patterns, and concrete examples visible from implementation.
+Read the strength of individual sentences according to wording such as `fix`, `basically`, `allow`, and `example`.
+
+- Maven coordinates basically use `groupId = jp.igapyon` and `artifactId = <project>`
+- Artifact names for single fat jar, Maven plugin jar, and distribution zip are aligned to an `artifactId-version` style that is easy to trace from Maven coordinates
+- Runtime jar names inside distribution zips are also versioned like distribution file names
+- Place the CLI main class at `jp.igapyon.<project>.cli.<Project>Cli`
+- The CLI should not pack real processing into `main(String[] args)`; delegate to a testable entrypoint such as `run(String[] args, PrintStream out, PrintStream err)`
+- In principle, confine `System.exit` to the end of the CLI main, and return exit codes from core APIs and CLI implementation logic
+- Use CLI stdout for normal output and artifact bodies; use stderr for diagnostics / usage errors / progress, and do not mix them
+- When handling binary artifacts in CLI, output files are the default; if stdout is used, state that as a command contract
+- Keep CLI command dispatch as simple branching that lets upstream command names be read and traced; do not over-abstract it
+- If creating a distribution zip, include the minimal runtime-user-facing items such as the jar, `README.md`, `LICENSE`, and runtime CLI docs
+- Java main source must observe source / binary `1.8` compatibility, and must not assume newer Java APIs / syntax such as `List.of`, `Map.of`, `record`, `var`, or `Files.readString`
+- Test source should also move toward Java 1.8 assumptions where possible, but final judgment should be checked with Maven compiler settings and CI / runtime environments
+- Java source should have the copyright / SPDX header adopted in that repository
+- Keep the root class as a facade close to the upstream file name, and if the implementation is large, delegate to responsibility classes such as `Public`, `Import`, `Export`, and `Validate`
+- Facade classes should preserve upstream-derived public method names and overloads, and should not expose Java-side helper classes too much to users
+- Even during straight conversion, public APIs touched by external users should be stabilized around root facades, while helper classes may change according to upstream-following work
+- In initial straight conversion, POJOs / result objects / warning objects may be simple classes with public fields
+- Small immutable value objects such as report entries or archive entries may be represented as simple classes with constructors and public final fields
+- Options objects may be nested classes with public fields, and `null` options should be translated into default options at entrypoints
+- For structures where order affects output, such as JSON / reports / workbooks, prefer `LinkedHashMap` / `LinkedHashSet`, and sort explicitly if needed
+- Treat text artifacts as `String` with explicit `UTF-8`
+- Treat binary artifacts as `byte[]`, and push file paths to CLI / test / runtime boundaries
+- Core API return values should directly return `String` / `byte[]` / model for single artifacts, and group warnings / changes / multiple artifacts into result objects
+- Archive artifacts such as zip / xlsx / report bundles should fix determinism so entry names, entry order, timestamps, and bytes do not fluctuate
+- Entry names in report bundles and zips should be fixed user-readable names, and should not include values derived from temporary paths, versions, or the current date
+- When adding text entries to archives, fix final newline presence if needed and include it in byte-level parity comparisons
+- Use fixed zip timestamps if needed, and do not mix current timestamps that interfere with byte-level parity
+- AI-facing prompt / spec markdown should not require users to reference source tree paths; move it toward classpath resources and API / CLI retrieval contracts
+- When using vendor-derived markdown at runtime, copy it to classpath resources at build time so it can be read from inside the JAR
+- Classpath resources should be read in a way that works inside a JAR, such as `getResourceAsStream`, and should not depend on relative paths in a development checkout
+- Prefer upstream `testdata` for fixtures, and make fixture names inferable from test names
+- Test names should make the upstream test intent readable in English, and should include `Upstream` and fixture names if needed
+- Keep focused regression commands in docs, and make them traceable from the changed upstream file / Java class / Java test
+- Allow docs-only updates to skip additional tests, and run target tests only for code changes or regression command updates
+- Include README / docs / CLI help synchronization in tests, and detect mismatches between usage wording and implementation through CLI regression
+- CLI tests should check stdout / stderr / exit code / output files / archive entries to detect mismatches between README / usage and implementation early
+- Accumulate warnings / changes in result objects as records of differences where processing can continue
+- Entry contract violations and inputs that cannot be parsed syntactically should move toward exceptions, not warnings
+- Modes such as `replace` / `merge` / `patch` should be explicit string contracts, and modes that require a base model should be checked at entrypoints
+- Upstream vocabulary that conflicts with Java keywords, such as `import`, should be avoided with minimal changes such as `imports` or an `Import` suffix, and should not be replaced with entirely different vocabulary too much
+- Java-side batch / directory processing should use names easy to distinguish from normal single-input commands, such as `*-batch`, `*-directory`, or `--input-directory`, and should not be mixed into core API responsibilities
+- Even when Java-side original batch commands and diagnostics are convenient, separate them in documentation from the core straight conversion contract
+
+The same idea applies to method names.
+
+- If an upstream function name is `camelCase`, basically keep the Java-side method name unchanged
+- Avoid large Java-convention translations like class names; preserve vocabulary correspondence
+- Static / instance differences, argument grouping, return types, and exception design may be adjusted on the Java side
+- However, do not move central verbs and responsibility names far away from upstream
+
+Examples:
+
+- `importFromXml` -> `importFromXml`
+- `exportToXml` -> `exportToXml`
+- `parseAiJsonText` -> `parseAiJsonText`
+- `importIntoProjectModel` -> `importIntoProjectModel`
+
+## What Was Ported and What Was Excluded
+
+The Java version does not aim to bring in the entire upstream as-is.
+The targets are mainly core / CLI / batch / packaging paths that are natural to handle in a Java runtime.
+
+Main targets:
+
+- domain model
+- codec / import / export
+- validation
+- CLI / batch entrypoint
+- runtime packaging
+- report / artifact / exchange formats that are natural to handle in the Java runtime
+
+Mainly out of scope:
+
+- paths premised on browser / Web UI
+- bringing the GUI itself to the Java side
+- the distribution form itself as a single-file web app
+- browser-specific DOM / preview / event handling
+- helper implementations for UI convenience that are not natural on the Java side
+
+In other words, the upstream semantic structure is received, but the GUI is not brought in, and the runtime environment is translated into Java CLI / jar distribution.
+
+## Things Intentionally Added on the Java Side
+
+Even in `straight conversion`, the Java side adds operationally necessary wrappers and packaging.
+
+Main examples:
+
+- Organization of public entrypoints such as `CoreApi*`
+- Java CLI entrypoint
+- Java-side wrapper module for adding Maven plugin goals
+- API / CLI entrypoints for retrieving AI-facing prompt markdown
+- single fat jar packaging
+- distribution zip packaging depending on the processing target
+- auxiliary paths for Java-side operation, such as batch / directory commands
+
+These are not mixed as the same responsibility as the upstream body; they are treated separately as `Java-side original extensions`.
+
+In addition to the CLI runtime, Java-side execution paths such as Maven plugins may be considered first-class, high-priority paths for CLI / batch conversion tools.
+Especially for tools that fit naturally into a build process, such as artifact generation, validation, conversion, and index creation, Maven plugin support is highly worth considering.
+
+In that case, a multi-module Maven reactor repository structure may be used.
+
+- The repository root is an aggregator parent `pom`
+- In principle, do not place `src/main/java` or `src/test/java` under the aggregator root
+- Runtime jar implementation is under `<repo>/<runtime-module>/src/...`
+- Maven plugin implementation is under `<repo>/<plugin-module>/src/...`
+- Shared core contracts should live in the runtime module or core module, and should not flow backward into the plugin module
+- Directory / batch processing used by both CLI and Maven plugin should live in the runtime module or a core-adjacent runtime helper, not in the plugin module
+
+At this time, it is not a problem that Java source becomes one level deeper than the repository root.
+The important points are that the reason for multi-module structure can be explained as `separation of Java-side original extensions` and `reuse of shared core API`, and that README / mapping / regression docs follow that structure.
+
+Directory / batch processing is especially valuable in Java in practical terms.
+Maven plugins often need to process multiple files as part of a build process, and even in CLI usage, considering JVM startup cost, batch processing can be more natural than starting a Java process for each file.
+However, this is not the core specification of upstream straight conversion; treat it as added value for Java-side execution paths.
+
+Design notes:
+
+- Preserve the single-file conversion core API as-is, and place directory / batch processing in a runtime helper that repeatedly calls it
+- If CLI and Maven plugin both provide the same directory / batch specification, reuse the same helper and do not confine the processing specification only to the plugin side
+- When input directory and output directory are part of the contract, decide whether output may be placed beside the input when no output destination is specified only after confirming generated artifacts will not become inputs again
+- Limit directory search targets to explicit input extensions, and do not include generated artifacts or temporary files
+- Use `false` as the conservative default for recursive processing; when recursion is enabled, preserve relative directory structure to avoid output collisions
+- If an option for single-file input, such as archive / zip output, is ambiguous in directory mode, forbid it
+- Explicitly reject conflicting options such as `inputDirectory` and `outputFile` at the entrypoint
+- Explain the same constraints in CLI help, README, Maven plugin parameter docs, and regression docs
+
+## Naming When Adding a Maven Plugin
+
+When adding a Maven plugin as a Java-side original extension, align the artifact name, prefix, and goal name at the beginning.
+Maven has its own conventions here, and fixing these later tends to widen the range of user-facing command and README changes.
+
+Basic policy:
+
+- Use the normal reverse-domain style for `groupId`
+- Prefer `${prefix}-maven-plugin` for the plugin artifactId as a third-party plugin convention
+- Do not choose `maven-${prefix}-plugin` for normal miku Java versions, because that form follows Apache Maven official plugin conventions
+- Align the command prefix desired for short-form usage with the artifactId
+- Explicitly set the prefix with `goalPrefix` in `maven-plugin-plugin` if needed
+- Make goal names short and descriptive of the processing content
+- Treat plugin version as something specified explicitly in the consuming `pom.xml`
+
+For example, if the artifactId is `miku-indexgen-maven-plugin`, the prefix is `miku-indexgen`; if the goal is `index`, the short form becomes `mvn miku-indexgen:index`.
+
+However, even if artifactId and `goalPrefix` are correct, short form is not always resolved.
+If the user's Maven cannot search that plugin group for prefix resolution, specifying full coordinates is more reliable.
+Especially for third-party plugins, `mvn ${prefix}:${goal}` can fail unless the plugin group is included in the user's `settings.xml` or project configuration.
+Therefore, README and development docs should describe `an execution example that reliably passes with full coordinates` separately from `preconditions for short form to pass`.
+
+Parameter naming should also be fixed in the early stage.
+
+- Move plugin parameter names toward the vocabulary of upstream CLI options and core options objects
+- Do not replace semantic vocabulary too much just because it is Maven-side
+- Make list / collection parameters explainable in terms of correspondence between XML element names and Java field names
+- Align plugin parameter defaults with README / plugin help / core defaults
+- When adding directory / batch goals, use the same vocabulary as Java-original CLI options and preserve semantic correspondence such as `inputDirectory`, `outputDirectory`, and `recursive`
+- If a parameter cannot be used mutually between directory / batch goals and single-file goals, reject it explicitly at plugin execution and write the constraint in README
+
+Findings:
+
+- Plugin naming is not just appearance; it directly affects prefix resolution and user-facing commands
+- If `artifactId`, `goalPrefix`, and `goal` drift apart, README and execution method explanations tend to become hard to understand
+- Whether short form succeeds depends not only on naming but also on plugin group resolution settings
+- If parameter names use different vocabulary in CLI and Maven plugin, synchronization cost increases across README, help, tests, and adapter implementation
+- If the main target of straight conversion is CLI / batch / report work and it naturally fits into a build process, plugin naming should be fixed early
+- If the same directory / batch feature exists in both CLI and Maven plugin, keep the plugin goal as a thin adapter, and fix traversal, relative path resolution, output name decisions, and repeated conversion in runtime helper tests
+
+## CLI Handling
+
+When moving an upstream that has a CLI to Java, the Java-side CLI should respect the Node CLI interface as much as possible.
+
+Important points are as follows.
+
+- Bring command names and subcommand structure close enough that upstream descriptions and usage markdown can reuse the same wording
+- Bring option names and argument order as close as possible to upstream
+- Do not break text / json / binary output contracts
+- Keep diagnostics and usage error categories traceable
+- Provide AI-facing prompt markdown as a CLI / API retrieval contract, not as source file references
+
+However, the following may be added for Java-side operational convenience.
+
+- batch command
+- directory input option
+- Maven plugin goal
+- minimal startup method differences for fat jar execution
+- auxiliary diagnostics that match Java runtime / file APIs
+
+Even in this case, keep the upstream CLI body contract separate from Java-side original extensions, and preserve the ability to explain where the added part begins.
+
+Findings:
+
+- If the CLI contract is vague at the beginning, synchronization cost for help / README / tests / diagnostics tends to increase later
+- For CLIs that naturally fit into a build process, providing a Maven plugin often greatly improves practicality for Java users
+- Java-side original batch / directory commands are convenient, but mixing them with upstream straight conversion easily breaks the upstream-following unit
+- Because JVM startup cost exists, it is reasonable for Java CLI to provide directory / batch processing even apart from Maven plugins
+- In directory mode, allowing `outputFile` or archive options from single-file mode as-is often makes meaning ambiguous, so mutual exclusion should be fixed in entrypoint validation
+- Maintenance is easier when `core contract` and `Java-side operational extensions` are treated separately
+
+## Operational Decisions Reflected Back into Documents
+
+Straight conversion is not complete with the initial policy alone.
+For this reason, update this document each time straight conversion is applied, and try to reduce the amount of operational judgment that must be fixed individually along the way.
+
+- Fix upstream diff check units by `upstream file`
+- Fix `upstream file -> Java class -> Java test` correspondence in documents
+- Distinguish docs-only updates and code changes operationally
+- Manage Java-side original extensions separately by categories such as `batch command`, packaging, and diagnostics
+- For major artifacts, use byte-level parity in addition to semantic comparison
+- Fix determinism with tests so the same input produces the same output
+- In the maintenance phase, prioritize checking existing implementation and following upstream diffs over adding new features
+
+Byte-level parity is especially worth explicitly adopting as a quality criterion along the way.
+When text / json / xml / zip / xlsx / report artifacts can be compared down to bytes, implicit specifications such as ordering, line endings, entry names, default value completion, and incidental metadata become easier to see.
+This suppresses unconscious Java-side redesign or formatting differences, and makes differences from upstream easier to discuss concretely.
+
+Findings:
+
+- Byte-level parity does not need to be applied everywhere from the beginning, but it is highly worth applying early to final artifacts such as reports and archives
+- Instead of demanding the same strictness for all outputs at once, it is easier to expand gradually from artifacts where comparison has high value
+
+## Core API Boundary
+
+In straight conversion, fix the boundary between core API and CLI / runtime API early.
+
+Important points are as follows.
+
+- Core packages should not depend on file system APIs such as file paths or `Files`
+- Text documents should use `String` as the canonical representation
+- Binary artifacts should use `byte[]` as the canonical representation
+- Core APIs should not write directly to standard I/O, and should return model / result object / `String` / `byte[]`
+- APIs that return only a single artifact should directly return `String` or `byte[]`; APIs that need warnings / changes / multiple artifacts / metadata should return result objects
+- User-facing documents such as AI-facing prompt markdown should also be treated as artifacts retrievable via API / CLI, not as source tree file path references
+- `InputStream` / `OutputStream` are mainly used for internal implementation or runtime boundaries
+- File read / write and bridging to standard I/O should be pushed to the CLI layer
+- CLI should emit normal output and artifact bodies to stdout or output files, and diagnostics / usage errors / progress to stderr
+- Java CLI / Maven plugins that process long-running or multiple-file work should provide verbose / progress diagnostics that reveal the file being processed
+- Binary artifacts should be written to output files in principle; if stdout is used, state it as a command contract
+- Stdin input should be limited to things compatible with streams, such as text / json, and file path arguments should be preferred for binary or multiple-input-file processing
+
+If this boundary is vague, core implementation becomes pulled by Java runtime convenience, and the correspondence with upstream responsibilities becomes harder to see.
+
+Findings:
+
+- Using `String` and `byte[]` as canonical representations, and pushing file paths and streams to boundaries, tends to work well
+- When core starts holding `Path` or `Files`, CLI convenience fixes tend to flow backward into core
+- Fixing stdout / stderr usage makes it easier for CLI tests to check normal output and diagnostics separately
+- Verbose / progress diagnostics are easier to handle when they are not mixed into core output contracts, but are confined to stderr in CLI and Maven logs in Maven plugins
+
+## Holding Values
+
+How the internal model represents the presence or absence of values should also not fluctuate midstream.
+
+Basic policy:
+
+- Use `null` as the internal representation of `no value`
+- Empty strings may be kept if needed, but may also be normalized to `null` at entrypoints
+- Use `0` only when it is a valid value, and do not use it as a substitute for `no value`
+- Do not bring values substituted for report or CLI display convenience directly into the internal canonical representation
+
+The important point is to avoid confusing `blank` / `null` / `0`.
+
+Findings:
+
+- This policy generally works well
+- Especially in workbook import and report display, it becomes easier to separate missing input from valid value `0`
+- On the other hand, XML import entrypoints and human-facing output require local rules, so the whole system cannot be simplified uniformly
+- Therefore, the practical organization is `do not confuse values in the internal canonical representation` and `allow local conversion at input and display boundaries`
+
+## Returning Exceptions and Warnings
+
+It is easier to stay consistent if `parse` / `import` / `validate` return behavior is fixed as a shared principle.
+
+Basic division:
+
+- Entry contract violation
+  - Return as an exception
+- Semantic validation problem
+  - Return as an issue / warning
+- Local difference where processing can continue
+  - Accumulate in result warnings or changes
+
+Deciding this line first makes it easier to keep Java APIs consistent about what they throw and what they demote to warnings.
+Separate diagnostic granularity by layer.
+CLI returns user-facing messages and exit codes, core API aggregates into exceptions or result objects, and tests fix them as expected differences.
+This separation makes it harder for human-facing display convenience to flow backward into core exception design or internal models.
+
+Findings:
+
+- Without this line, the same kind of inconsistency easily splits into throw in one API and warning in another
+- Separating `entry contract violation` from `semantic validation` alone tends to stabilize CLI diagnostics considerably
+
+## Handling Options Objects
+
+Decide early how to represent Node.js upstream options objects in Java.
+
+Basic policy:
+
+- Do not make the builder pattern mandatory in initial porting
+- Do not move too far toward JavaBeans; prioritize field names that make upstream option names and meanings easy to trace
+- `overload without options` and `overload with options` may coexist
+- Preserve correspondence with upstream instead of replacing option names with Java-side original vocabulary
+
+Findings:
+
+- Adding too many builders or abstract request classes during initial porting tends to obscure correspondence with upstream option objects
+- It is easier to preserve upstream-following ability by first porting with simple POJOs and reorganizing later if needed
+
+## Library Policy
+
+Java has many convenient libraries, but straight conversion does not prioritize replacing things merely because it is convenient.
+
+Decision criteria:
+
+1. Whether upstream uses an external library
+2. Whether upstream has a scratch implementation
+3. Whether a Java-side library fits well enough
+4. Whether it is maintainable under target Java compatibility
+5. Whether it preserves upstream-following ability
+
+For this reason, miku-series Java versions often tend to implement from scratch instead of forcing library usage.
+For locations where upstream has a scratch implementation, following the same structure and logic on the Java side first makes diff comparison easier.
+For example, even in areas such as xlsx where Apache POI comes to mind easily, if the required range of generation / reading / validation is limited and byte-level parity or upstream-following ability is prioritized, choosing scratch implementation without even using POI is acceptable.
+
+Findings:
+
+- Even if Java has a convenient existing library, replacing early tends to make the work closer to `reimplementation` than `porting`
+- On the other hand, where upstream uses an external library, considering a corresponding Java library is often natural
+
+## Docs and Upstream-Following Operation
+
+Straight conversion has shared principles not only for implementation but also for upstream-following operation.
+
+Important points are as follows.
+
+- Fix `upstream file -> Java class -> Java test` correspondence in documents
+- Record diff check results by `upstream file`
+- Distinguish docs-only updates and code changes operationally
+- Prepare focused regressions that can be executed according to the change unit
+- Keep a location for communication items when upstream bugs are found
+- Keep shared principles and decision criteria in this guide; make README and development docs the canonical source for repository-specific current values, artifact names, and execution examples
+
+For docs-only updates, it is effective to avoid additional tests in principle, and check target units only for code changes or regression command updates.
+In repositories that introduce Maven plugins, at least the following may be kept as the minimal check set.
+
+1. `mvn test`
+2. `mvn package`
+3. Maven plugin smoke execution with full coordinates
+
+Because short-form smoke depends on plugin group resolution settings, it may be treated separately from the permanent minimal check set.
+
+When an upstream bug is found, handle it in the following order in principle.
+
+1. Record it as a communication item for upstream
+2. Leave enough information to identify the related upstream file / responsibility
+3. Do not stop Java-side straight conversion itself; continue as-is
+4. If adding a temporary workaround on the Java side, record that it is caused by an upstream bug
+
+Findings:
+
+- If the Java-side design is changed immediately every time an upstream bug is found, the work tends to move toward original fixes rather than straight conversion
+- Recording first and porting first is better for preserving upstream-following ability
+
+## Artifacts to Keep
+
+To make straight conversion reproducible, keep not only code but also the following artifacts.
+
+- repository top README
+- straight conversion guide
+- remaining items / current status document
+- `upstream file -> Java class` mapping
+- `upstream test intent -> Java test` mapping
+- follow-up log
+- focused regression command list
+- CLI help / usage contract
+- AI-facing prompt markdown API / CLI retrieval contract
+- fixture / parity / determinism tests
+
+When these are in place, another person can join midway and resume porting and upstream-following work at the same granularity.
+
+## Completion Criteria
+
+To treat the initial stage of straight conversion as complete, it should satisfy at least the following.
+
+- Main core paths work on the Java side
+- Minimal round-trip works
+- `upstream file -> Java class` mapping table exists
+- `upstream test intent -> Java test` mapping table exists
+- focused regression commands exist
+- If a CLI exists, contracts for main commands / options / diagnostics are fixed
+- The follow-up log contains at least several concrete `upstream file` examples
+- Determinism has been confirmed for major artifacts
+- Byte-level parity has been confirmed for artifacts with high comparison value, or the reason for not applying it has been documented
+
+The important point is not just that the code works, but that upstream-following ability and verification units remain.
+
+## Example Plan for the First Week
+
+### Day 1
+
+- Fix target Java compatibility, build tool, test framework, primary test entrypoint, and single fat jar packaging
+- Confirm whether the processing target needs a distribution zip
+- Create `workplace/` at the repository root and track only `.gitkeep` in Git
+- Start inventorying upstream files / tests / fixtures / CLI
+- Write the basic policy in README
+
+### Day 2
+
+- Create the first version of `upstream file -> Java class`
+- Create the first version of `upstream test intent -> Java test`
+- Decide the minimal core target
+
+### Day 3
+
+- Implement the domain model and minimal codec
+- Pass the minimal round-trip test
+
+### Day 4
+
+- Add validation and main fixture import
+- Decide the minimal focused regression unit
+
+### Day 5
+
+- Create the CLI entrypoint
+- Fix the help / usage / diagnostics contract with tests
+
+### Day 6
+
+- Implement high-comparison-value report / artifact items
+- Fix determinism with tests
+
+### Day 7
+
+- Start comparison from artifacts where byte-level parity can be introduced
+- Organize remaining items and follow-up log
+- Separate docs-only and code-change operation
+
+Findings:
+
+- Requiring tests every time even for docs-only updates tends to slow document maintenance
+- Instead, fixing the canonical focused regression commands in documents makes it easier to choose the necessary check units for code changes
+
+## Improving Quality
+
+In straight conversion, explainable upstream correspondence and output equivalence are more important than writing Java-side implementation that merely looks plausible.
+
+The verification pillars are as follows.
+
+- `docs/upstream-class-mapping.md`
+  - Fixes `upstream file -> Java class` correspondence
+- `docs/upstream-test-mapping.md`
+  - Fixes `upstream test intent -> Java test` correspondence
+- `docs/upstream-followup-log.md`
+  - Records diff check results by `upstream file`
+
+In addition, for artifacts such as text / json / xml / zip / xlsx / report artifacts, use byte-level comparison in addition to semantic comparison.
+
+This verification has the following effects.
+
+- Implicit specifications such as ordering, line endings, entry names, and default value completion become visible
+- It becomes easier to suppress unconscious Java-side redesign or formatting differences
+- Upstream differences become easier to discuss concretely in terms of `what differs`
+- It becomes easier to fix determinism so the same input produces the same output
+
+## Handling in the Maintenance Phase
+
+After passing the initial straight conversion implementation and having the main Java-side paths in place, treat the work as the maintenance phase.
+
+However, the basic stance does not change even at this stage.
+
+- Prioritize checking existing implementation and following upstream diffs over adding new features
+- Before proceeding with Java-side original cleanup, keep mapping tables, tests, and follow-up logs consistent
+- When upstream is updated, check by `upstream file`
+
+In particular, do not mix new features while straight conversion is in progress.
+Needed new features or Java-side original value should be handled on a separate track after the main straight conversion paths are in place and the upstream-following units and verification units have been fixed.
+
+For this reason, it is appropriate to describe this porting work not as `work to rebuild for Java`, but as `work to map Node.js / TypeScript upstream into Java while keeping it trackable, then maintain its equivalence`.
+
+## Application Example in This Repository
+
+In this repository, the shared principles above are applied to `mikuproject`.
+
+- upstream:
+  - `vendor/mikuproject/src/ts/*.ts`
+- main Java-side responsibilities:
+  - `MS Project XML`
+  - `ProjectModel`
+  - validation
+  - workbook JSON / XLSX
+  - patch / AI JSON
+  - report (`Markdown`, `SVG`, `WBS XLSX`, `Mermaid`)
+  - CLI entrypoint
+- representative Java-side original extensions:
+  - `CoreApi*`
+  - `MikuprojectCli`
+  - single fat jar packaging
+  - distribution zip packaging depending on the processing target
+
+When shared principles are fixed first and repository-specific application examples are placed under them, the same approach becomes easier to reuse in other miku-series projects.
+
+Environment premises fixed in this repository:
+
+- target Java compatibility:
+  - source / binary compatibility with `1.8`
+  - the actual compiler is not limited to `JDK 1.8`
+- build tool:
+  - `Maven`
+- test framework:
+  - `JUnit Jupiter 5.14.1`
+- primary test entrypoint:
+  - `mvn test`
+- runtime packaging:
+  - single fat jar fixed (`target/mikuproject.jar`)
+  - distribution zip added depending on the processing target (`target/mikuproject-dist.zip`)
+
+For progress, remaining items, and the latest check results in this repository, treat `README.md`, `docs/remaining-migration-items.md`, `docs/upstream-class-mapping.md`, `docs/upstream-test-mapping.md`, and `docs/upstream-followup-log.md` as canonical, not this application example.

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-40-agentskills-design-v20260501.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-40-agentskills-design-v20260501.md
@@ -1,0 +1,748 @@
+# Miku Software Agent Skills Design v20260425
+
+This memo organizes design characteristics commonly expected for Agent Skills versions in the `miku` software series.
+
+The initial versions of the related tools were created by `Mikuku` and Toshiki Iga.
+
+The current contents are based on current Agent Skills examples, the main-application design memo, the Java application design memo, and the straight-conversion guide checked on 2026-04-25.
+
+## Design Summary
+
+The Agent Skills versions in the `miku` software series can be summarized as follows.
+
+> Agent-facing local workflow packages that make miku main applications easier for AI agents to call, while preserving upstream semantics, structured artifacts, diagnostics, and human-reviewable handoff points.
+
+What characterizes Agent Skills versions is not a new product separate from the upstream application. It is a repeated set of constraints.
+
+- Keep the semantic center of the upstream main application
+- Make AI-agent workflows explicit and repeatable
+- Prefer structured input / output over screen operation or loose prose
+- Keep intermediate artifacts inspectable when needed
+- Use upstream public APIs, CLI, or bundled runtime artifacts rather than duplicating product logic
+- Treat the skill as a thin orchestration and guidance layer
+- Distinguish conversation state from canonical source and primary product artifacts
+- Package the skill so it can be installed and used locally
+
+## Role of This Document
+
+This document is not a detailed specification for one skill repository. Repository-specific behavior should be checked in each `SKILL.md`, README, and product-specific documents.
+
+Use the shared design documents together as follows.
+
+- `docs/miku-soft-10-mainapp-design-v20260501.md`
+  - describes the upstream product design and semantic center
+- `docs/miku-soft-20-javaapp-design-v20260501.md`
+  - describes Java runtime versions when they exist
+- `docs/miku-soft-30-straight-conversion-v20260425.md`
+  - describes how Java versions are created from upstream main applications
+- `docs/miku-soft-40-agentskills-design-v20260501.md`
+  - describes how Agent Skills versions should expose miku workflows to AI agents
+
+This document separates the following levels.
+
+- **Cross-cutting principles**: design policies that should generally be kept for Agent Skills versions.
+- **Recommended conventions**: repository, packaging, state, and documentation shapes that make maintenance easier.
+- **Observed tendencies**: design habits visible in current Agent Skills repositories.
+- **Product-specific notes**: design decisions for specific skill products, recorded as concrete examples.
+
+When a specification is unclear, first check whether the decision preserves upstream meaning and improves agent-operable structured workflow. Agent convenience is important, but it should not hide unsupported behavior, discard diagnostics, or make the skill drift into a different product.
+
+## Scope
+
+The series whose names start with `miku` includes several related product types.
+
+Main applications:
+
+- `miku-abc-player`
+- `miku-docx2md`
+- `miku-indexgen`
+- `miku-unicode-guard`
+- `miku-xlsx2md`
+- `mikuproject`
+- `mikuscore`
+
+Java application versions:
+
+- `miku-indexgen-java`
+- `mikuproject-java`
+- `miku-xlsx2md-java`
+
+Agent Skills versions:
+
+- `mikuproject-skills`
+- `mikuscore-skills`
+
+Projects with the `-skills` suffix are positioned as Agent Skills versions that make the original products easier for AI agents to use.
+
+This document focuses on Agent Skills versions. It does not define the Web UI conventions for upstream main applications, and it does not define the Java packaging conventions for Java application versions.
+
+## Shared Direction
+
+Agent Skills versions continue the shared direction of the miku series: small local bridge tools that convert, extract, inspect, normalize, or export domain files and domain data.
+
+The Agent Skills version emphasizes the parts that fit AI-agent operation particularly well.
+
+- explicit activation and usage instructions
+- structured JSON, Markdown, XML, XLSX, SVG, ZIP, or similar artifacts
+- local import / validate / export operations
+- agent-readable diagnostics and summaries
+- small projections instead of unnecessarily large state handoff
+- patch / apply / diff workflows where existing data is revised
+- bundled Java CLI and Node.js CLI paths where practical
+- repeatable file-based operation
+- skill bundles that can be installed into an agent environment
+
+An Agent Skills version should not become a generic planner, generic converter, or autonomous replacement for the upstream application. Its value is that an AI agent can use the upstream miku product correctly with less guesswork.
+
+## Relationship to Main Applications
+
+Agent Skills versions are downstream of miku main applications.
+
+The upstream main application owns the product semantics, canonical source, core conversions, output policy, and limitations. The skill owns agent-facing activation, workflow guidance, runtime discovery, state handoff, and packaging.
+
+The preferred relationship is as follows.
+
+- upstream main application provides core APIs, CLI, bundled runtime, or stable artifacts
+- Agent Skill calls those upstream surfaces
+- Agent Skill explains when to use which operation
+- Agent Skill keeps intermediate JSON and file artifacts organized
+- Agent Skill reports diagnostics, warnings, and hard errors in an agent-readable form
+- Agent Skill does not reimplement core conversion behavior unless no upstream surface exists
+
+If an upstream capability is missing, the preferred order is to request or implement the capability on the upstream side, expose it as a stable upstream API, and then let the skill call it. Agent Skills should not silently add upstream product capabilities on the skill side. Skill-local workaround code should be treated as temporary or product-specific, not as the new semantic center.
+
+## Role of Agent Skills
+
+In this document, an Agent Skill means a `miku` repository with a `-skills` suffix that packages one or more skills for agent environments.
+
+An Agent Skill is primarily an agent-facing workflow adapter. It usually exposes one or more of the following.
+
+- `SKILL.md` activation and operating instructions
+- references for detailed workflows and examples
+- local scripts for import / export / validation / report generation
+- bundled upstream runtime artifacts or install-time runtime dependency
+- test coverage for skill behavior and smoke paths
+- distributable skill bundle or bundle zip
+
+The Agent Skill is not primarily the browser UI and is not primarily a Java port. It can use Node.js, Java, or another runtime if that is the natural way to call the upstream product, but the skill layer itself should remain thin.
+
+The center of an Agent Skill is reliable orchestration: determine when the skill applies, call the upstream runtime, validate or transform structured documents, preserve useful state, emit artifacts, and tell the agent what to do next without hiding important constraints.
+
+## Cross-Cutting Principles
+
+miku Agent Skills emphasize the following cross-cutting principles.
+
+1. Preserve the semantic center and product boundary of the upstream main application.
+2. Treat the skill as an agent workflow adapter, not as a replacement implementation.
+3. Use structured artifacts and diagnostics instead of screen-driven or prose-only operation.
+4. Keep skill activation explicit enough to avoid accidental takeover of generic tasks.
+5. Prefer local runtime execution and file artifacts over server-dependent workflows.
+6. Distinguish canonical source, conversation state, primary output, reports, and temporary handoff data.
+7. Use small projections, patches, validation, and diffs for AI-assisted edits where practical.
+8. Make installation, bundling, smoke testing, and upstream synchronization explainable.
+9. Keep workflow guidance separate from execution backend selection so CLI, MCP, and handoff execution can follow explicit policy.
+
+### Basic Philosophy of Agent Skills
+
+Agent Skills versions emphasize the following philosophy.
+
+- Run product operations locally when practical
+- Keep the upstream product meaning recognizable
+- Use the upstream API or CLI before writing skill-local conversion logic
+- Make AI-facing operations explicit
+- Keep intermediate JSON internal when direct internal execution is possible
+- Expose handoff artifacts when a human or upper-layer agent needs to inspect or reuse them
+- Preserve diagnostics and warnings as part of the result
+- Keep state and generated files easy to save, compare, and rerun
+- Make skill activation narrow enough that generic user requests are not captured accidentally
+- Keep `SKILL.md` concise and place detailed workflow material in references or docs
+
+The value of an Agent Skills version is not that it can answer a domain question conversationally in a generic way. It is that it can safely drive a specific miku workflow through structured operations that are faithful to the upstream product.
+
+### Common Principles for Agent Skills
+
+Agent Skills use the following principles as defaults.
+
+- Place one or more skills under `skills/`
+- Put each skill's primary instructions in `skills/<skill-name>/SKILL.md`
+- Keep the skill name close to the upstream product name when the product identity matters
+- Require explicit product naming for skills that would otherwise overlap with generic tasks
+- Keep detailed references under the skill directory or repository `docs/`
+- Use Node.js when calling a Node.js upstream runtime directly is the simplest path
+- Bundle both Java CLI and Node.js CLI paths as the standard future direction for miku Agent Skills
+- Treat the Java CLI runtime artifact as a single jar
+- Treat the Node.js CLI runtime artifact as a single JavaScript file
+- Use bundled upstream runtime artifacts when local, reproducible execution and bundling need them
+- Prefer upstream public APIs, stable global APIs, or documented CLI commands
+- Allow execution backend policy to choose CLI, MCP, or handoff behavior without changing the skill name or workflow vocabulary
+- Package distributable bundles with scripts that can be tested
+- Keep repository-level README user-facing and developer details under `docs/`
+- Use `workplace/` for local scratch data, upstream checks, generated outputs, and verification files
+
+These are defaults for the miku Agent Skills series. Individual products may add product-specific conventions, but should not change these foundations casually.
+
+### Activation Boundary Principles
+
+Agent Skills must be careful about when they activate.
+
+Many miku domains overlap with ordinary conversation. A request mentioning planning, schedules, tabular files, score files, music, Markdown, SVG, XML, or reports should not automatically mean that a product-specific skill must take over.
+
+The preferred activation rule is explicit opt-in.
+
+Typical activation criteria include the following.
+
+- the user explicitly names the upstream product or skill
+- the user requests a documented product-specific workflow
+- the recent conversation is already inside an explicitly activated workflow
+
+Without an explicit trigger, the agent should answer normally or ask a brief clarifying question if using the skill would materially change the result.
+
+Activation instructions should be written in `SKILL.md` because they are part of the skill contract, not just documentation.
+Product-specific trigger words and exceptions should be recorded in each product's `SKILL.md` or product-specific notes.
+
+### Core Runtime Principles
+
+Agent Skills should use declared runtime artifacts before broad repository exploration.
+
+The preferred order is as follows.
+
+1. Read the active skill's `SKILL.md`
+2. Check the bundled runtime artifacts declared by the skill
+3. Use upstream public APIs, stable globals, or documented CLI/runtime flows
+4. Use skill-local helpers only when they are the intended adapter layer
+5. Search broadly for alternatives only when the declared runtime path is missing or unusable
+
+This keeps agent behavior predictable. It also prevents the skill from accidentally using stale generated files, unrelated scripts, or partial local experiments.
+
+Runtime artifact lookup should be simple and fixed. Place the single jar and single JavaScript CLI file under the skill directory, such as `skills/<skill-name>/runtime/`, and let the skill resolve the declared versioned artifacts there.
+
+Do not create a separate skill product line only because an additional runtime path exists. When both Java CLI and Node.js CLI runtimes are available, treat them as runtime artifacts of the same normal `-skills` package. The skill name, activation rules, workflow vocabulary, artifact roles, and product boundary should remain tied to the upstream main application, not to the runtime implementation.
+
+When both Java CLI and Node.js CLI runtime artifacts are bundled, the skill may prefer the Java CLI first for local execution. A single jar is easy to locate, smoke-test, and run in automation environments. If the Java CLI artifact is missing, cannot be invoked, or does not support the requested operation, the skill may fall back to the Node.js CLI runtime.
+
+This runtime preference is an execution policy, not a semantic priority. The upstream main application remains the semantic center. Runtime differences should be reported as capability or compatibility diagnostics.
+
+### Execution Backend Policy Principles
+
+Agent Skills should remain the workflow layer even when the execution backend changes.
+
+The skill owns activation rules, operation selection, artifact roles, file placement guidance, diagnostics policy, and handoff expectations. The execution backend owns how an operation is actually carried out in a particular environment.
+
+Common backend categories are:
+
+- CLI backend: run bundled or configured upstream CLI artifacts, usually through Java or Node.js commands
+- MCP backend: call a product-specific MCP server that exposes aligned tools and resources
+- handoff backend: do not execute the product operation directly; return the spec, structured JSON, prompt, or step-by-step handoff material visibly
+
+The default policy for mature miku Agent Skills should be `cli-preferred`: try the declared local CLI backend first, and fall back to MCP only when that fallback is allowed by the active environment and repository policy.
+
+Supported policy values should be interpreted as follows.
+
+- `cli-only`: use only the CLI backend; do not inspect or call MCP as an automatic fallback
+- `cli-preferred`: use CLI first; use MCP only when CLI is unavailable or unsuitable and fallback is allowed
+- `mcp-only`: use only the MCP backend; do not inspect or run CLI artifacts as an automatic fallback
+- `mcp-preferred`: use MCP first; use CLI only when MCP is unavailable or unsuitable and fallback is allowed
+- `handoff-only`: do not execute backend operations; provide visible handoff material and instructions
+
+Execution backend policy is subordinate to the user's explicit instruction and the active environment policy. If an environment disallows CLI execution, a skill must not run CLI commands merely because `cli-preferred` is the repository default. If an environment disallows MCP access, a skill must not call MCP tools merely because CLI failed.
+
+Strict policies are intentionally strict. Under `cli-only` or `mcp-only`, failure of the selected backend should be reported as a hard execution-path error instead of silently switching to another backend. Under `handoff-only`, backend execution should not occur even when CLI or MCP is available.
+
+When fallback is allowed and happens, diagnostics should state the source backend, target backend, and concise reason. For example, a result may say that CLI was unavailable and execution continued through MCP, or that MCP lacked a required tool and execution continued through CLI.
+
+An MCP backend should use the MCP server layer described by the miku MCP design documents. The Agent Skill should not become the MCP server implementation and should not redefine MCP tool names, resource roles, or protocol contracts locally. It should describe how its operation vocabulary maps to the MCP tools and resources exposed by the product-specific MCP server.
+
+### AI-Facing Spec Retrieval Principles
+
+Agent Skills should not rely on broad file search to find prompt or spec documents.
+
+When an upstream product provides AI-facing prompts, JSON specs, schemas, workflow instructions, or similar documents, those documents should be retrievable through a stable upstream API or CLI contract.
+
+The skill may bundle or reference those documents, but the preferred runtime path is as follows.
+
+- Call an upstream API such as `getAiSpec()` or `getAiSpecText()`
+- Call a documented CLI command such as `<product> ai spec`
+- Receive `id`, `version`, `text`, diagnostics, and related metadata as structured data where practical
+
+This keeps prompt and spec retrieval stable across repository layout changes. It also prevents skills from depending on source-tree paths, generated file names, or broad search behavior.
+
+### Thin Adapter Principles
+
+Agent Skills keep product logic in the upstream application as much as possible.
+
+The skill layer may contain:
+
+- activation rules
+- workflow instructions
+- operation selection
+- input kind detection
+- file naming conventions
+- runtime path discovery
+- small adapters around upstream API calls
+- result formatting for the agent
+- bundle-building scripts
+- smoke tests
+
+The skill layer should not contain:
+
+- a parallel implementation of upstream conversion
+- hidden product semantics that the upstream does not know
+- broad UI replacement logic
+- model-specific prompting logic that makes the skill unusable with another agent
+- server credentials or provider-specific calling code unless the repository explicitly owns that integration
+
+When skill-local code becomes large, first ask whether the upstream main application should expose a smaller public API.
+
+### State and Artifact Principles
+
+Agent Skills distinguish several kinds of data.
+
+- canonical source or semantic base owned by the upstream product
+- conversation state used by the skill or agent
+- AI-facing projection or draft document
+- patch or edit document returned by AI
+- primary product output
+- report or presentation output
+- diagnostics and warnings
+- temporary files and local scratch outputs
+
+These roles should not be collapsed only because they are all represented as JSON or files.
+
+For individual products, the conversation state may differ from the upstream semantic base. That does not make the conversation state the canonical semantic center of the product.
+
+Similarly, two artifacts may share an extension while having different roles, such as structural exchange data and human-facing reports. Ambiguous filenames and ambiguous operation names should be avoided when identical extensions represent different artifact roles.
+
+### AI Workflow Principles
+
+Agent Skills should prefer structured AI workflows.
+
+Representative operations include:
+
+- provide a JSON spec or schema-like guide
+- accept a draft document
+- validate document kind and required fields
+- import draft into product state
+- export a small overview or detail projection
+- accept a patch document
+- validate patch references and impact radius
+- apply patch to a base state
+- return change summary, diagnostics, and updated state
+- export human-facing reports
+
+When revising existing state, prefer small projections and patches over full-state replacement where the upstream product supports them.
+
+This has several advantages.
+
+- AI context stays smaller
+- returned changes are easier to validate
+- references to existing IDs can be checked
+- diffs are easier for humans to review
+- accidental unrelated edits are less likely
+
+Visible handoff is useful when the user or an upper-layer agent needs to inspect or pass data. However, when the skill can safely execute import / apply / export internally, it should not stop merely by printing intermediate JSON.
+
+### Handoff and Agent-Internal Principles
+
+Agent Skills may support both handoff-style and agent-internal workflows.
+
+Handoff-style workflow:
+
+- skill returns spec, projection, workbook, or prompt material visibly
+- user or upper-layer agent passes that material to another AI turn or tool
+- useful for inspection, debugging, interoperability, and early MVPs
+
+Agent-internal workflow:
+
+- skill keeps intermediate JSON internal when possible
+- agent calls the next operation directly
+- visible output focuses on result, diagnostics, artifacts, and next useful choices
+- useful when the agent environment supports tool execution and state handling
+
+Both styles are allowed. The default for mature flows should move toward agent-internal execution when it is safer and less noisy. Handoff should remain available when it improves reviewability or when the environment cannot chain operations internally.
+
+### Error and Diagnostic Principles
+
+Agent Skills distinguish hard errors from soft errors.
+
+Hard errors include:
+
+- unsupported or ambiguous document kind
+- missing required base state for patch application
+- syntactically invalid structured input
+- missing upstream runtime
+- failed import / export that prevents a valid result
+
+Soft errors include:
+
+- upstream warnings
+- partial import where the upstream says processing can continue
+- ignored unknown fields or columns
+- fallback output formatting
+- report simplifications
+
+On hard error, the skill should stop the operation and report what is needed to continue. On soft error, the skill may continue and report warnings concisely with enough structure for the agent or user to understand the risk.
+
+Diagnostics should preserve upstream messages and locations where practical. Skill-side wording should not hide upstream limitations.
+
+### File and Workplace Principles
+
+Agent Skills often produce state and report artifacts.
+
+Generated files should be placed in predictable product-specific directories rather than scattered through the repository root.
+
+Recommended local shape:
+
+```text
+<product>/
+  state/
+  output/ or report/
+  tmp/
+```
+
+Recommended usage:
+
+- `state/` for conversation state, draft JSON, patch JSON, workbook JSON, and similar reusable state files
+- `output/` for final deliverables when the product is naturally conversion / rendering oriented
+- `report/` for human-facing reports such as spreadsheets, Markdown, SVG, diagram text, and ZIP
+- `tmp/` for short-lived local work
+
+When multiple artifacts come from one run, use a common timestamp or run prefix so they can be grouped.
+
+The repository-level `workplace/` directory remains local scratch space for development, upstream checks, generated outputs, and verification files. It should not become a source directory or a hidden place for checked-in fixtures.
+
+### Upstream Runtime Artifact Principles
+
+Agent Skills repositories should move toward receiving upstream main applications as runtime artifacts rather than as full upstream source trees.
+
+The TOBE target shape is as follows.
+
+- receive a single jar for the Java CLI path
+- receive a single JavaScript file for the Node.js CLI path
+- do not edit upstream source inside the skill repository
+- document the artifact update procedure
+- verify the received artifacts through skill smoke tests and API / CLI contract checks
+
+Current repositories may not yet have this shape. During transition, it is acceptable for a skill repository to keep a vendored upstream source tree or a broader runtime copy when that is how the current skill works. However, this is a current-state allowance, not the target design.
+
+Near-term maintenance should move those repositories toward the target shape: replace source-tree dependency with received single-jar and single-JavaScript runtime artifacts under the skill directory.
+
+### Packaging and Distribution Principles
+
+Agent Skills should be installable as local skill packages.
+
+Packaging should include the files needed for the agent to read instructions and run intended local workflows.
+
+As the TOBE target shape, miku Agent Skills should bundle both Java CLI and Node.js CLI paths when the corresponding upstream runtime exists or can be produced. The Java path should be represented by a single jar, and the Node.js path should be represented by a single JavaScript CLI file.
+
+Current repositories may temporarily use broader vendored runtime contents or source-tree-derived packaging. This is allowed only as a transition state. New packaging work should move toward single-runtime-artifact handling.
+
+The purpose of bundling both paths is not to make the skill layer heavier. It is to let an agent choose the runtime that best fits the local environment while keeping each runtime artifact simple, explicit, and reproducible.
+
+Typical bundle contents:
+
+- `SKILL.md`
+- references needed by the skill
+- skill-local scripts
+- single jar Java CLI runtime when provided
+- single-file JavaScript CLI runtime when provided
+- upstream runtime artifacts, preferably single jar and single JavaScript CLI file
+- package metadata when needed
+- license files and notices as appropriate
+
+Packaging should exclude development-only noise.
+
+Examples:
+
+- local scratch files
+- `workplace/` contents
+- temporary reports
+- test output
+- unrelated upstream development files if not needed at runtime
+
+Bundle-building scripts should be deterministic enough that changes are reviewable. A zipped bundle should be created by a documented command such as `npm run build:bundle` or `npm run build:bundle:zip`.
+
+### Testing Principles
+
+Agent Skills use tests to preserve activation behavior, runtime wiring, structured I/O, and packaging.
+
+Test coverage should include:
+
+- skill smoke tests
+- upstream runtime availability checks
+- runtime selection checks, including Java CLI available, Java CLI unavailable with Node.js fallback, unsupported Java CLI operation with Node.js fallback, and all runtimes missing as a hard error
+- execution backend policy checks, including strict `cli-only`, strict `mcp-only`, preferred fallback behavior, and `handoff-only` no-execution behavior when the repository supports those modes
+- representative import / export operations
+- draft / patch / validate / apply operations where applicable
+- diagnostics and hard-error behavior
+- bundle creation
+- important file naming and artifact paths
+
+As miku Agent Skills move toward receiving upstream runtime artifacts as a single jar and a single JavaScript CLI file, the TOBE target shape is that the upstream source tree and upstream source test suite are not bundled and cannot be executed in the skill repository.
+
+The main responsibility of the skill repository is to verify that the bundled runtime artifacts exist, can be invoked from the skill layer, expose the expected API / CLI contracts, and support the intended agent workflows.
+
+When a failure points into the upstream product itself, fix and verify it in the upstream repository first, then receive updated single-jar or single-JavaScript runtime artifacts in the skill repository.
+
+### Documentation Principles
+
+Agent Skills keep README, `SKILL.md`, references, and docs roles separate.
+
+`README.md` is the user-facing entry point. It should explain:
+
+- what the skill package does
+- how to install or build it
+- how to start using the main skill
+- representative operations
+- runtime requirements
+- where developer documents live
+
+`SKILL.md` is the agent-facing operating contract. It should explain:
+
+- when the skill activates
+- what the skill is allowed to do
+- the most important workflow rules
+- runtime lookup discipline
+- hard boundaries and common mistakes
+- where detailed references are located
+
+Detailed references may include:
+
+- workflow examples
+- input / output formats
+- runtime API notes
+- file import / export notes
+- report export notes
+- installation notes
+- development notes
+
+Do not make `SKILL.md` carry every product detail. It should be compact enough for an agent to read at activation time.
+
+## Recommended Conventions
+
+### Repository Shape
+
+A typical Agent Skills repository has the following shape.
+
+```text
+repository root
+  README.md
+  LICENSE
+  package.json
+  docs/
+  scripts/
+  skills/
+    <skill-name>/
+      SKILL.md
+      references/
+      runtime/
+        <product>-<version>.jar
+        <product>-<version>.mjs
+  tests/
+  workplace/.gitkeep
+```
+
+In the TOBE target shape, runtime artifacts should be placed under each skill directory. Do not design new normal operation around root-level runtime artifacts, vendored source trees, or multiple competing runtime lookup paths. Current repositories that still use a vendored runtime tree should document that as a transition state and keep the lookup path explicit.
+
+For example, `mikuproject-skills` should move toward this shape when both runtime paths are available.
+
+```text
+skills/
+  mikuproject/
+    SKILL.md
+    references/
+    runtime/
+      mikuproject-<version>.jar
+      mikuproject-<version>.mjs
+```
+
+The Java jar and Node.js CLI file are peer runtime artifacts. Use versioned file names for received artifacts, and resolve the actual file under `runtime/` at execution time. Their presence should not change the skill name or split the workflow vocabulary into runtime-specific skill products.
+
+`vendor/` directories are transition-only locations for repositories that still depend on copied upstream source trees or broader runtime trees. New normal operation should not add new runtime lookup through `vendor/`. As upstream Java and Node.js CLI artifacts become available as single files, repositories should move those artifacts into `skills/<skill-name>/runtime/` and remove the vendored runtime tree.
+
+### Skill Naming Conventions
+
+Skill names should usually match the upstream product name.
+
+Examples:
+
+- `mikuproject`
+- `mikuscore`
+
+Use a more specific name only when the skill intentionally exposes a narrow subset and the product name alone would be misleading.
+
+Avoid generic names such as `planner`, `score`, `xlsx`, or `markdown` for product-specific miku skills. Generic names make accidental activation more likely and weaken the relationship to the upstream product.
+
+### Operation Naming Conventions
+
+Operation names should expose artifact roles, not just file extensions.
+
+Good operation names:
+
+- `draft`
+- `patch`
+- `state`
+- `<format>-import`
+- `<format>-export`
+- `<state-format>-export`
+- `<report-kind>-export`
+- `<bundle-kind>-export`
+
+Avoid ambiguous names when the same extension has multiple meanings.
+
+For example, if two outputs both use `XLSX` but one is structural exchange data and the other is a human-facing report, use names that distinguish those roles.
+
+### Runtime API Conventions
+
+Agent Skills should call stable upstream surfaces.
+
+Preferred surfaces:
+
+- exported Node.js modules
+- documented CLI commands
+- stable global APIs intentionally exposed by bundled single-file or browser-derived runtime
+- Java CLI or Maven plugin when a Java version is the intended local runtime
+
+The skill should not depend on UI DOM state, browser click sequences, or private generated internals when a public API exists.
+
+If a stable upstream API is not available, document the dependency clearly and consider adding the needed API upstream.
+
+### Result Reporting Conventions
+
+Skill responses should be concise but structured.
+
+A useful result usually includes:
+
+- operation performed
+- success or failure
+- key artifact paths or artifact names
+- warning count and short warning summary
+- important diagnostics
+- next state identifier or file path when relevant
+
+Do not dump large JSON or generated artifacts into the conversation unless the user asked for the body or visible handoff is the intended workflow. Prefer file artifacts or concise summaries when the environment supports them.
+
+### Bundle Script Conventions
+
+Bundle scripts should be explicit.
+
+Bundle scripts are packaging and verification commands for the skill package. In the TOBE target shape, they should not assume that TypeScript source, Java source, or the full upstream source tree is present in the skill repository.
+
+The normal inputs are the skill files and the received runtime artifacts:
+
+- single jar Java CLI runtime
+- single JavaScript CLI runtime
+- `SKILL.md`
+- references and small skill-local scripts
+
+Common commands:
+
+```bash
+npm test
+npm run build:bundle
+npm run build:bundle:zip
+```
+
+`npm test` should verify the skill layer and the bundled runtime artifact contracts. `build:bundle` and `build:bundle:zip` should assemble those files into installable skill artifacts. In the TOBE target shape, they should not compile upstream TypeScript or Java source as part of normal skill packaging.
+
+If a current repository still compiles or copies broader upstream runtime contents as part of packaging, that can be tolerated during transition, but it should be treated as a migration item toward single jar and single JavaScript runtime artifacts.
+
+The build script should fail when required runtime files are missing. It should not silently create a skill bundle that cannot run the documented workflow.
+
+## Product-Specific Notes
+
+### Notes Specific to `mikuproject-skills`
+
+`mikuproject-skills` centers on WBS drafting, revision, import / export, and report generation through `mikuproject`.
+
+Important design points:
+
+- skill name is `mikuproject`
+- explicit triggers include `mikuproject`, `miku project`, and documented synonyms
+- activation is explicit and should not trigger from generic planning words alone
+- current MVP keeps `spec`, `draft`, `patch`, and `workbook` in one skill
+- conversation-boundary state is primarily `mikuproject_workbook_json`
+- upstream semantic base remains MS Project XML and `ProjectModel`
+- new WBS creation uses `project_draft_view`
+- existing WBS revision uses local projections and `Patch JSON`
+- file import / export is separate from AI draft / patch workflow
+- structural workbook `XLSX` and report `WBS XLSX` must be named as different artifact roles
+- report outputs such as `WBS XLSX`, `SVG`, `Markdown`, `Mermaid`, and ZIP are derived outputs
+- AI JSON spec retrieval is exposed through upstream core API functions and the `mikuproject ai spec` CLI path, so the skill should prefer those contracts over file search
+- declared `mikuproject` runtime artifacts are checked before broad repository exploration
+- execution backend policy defaults to `cli-preferred`, while still allowing `cli-only`, `mcp-only`, `mcp-preferred`, and `handoff-only` when the user, environment, or repository configuration requires them
+- MCP backend support should use the `mikuproject-mcp` server layer and aligned MCP tools; `mikuproject-skills` remains the Agent Skill workflow layer, not the MCP server implementation
+- the upstream Node.js CLI runtime artifact is produced by `mikuproject` as a single `bundle/mikuproject.mjs` file and should be received by `mikuproject-skills` as `skills/mikuproject/runtime/mikuproject-<version>.mjs`
+- the upstream Java CLI runtime artifact is produced by `mikuproject-java` as `target/mikuproject.jar` and should be received by `mikuproject-skills` as `skills/mikuproject/runtime/mikuproject-<version>.jar`
+
+This skill does not aim to replace the `mikuproject` browser UI. Its center is structured AI-agent operation over the upstream product's core APIs and artifacts.
+
+### Notes Specific to `mikuscore-skills`
+
+`mikuscore-skills` should follow the same relationship to `mikuscore`.
+
+Expected design points:
+
+- skill name is `mikuscore`
+- explicit triggers should name `mikuscore` or a documented `mikuscore` score workflow
+- activation is explicit and should not trigger from generic music theory, generic MIDI editing, ordinary notation discussion, or format names alone
+- preserve `mikuscore` product boundaries as a score conversion and AI handoff tool
+- keep `MusicXML` as the canonical score source and explanation axis across format pairs
+- use `ABC` for current generative-AI full-score handoff and new-score generation
+- state the documented `ABC` baseline as `ABC standard 2.2`, while noting that some standard features remain partial or unimplemented
+- distinguish notation source, AI-facing representation, rendered output, final deliverables, and temporary handoff data
+- operation categories include `convert`, `render`, `diagnostics`, `format-guidance`, `ai-handoff`, and `workflow`
+- prefer the vendored upstream CLI or documented runtime flow before broad repository exploration or generic converter logic
+- in the development repository, check `vendor/mikuscore` first; in an installed bundle, check the skill-local `skills/mikuscore/vendor/mikuscore` runtime before treating the runtime as missing
+- current documented conversion / render routes include `ABC <-> MusicXML`, `ABC -> MIDI`, `MIDI -> MusicXML`, `MusicXML <-> MEI`, `MusicXML <-> LilyPond`, `MusicXML <-> MuseScore`, `MusicXML -> SVG`, and `ABC -> MusicXML -> SVG`
+- keep `MEI`, `LilyPond`, and other experimental paths explicitly marked as experimental when explaining them
+- place default generated files under a workspace-local `mikuscore/` tree: `state/` for handoff or canonical artifacts, `output/` for final deliverables, and `tmp/` for temporary intermediates
+- avoid presenting the skill as a full notation editor
+- make unsupported notation, fallback, and conversion loss visible as diagnostics
+
+The current `mikuscore-skills` repository may still bundle a vendored `mikuscore` runtime tree, including runtime dependencies, as its practical runtime source. That is acceptable as the current state when documented in README, `SKILL.md`, references, and smoke tests. The longer-term shared target remains single runtime artifact handling when upstream provides suitable JavaScript and Java CLI artifacts.
+
+The details should be fixed in the `mikuscore-skills` repository's own `SKILL.md`, README, references, and docs.
+
+## Maintenance Principles
+
+Agent Skills maintenance focuses on keeping the skill aligned with upstream product behavior and agent runtime expectations.
+
+Important maintenance questions:
+
+- Does the skill still activate only for intended requests?
+- Does the declared runtime path still exist in development and bundled installs?
+- Did upstream API names, document kinds, or diagnostics change?
+- Do smoke tests cover the main workflows users actually ask for?
+- Does bundling include all required files and exclude local scratch data?
+- Are artifact names still unambiguous?
+- Are README, `SKILL.md`, references, and tests still synchronized?
+
+When updating upstream, separate the work into:
+
+- upstream sync
+- skill adapter changes
+- docs updates
+- bundle verification
+- smoke test results
+
+This separation makes it easier to tell whether a change came from upstream behavior, skill orchestration, packaging, or documentation.
+
+## Minimal Checklist for a New Agent Skills Repository
+
+Before treating a new `-skills` repository as usable, confirm at least the following.
+
+- Upstream product and semantic center are named
+- Skill name and activation rule are fixed
+- Product boundary and non-goals are written in `SKILL.md`
+- Runtime lookup order is documented
+- Upstream API / CLI / runtime surface is identified
+- Main operations are named by artifact role
+- Conversation state format is chosen, if state is needed
+- Hard errors and soft errors are separated
+- Generated file placement is decided
+- Bundle command exists
+- Smoke test command exists
+- README links to developer docs
+- `workplace/` is present or local scratch policy is otherwise documented
+
+This checklist is intentionally small. The purpose is to prevent an Agent Skill from becoming an unclear collection of prompts and scripts before its relationship to the upstream product is stable.

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-50-mcp-design-v20260501.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-50-mcp-design-v20260501.md
@@ -1,0 +1,862 @@
+# Miku Software MCP Design v20260501
+
+This memo organizes design characteristics commonly expected for MCP server versions in the `miku` software series.
+
+The initial versions of the related tools were created by `Mikuku` and Toshiki Iga.
+
+The current contents are based on the miku main-application design memo, Java application design memo, straight-conversion guide, Agent Skills design memo, and the MCP concepts checked on 2026-04-27.
+
+## Design Summary
+
+The MCP server versions in the `miku` software series can be summarized as follows.
+
+> Protocol adapters that expose miku product operations to MCP clients as tools, resources, and prompts, while preserving upstream semantics, local-first workflows, structured artifacts, diagnostics, and runtime traceability.
+
+What characterizes MCP server versions is not a new product separate from the upstream application. It is a repeated set of constraints.
+
+- Keep the semantic center of the upstream main application
+- Expose product operations through stable MCP tools
+- Expose reusable state, specifications, reports, and generated files through MCP resources
+- Expose a small number of product-specific prompts when useful
+- Keep local stdio execution as the first implementation target
+- Allow HTTP server deployment as a later transport and hosting variant
+- Use Node.js / TypeScript as the standard MCP server implementation choice
+- Use upstream public APIs, CLI, or bundled runtime artifacts rather than duplicating product logic
+- Treat the MCP server as a thin protocol adapter
+- Prefer stateless or short-lived execution over durable server-side product state
+- Treat client-provided files and data as the source of truth unless a product-specific design explicitly says otherwise
+- Keep local and server deployments aligned around the same tool contracts
+- Preserve diagnostics, warnings, and artifact roles in structured results
+
+For the current `mikuproject-mcp` repository, this means the MCP server is
+implemented in Node.js / TypeScript. Runtime artifacts live under `runtime/`;
+`packages/java/` is a placeholder only, not a second MCP server implementation
+target.
+
+## Role of This Document
+
+This document is not a detailed specification for one MCP repository. Repository-specific behavior should be checked in each MCP server README, package metadata, tool schema, and product-specific documents.
+
+Use the shared design documents together as follows.
+
+- `docs/miku-soft-10-mainapp-design-v20260501.md`
+  - describes the upstream product design and semantic center
+- `docs/miku-soft-40-agentskills-design-v20260501.md`
+  - describes how Agent Skills versions expose miku workflows to AI agents
+- `docs/miku-soft-50-mcp-design-v20260501.md`
+  - describes how MCP server versions should expose miku workflows to MCP clients
+
+This document separates the following levels.
+
+- **Cross-cutting principles**: design policies that should generally be kept for MCP server versions.
+- **Recommended conventions**: transport, tool, resource, state, runtime, and packaging shapes that make maintenance easier.
+- **Observed tendencies**: design habits visible in current miku repositories and MCP usage.
+- **Product-specific notes**: design decisions for specific MCP products, recorded as concrete examples.
+
+When a specification is unclear, first check whether the decision preserves upstream meaning and keeps the MCP surface stable for clients. For products with a documented CLI, look first to the CLI command tree as the source of truth before inventing MCP method names or operation groups. MCP convenience is important, but it should not hide unsupported behavior, discard diagnostics, or make local and server deployments drift into different products.
+
+## MCP Specification Authority
+
+This document defines the miku-series design stance for MCP server products. It does not replace the external MCP protocol specification.
+
+When implementing an MCP server in a miku-series repository, follow MCP-related authorities in the following order.
+
+1. The official specification published at `modelcontextprotocol.io`
+2. The types and schemas provided by the official MCP SDKs
+3. Changes accepted through MCP governance and Specification Enhancement Proposals
+4. Optional compatibility notes for individual MCP clients such as Claude Desktop, Claude Code, IDE clients, or other host applications
+
+The official MCP specification is the primary contract. Client-specific behavior is optional compatibility material, not a source of product semantics and not a reason to change the core protocol shape.
+
+When supporting a specific client, implement the support as a compatibility layer or documented operational note. Do not let client-specific behavior redefine tool names, input schemas, result schemas, resource URI roles, artifact roles, or error categories. If a client requires a workaround, keep the official MCP contract intact and document the workaround as client compatibility behavior.
+
+The preferred order is:
+
+1. Implement the official MCP contract.
+2. Verify behavior with official SDK types and schemas.
+3. Add client compatibility checks where useful.
+4. Document any client-specific behavior separately from the protocol contract.
+
+## Scope
+
+The series whose names start with `miku` includes several related product types.
+
+Main applications:
+
+- `miku-abc-player`
+- `miku-docx2md`
+- `miku-indexgen`
+- `miku-unicode-guard`
+- `miku-xlsx2md`
+- `mikuproject`
+- `mikuscore`
+
+Agent Skills versions:
+
+- `mikuproject-skills`
+- `mikuscore-skills`
+
+MCP server versions:
+
+- `mikuproject-mcp`
+
+Projects with the `-mcp` suffix are positioned as MCP server adapters for original suffixless tools or their runtime artifacts.
+
+For `mikuproject-mcp`, the server implementation is Node.js / TypeScript.
+`packages/java/` is intentionally only a placeholder.
+
+This document focuses on MCP server versions. It does not define the Web UI conventions for upstream main applications, Java packaging conventions for Java application versions, or skill packaging conventions for Agent Skills repositories.
+
+## Shared Direction
+
+MCP server versions continue the shared direction of the miku series: small local bridge tools that convert, extract, inspect, normalize, or export domain files and domain data.
+
+The MCP version emphasizes the parts that fit MCP operation particularly well.
+
+- model-callable tools
+- application-readable resources
+- user-selectable prompts where useful
+- structured JSON input and output schemas
+- local import / validate / export operations
+- resource links for generated artifacts
+- diagnostics and warnings as structured results
+- repeatable file-based operation
+- request-scoped or session-scoped data processing
+- command execution on behalf of the MCP client
+- stdio local server execution
+- optional HTTP server deployment when remote access is required
+
+An MCP version should not become a generic planner, generic converter, hosted replacement application, or independent semantic implementation. Its value is that MCP clients can use the upstream miku product correctly through stable tool and resource contracts.
+
+For most miku MCP servers, the default execution model is simple: the MCP client
+provides the input files, structured data, or resource references for each
+operation; the MCP server validates the request, invokes the upstream product
+API, CLI, or bundled runtime through fixed adapter code, and returns generated
+artifacts, diagnostics, summaries, or transformed data. The MCP server should
+not become the durable owner of the product data unless that responsibility is
+explicitly designed for a specific product.
+
+## Relationship to Main Applications
+
+MCP server versions are downstream of miku main applications.
+
+The upstream main application owns the product semantics, canonical source, core conversions, output policy, and limitations. The MCP client or calling environment usually owns the concrete input and output files for a run. The MCP server owns protocol exposure, tool schema, resource naming, transport handling, runtime discovery, command invocation, and result formatting.
+
+The preferred relationship is as follows.
+
+- upstream main application provides core APIs, CLI, bundled runtime, or stable artifacts
+- MCP server calls those upstream surfaces
+- MCP server exposes product operations as tools
+- MCP server exposes reusable state and artifacts as resources
+- MCP server may expose product-specific workflow prompts
+- MCP server returns diagnostics, warnings, hard errors, and generated artifact links in a structured form
+- MCP server treats durable product data as client-owned unless a product-specific design assigns persistence to the server
+- MCP server keeps intermediate state request-scoped or session-scoped where practical
+- MCP server does not reimplement core conversion behavior unless no upstream surface exists
+
+If an upstream capability is missing, the preferred order is to request or implement the capability on the upstream side, expose it as a stable upstream API, and then let the MCP server call it. MCP servers should not silently add upstream product capabilities on the MCP side. MCP-local workaround code should be treated as temporary or product-specific, not as the new semantic center.
+
+## Relationship to Agent Skills
+
+Agent Skills and MCP servers are closely related, but they are not the same layer.
+
+Agent Skills are instruction and workflow packages for agents. They explain when to activate a product-specific workflow, which runtime artifacts to use, how to manage intermediate files, and how to avoid confusing artifact roles.
+
+MCP servers are protocol adapters. They expose callable tools, readable resources, and optional prompts to MCP clients.
+
+The preferred relationship is as follows.
+
+- Agent Skills may continue to guide agents that can read `SKILL.md` and run local commands directly
+- MCP servers should serve clients that prefer a standard tool/resource/prompt protocol
+- both should call the same upstream runtime artifacts or public APIs when possible
+- both should use the same product vocabulary and artifact roles
+- neither should become the semantic owner of the product
+
+For a product such as `mikuproject`, an Agent Skills repository may include a local MCP server, or a separate `mikuproject-mcp` repository may provide one. In either case, the MCP contract should stay aligned with the Agent Skills operation map and upstream CLI contracts.
+
+## Role of MCP Servers
+
+In this document, an MCP server means a `miku` repository or package with an MCP server entrypoint that provides product operations through MCP.
+
+An MCP server usually exposes one or more of the following.
+
+- stdio server entrypoint for local MCP clients
+- HTTP server entrypoint for hosted or remote MCP clients
+- tool definitions with JSON input schemas
+- structured tool results and optional output schemas
+- resource definitions for state, specifications, reports, and generated files
+- resource templates for session or workspace-scoped artifacts
+- prompt definitions for product-specific workflows
+- runtime adapters for bundled CLI artifacts or public APIs
+- smoke tests for protocol startup and core tool calls
+
+The MCP server is not primarily the browser UI, not primarily a runtime port, and not primarily an Agent Skill. For miku MCP repositories, Node.js / TypeScript is the normal MCP server implementation choice. The server can call bundled or configured runtime artifacts if that is the natural way to execute the upstream product, but the MCP layer itself should remain thin.
+
+The center of an MCP server is reliable protocol adaptation: receive a typed
+tool call, validate arguments, call the upstream runtime, expose resulting
+artifacts as resources, and return diagnostics without hiding important
+constraints. When state is needed, prefer explicit input and output artifacts or
+short-lived session state over implicit durable server-side product state.
+
+## Cross-Cutting Principles
+
+miku MCP servers emphasize the following cross-cutting principles.
+
+1. Preserve the semantic center and product boundary of the upstream main application.
+2. Treat MCP as a protocol adapter, not as a replacement implementation.
+3. Keep MCP tool contracts stable across local stdio and HTTP server deployments.
+4. Prefer local stdio execution as the first implementation target.
+5. Add HTTP server deployment only with explicit session, storage, authentication, and isolation boundaries.
+6. Use structured input schemas, structured results, diagnostics, and resource links instead of loose prose.
+7. Distinguish canonical source, conversation state, MCP resources, primary output, reports, and temporary files.
+8. Make runtime selection, artifact storage, smoke testing, and upstream synchronization explainable.
+
+### Basic Philosophy of MCP Servers
+
+MCP server versions emphasize the following philosophy.
+
+- Run product operations locally when practical
+- Keep the upstream product meaning recognizable
+- Use upstream API or CLI before writing MCP-local conversion logic
+- Expose only product-specific operations that are useful to MCP clients
+- Keep tool names stable, explicit, and product-prefixed
+- Derive tool names from the upstream CLI command tree when a documented CLI
+  exists
+- Keep intermediate JSON internal when direct tool composition is possible
+- Return generated files as resources or resource links when practical
+- Preserve diagnostics and warnings as part of the result
+- Keep state and generated files easy to save, compare, and rerun
+- Keep local and hosted deployments aligned around the same tool contracts
+
+The value of an MCP server version is not that it can answer a domain question conversationally in a generic way. It is that MCP clients can safely call specific miku workflows through structured operations that are faithful to the upstream product.
+
+### Common Principles for MCP Servers
+
+MCP servers use the following principles as defaults.
+
+- Use a `-mcp` suffix when the MCP server is a separate repository or package
+- Keep the product name in tool names
+- When a documented CLI exists, derive MCP tool names from the canonical CLI
+  command tree
+- Use stdio transport as the first local implementation
+- Treat HTTP transport as an additional deployment form, not a separate product contract
+- Use Node.js / TypeScript as the standard implementation choice for the MCP server
+- Prefer a single Node.js / TypeScript MCP server unless a concrete product constraint justifies another server implementation
+- Prefer bundled or configured runtime artifacts when local, reproducible execution needs them
+- Prefer upstream public APIs, stable global APIs, or documented CLI commands
+- Align the MCP package version with the primary bundled Node.js CLI runtime
+  version by default
+- Keep tool schemas and result schemas under version control
+- Keep repository-level README user-facing and developer details under `docs/`
+- Use `workplace/` or a configured workspace root for local scratch data, uploaded files, generated outputs, and verification files
+
+These are defaults for the miku MCP series. Individual products may add product-specific conventions, but should not change these foundations casually.
+
+## Transport Principles
+
+MCP is a protocol, not a synonym for an HTTP server.
+
+The first transport for miku MCP servers should usually be local stdio.
+
+Local stdio is appropriate when:
+
+- the user runs an MCP client on the same machine
+- the product reads and writes local files
+- the upstream runtime is available as a local executable artifact or CLI command
+- the workflow benefits from local-first processing and simple installation
+
+HTTP transport is appropriate when:
+
+- multiple clients need remote access
+- the server owns session storage
+- files are uploaded to a controlled workspace
+- authentication, quota, and audit requirements are explicit
+- the deployment environment can isolate user workspaces safely
+
+Local stdio and HTTP deployments should share the same tool names and core input/output contracts. Differences should be limited to transport, file reference handling, session identity, storage, and authentication.
+
+## Local Stdio Server Principles
+
+The local stdio server is the preferred MVP shape.
+
+It should:
+
+- start as a local process launched by the MCP client
+- communicate over standard input and standard output
+- avoid requiring a network listener
+- discover bundled or configured runtime artifacts
+- call upstream CLI or APIs with explicit file paths
+- confine file reads and writes to declared workspace roots where practical
+- return generated file references as resources or resource links
+
+The local stdio server should not behave like a long-running public web service. It is a local adapter process whose authority comes from the user and the MCP client configuration.
+
+## HTTP Server Principles
+
+The HTTP server is a deployment variant, not the initial semantic center.
+
+For miku MCP servers, the preferred HTTP shape is an ephemeral execution
+adapter. The client remains the owner of the canonical product files and data.
+The HTTP server receives explicit inputs, uploads, or session-scoped resource
+references, runs the configured product runtime or CLI, and returns generated
+artifacts, transformed data, and diagnostics. It should not become a durable
+product database or the source of truth for current product state unless a
+product-specific design explicitly assigns that responsibility.
+
+An HTTP MCP server must define the following before it is treated as production-ready.
+
+- authentication and authorization model
+- session identity
+- workspace isolation
+- uploaded file lifecycle
+- generated artifact lifecycle
+- maximum input and output sizes
+- cleanup policy
+- audit or trace policy when needed
+- runtime sandboxing or equivalent execution boundary
+- user-visible confirmation policy for destructive operations when the client supports it
+
+HTTP deployment should not expose arbitrary local filesystem paths from the host. It should prefer session-scoped resource URIs, upload identifiers, or controlled workspace-relative paths.
+
+Mutation-style tools in an HTTP deployment should prefer input-to-output
+semantics: given base data and a patch, edit request, conversion request, or
+other operation input, return the updated data, diff, summary, diagnostics, and
+generated artifacts for the client to persist. Server-side product state should
+be request-scoped or session-scoped, short-lived, and safe to discard.
+
+### HTTP MVP Implementation Guidance
+
+The first `mikuproject-mcp` Streamable HTTP implementation confirmed that a miku
+MCP HTTP MVP can stay small when it follows the stateless execution-adapter
+model.
+
+Recommended first implementation shape:
+
+- keep the stdio entrypoint unchanged
+- add HTTP as a separate entrypoint, not as a replacement for stdio
+- expose a single Streamable HTTP endpoint such as `/mcp`
+- bind to `127.0.0.1` by default
+- use stateless transport unless server-to-client requests, resumability, or
+  durable per-client state is explicitly needed
+- create or reset MCP server state per request when the product operation can be
+  handled as input-to-output processing
+- do not accept client-provided host file path arguments in HTTP `tools/call`
+  when inline content or controlled resource references can represent the input
+- prefer inline JSON/text content and Base64 content for stateless HTTP calls
+- use request-scoped temporary workspaces only for adapter-internal runtime
+  files, such as materializing one inline input when an upstream CLI accepts
+  only one stdin payload for a multi-input operation
+- remove request-scoped temporary workspaces after the response completes
+- do not issue `Mcp-Session-Id` in the stateless MVP
+- validate `Origin` and reject non-local origins unless explicitly allowlisted
+- set an HTTP request body size limit before passing input to the MCP transport
+- set an HTTP response body size limit before returning large content-mode or
+  Base64 artifacts
+- keep tool names, input schemas, resource URIs, prompt names, result shapes,
+  diagnostics, and artifact roles identical to stdio
+- verify initialize, tool listing, representative tool calls, resource reads,
+  prompt listing, invalid-origin rejection, request-size rejection,
+  response-size rejection, host-path rejection, and temporary workspace cleanup
+  through an HTTP client test
+
+If a stateless HTTP profile deletes temporary workspaces immediately after each
+response, returned server-local paths are not durable artifact handles. Hosted
+profiles that need clients to retrieve generated files should add explicit
+content-return, download, or resource-retention behavior.
+
+Invalid session behavior is not applicable to a stateless MVP that does not
+issue `Mcp-Session-Id`. If a later profile enables stateful HTTP sessions,
+invalid session behavior should be designed and tested with that session model.
+
+This shape is intentionally not a hosted multi-user design. Remote deployment
+still requires the broader HTTP server principles above: authentication,
+workspace isolation, upload lifecycle, storage policy, cleanup, audit, and
+runtime isolation.
+
+## Tool Design Principles
+
+MCP tools are the main execution surface.
+
+Tool names should be product-prefixed and stable.
+
+When a product has a documented CLI, first treat the CLI command tree as the
+source of truth. MCP method names should be derived from that tree before any
+MCP-specific shortening, grouping, or convenience naming is considered.
+
+For products with a documented CLI, MCP tool names should preserve the CLI
+command tree. Use this form:
+
+```text
+<product>_<cli command tokens joined by "_">
+```
+
+Omit only the runtime launcher, such as `node mikuproject.mjs` or
+another runtime command. Convert hyphenated CLI tokens to snake_case.
+
+The CLI command group is part of the operation name. Do not shorten
+`ai detect-kind` to `detect_kind`, `ai validate-patch` to `validate_patch`, or
+`state apply-patch` to `apply_patch` in the MCP surface. Shorter names hide the
+upstream command structure and make MCP, CLI diagnostics, tests, and Agent
+Skills documentation harder to compare.
+
+Examples:
+
+- `mikuproject_version`
+- `mikuproject_ai_spec`
+- `mikuproject_ai_detect_kind`
+- `mikuproject_state_from_draft`
+- `mikuproject_ai_export_project_overview`
+- `mikuproject_ai_export_bundle`
+- `mikuproject_ai_export_task_edit`
+- `mikuproject_ai_export_phase_detail`
+- `mikuproject_ai_validate_patch`
+- `mikuproject_state_apply_patch`
+- `mikuproject_state_diff`
+- `mikuproject_state_summarize`
+- `mikuproject_export_workbook_json`
+- `mikuproject_export_xml`
+- `mikuproject_export_xlsx`
+- `mikuproject_import_xlsx`
+- `mikuproject_report_wbs_xlsx`
+- `mikuproject_report_daily_svg`
+- `mikuproject_report_weekly_svg`
+- `mikuproject_report_monthly_calendar_svg`
+- `mikuproject_report_all`
+- `mikuproject_report_wbs_markdown`
+- `mikuproject_report_mermaid`
+
+Tool input should use JSON Schema. Tool results should return structured content when practical. For compatibility with clients that primarily display text, structured results may also be serialized into a text content block.
+
+Tools should prefer explicit argument names over positional behavior. Large input and output should be passed by file path, resource URI, upload ID, or resource link instead of being forced into chat-visible text.
+
+## Resource Design Principles
+
+MCP resources should expose reusable state and artifacts.
+
+Typical resources include:
+
+- AI-facing specifications
+- current workbook state
+- saved workbook states
+- imported canonical source files
+- generated report files
+- diagnostics logs
+- operation summaries
+
+Resource URIs should distinguish artifact roles.
+
+Examples:
+
+- `mikuproject://spec/ai-json`
+- `mikuproject://state/current`
+- `mikuproject://state/{name}`
+- `mikuproject://report/{name}`
+- `mikuproject://diagnostics/{operationId}`
+
+When a resource maps to a real local file, the server may return a `file://` resource link only when the client is expected to access that file directly. Otherwise, a product-specific URI should be preferred so that the server remains the controlled access point.
+
+## Prompt Design Principles
+
+MCP prompts should be small and product-specific.
+
+Prompts are useful when a client wants user-selectable workflow templates. They should not become the primary location for product semantics.
+
+Typical prompts include:
+
+- create a new product-specific draft from user requirements
+- revise an existing state using a small projection and patch
+- review a product artifact using documented diagnostics
+
+For products that already expose AI-facing specifications through upstream APIs or CLI commands, the MCP server should expose that specification as a tool or resource. Prompt text can reference the specification, but should not duplicate a large schema if the upstream product already provides a stable retrieval path.
+
+## Runtime Principles
+
+MCP servers should use declared runtime artifacts before broad repository exploration.
+
+The preferred order is as follows.
+
+1. Check the MCP server configuration
+2. Check bundled runtime artifacts declared by the package under `runtime/`
+3. Use upstream public APIs, stable globals, or documented CLI/runtime flows
+4. Use MCP-local helpers only when they are the intended adapter layer
+5. Search broadly for alternatives only when the declared runtime path is missing or unusable
+
+When multiple runtime artifacts are available, runtime selection is an execution
+policy, not a semantic priority. The upstream main application remains the
+semantic center. Runtime differences should be reported as capability or
+compatibility diagnostics.
+
+When an MCP repository bundles upstream runtime artifacts, `runtime/` is the preferred repository directory. The name reflects that these files are execution artifacts used by the MCP adapter, not general vendored source material. Use `vendor/` only when a repository intentionally vendors third-party source or dependency material.
+
+Recommended runtime artifact layout:
+
+```text
+runtime/
+  product-runtime/
+    runnable-artifact
+    source-traceability-artifact
+```
+
+`runtime/` is the installed runtime surface for the MCP adapter. It should
+contain runnable artifacts and, when available, paired source traceability
+artifacts. The MCP server executes only runnable artifacts, but source
+traceability artifacts can keep runtime bundles auditable without requiring the
+full upstream source checkout.
+
+The exact filenames may differ by product, but the artifact role should remain clear in directory names, package metadata, and diagnostics.
+
+## State and Artifact Principles
+
+MCP servers distinguish several kinds of data.
+
+- canonical source or semantic base owned by the upstream product
+- MCP server session state
+- AI-facing projection or draft document
+- patch or edit document returned by AI
+- primary product output
+- report or presentation output
+- diagnostics and warnings
+- temporary files and local scratch outputs
+
+These roles should not be collapsed only because they are all represented as JSON or files.
+
+For local stdio deployment, file paths can be a practical state boundary. For
+HTTP deployment, inline content, Base64 content, session-scoped resource URIs,
+or upload identifiers are usually safer than arbitrary host paths. Temporary
+files created from inline HTTP inputs should be treated as adapter-internal
+runtime bridges, not as durable artifacts or public resource handles.
+
+For products such as `mikuproject`, `mikuproject_workbook_json` may be the practical MCP state handoff format, while `MS Project XML` remains the product's semantic base. The MCP server should make that distinction visible in naming, docs, and tool descriptions.
+
+## Local and Server Variant Principles
+
+A separate MCP product may support both local and server deployments.
+
+The recommended split is:
+
+- core tool definitions
+- core input and result schemas
+- runtime adapter interface
+- local stdio entrypoint
+- HTTP entrypoint
+- storage adapter
+- session adapter
+
+Local and server variants should not create different operation vocabularies. They should share the same core tool names and result shapes.
+
+Variant-specific differences should be limited to:
+
+- transport
+- file reference representation
+- workspace and session scope
+- authentication
+- storage persistence
+- artifact lifetime
+- runtime isolation
+
+If a capability is not safe or practical in one deployment form, the server should report an explicit capability or policy error rather than silently changing behavior.
+
+## Implementation Language Principles
+
+MCP is a protocol, not a language-specific product shape. A miku MCP server may be implemented in TypeScript, Java, or another language when that language is appropriate for the repository and runtime environment.
+
+For miku MCP repositories, Node.js / TypeScript is the standard choice because
+it gives a direct path to local stdio MCP servers, official SDK alignment, JSON
+Schema handling, package metadata, and smoke testing.
+
+Do not add a second MCP server implementation unless a concrete product,
+distribution, or runtime constraint requires it. If that happens, decide the
+language-specific porting rules at that time, using the checked-in MCP contract
+as the stable boundary.
+
+## Recommended Repository Layout
+
+When a miku MCP repository uses a Node.js / TypeScript implementation and keeps room for possible future implementation variants, use a repository layout that separates the shared MCP contract from language-specific server code and runtime artifacts.
+
+Recommended layout:
+
+```text
+mikuproject-mcp/
+  docs/
+  contract/
+    tools/
+    results/
+    resources/
+    errors/
+  packages/
+    node/
+      src/
+      test/
+    java/
+      .gitkeep
+  runtime/
+    product-runtime/
+  workplace/
+```
+
+The intended responsibilities are:
+
+- `contract/`
+  - owns shared MCP tool names, input schemas, result shapes, resource URI conventions, prompt names, artifact roles, diagnostics, and error categories
+- `packages/node/`
+  - owns the Node.js / TypeScript MCP server implementation
+  - is usually the first implementation and initial reference implementation
+- `packages/java/`
+  - placeholder only
+- `runtime/`
+  - stores configured or bundled upstream execution artifacts used by the MCP adapters
+- `workplace/`
+  - stores local scratch files, generated outputs, and optional upstream checkouts
+
+The shared MCP contract should not live only as implicit TypeScript code. Keep the contract explicit enough that the MCP surface remains clear even if implementation choices change later.
+
+## Runtime Capability Boundary Principles
+
+When multiple upstream runtime paths exist, the core MCP contract should be limited to operations that are available across the supported runtime paths needed for the product's normal fallback policy.
+
+Runtime-specific operations may be added later as optional, capability-gated extensions, but they should be clearly separated from the core MCP contract. Such operations should:
+
+- be documented as optional extensions
+- report unavailable capability clearly when the selected runtime does not support them
+- avoid changing core tool names, schemas, result shapes, resource URI conventions, artifact roles, or error categories
+- avoid becoming required for the normal local stdio MVP workflow
+
+## Error Handling Principles
+
+MCP servers should separate the following.
+
+- invalid tool arguments
+- unsupported document kind
+- missing base state
+- upstream runtime failure
+- upstream validation error
+- upstream warning
+- file access or storage policy error
+- transport or session error
+
+Hard errors should make the tool call fail in a way the MCP client can surface clearly.
+
+Soft errors and upstream warnings should be returned in structured results when the operation can still produce a meaningful artifact. They should not be discarded only because the requested output file was generated.
+
+## Security and Trust Principles
+
+MCP servers expose executable operations to AI clients, so security boundaries must be explicit.
+
+Local stdio servers should:
+
+- avoid reading arbitrary files unless the user or client provides them explicitly
+- avoid writing outside configured workspace or output roots when practical
+- avoid accepting shell fragments or raw command lines from tool arguments
+- call upstream runtimes through fixed argument arrays, not string-built shell commands
+- report generated paths clearly
+
+HTTP servers should additionally:
+
+- authenticate clients or users
+- isolate sessions
+- restrict file access to controlled storage
+- enforce upload and output size limits
+- clean up temporary artifacts
+- prevent cross-user resource access
+- treat uploaded files as untrusted input
+
+MCP tool descriptions and annotations are not a substitute for server-side validation.
+
+## Product Boundary Principles
+
+MCP servers must preserve the product boundary of the upstream miku tool.
+
+Examples:
+
+- `mikuproject-mcp` exposes WBS import, draft, patch, state, and report operations; it is not a full project-management server.
+- `mikuscore-mcp` would expose score conversion, inspection, and handoff operations; it would not become a full notation editor.
+- `miku-xlsx2md-mcp` would expose workbook-to-Markdown extraction and diagnostics; it would not become a general spreadsheet automation server.
+
+If the MCP server starts needing broad domain features that the upstream application does not own, treat that as a product design issue rather than hiding it in MCP tool code.
+
+## Recommended MVP Shape
+
+For a first miku MCP server, use this shape.
+
+- local stdio transport
+- product-prefixed tools
+- JSON Schema input definitions
+- structured tool results
+- resource links for generated artifacts
+- bundled or configured runtime artifact lookup
+- smoke test for server startup
+- smoke test for one read-only tool
+- smoke test for one state-changing tool with temporary files
+
+For `mikuproject-mcp`, the MVP tools should be close to the Agent Skills MVP operation set.
+
+- `mikuproject_ai_spec`
+- `mikuproject_ai_detect_kind`
+- `mikuproject_version`
+- `mikuproject_state_from_draft`
+- `mikuproject_ai_export_project_overview`
+- `mikuproject_ai_export_bundle`
+- `mikuproject_ai_export_task_edit`
+- `mikuproject_ai_export_phase_detail`
+- `mikuproject_ai_validate_patch`
+- `mikuproject_state_apply_patch`
+- `mikuproject_state_diff`
+- `mikuproject_state_summarize`
+- `mikuproject_export_workbook_json`
+- `mikuproject_export_xml`
+- `mikuproject_export_xlsx`
+- `mikuproject_import_xlsx`
+- `mikuproject_report_wbs_xlsx`
+- `mikuproject_report_daily_svg`
+- `mikuproject_report_weekly_svg`
+- `mikuproject_report_monthly_calendar_svg`
+- `mikuproject_report_all`
+- `mikuproject_report_wbs_markdown`
+- `mikuproject_report_mermaid`
+
+The current first version includes core state workflow tools plus file
+import/export and report outputs that are available in the bundled Java and
+Node runtime artifacts. Additional CLI operations such as XML import and merge
+imports can remain later capability-gated extensions.
+
+## Out of Scope for the First Version
+
+The first version should not include:
+
+- broad hosted multi-tenant operation
+- custom user management
+- external AI model invocation
+- API key management for model providers
+- a browser UI replacement
+- full domain editing outside upstream-supported operations
+- automatic workflow planning beyond exposed tools and prompts
+- broad filesystem browsing
+- parallel implementation of upstream conversion logic
+
+These may become useful later, but they should not be allowed to blur the initial MCP contract.
+
+## Product-Specific Note: mikuproject-mcp
+
+`mikuproject-mcp` should expose `mikuproject` operations to MCP clients.
+
+The semantic center remains upstream `mikuproject`. The practical MCP state handoff format may be `mikuproject_workbook_json`. `MS Project XML` remains the semantic base and compatibility format for the product.
+
+`mikuproject-mcp` may be developed as an independent repository and product, rather than as a subdirectory of `mikuproject-skills`.
+
+This independence means that `mikuproject-mcp` owns its MCP-specific entrypoints, schemas, transport handling, and adapter code. It does not mean that `mikuproject-mcp` owns the product semantics of `mikuproject`.
+
+The preferred repository relationship is as follows.
+
+- `mikuproject`
+  - owns the upstream product semantics
+  - owns the canonical domain behavior, conversion policy, report policy, and AI-facing product contracts
+- `mikuproject-skills`
+  - provides the Agent Skills workflow design reference
+  - records operation maps, state-handling rules, file workflow rules, and agent-facing boundaries
+- `mikuproject-mcp`
+  - owns the MCP server entrypoints
+  - owns tool, resource, and prompt definitions
+  - owns MCP input and output schemas
+  - owns local stdio transport and optional HTTP transport
+  - owns session, workspace, storage, and runtime adapter policy for MCP deployments
+
+For development, `mikuproject-mcp` may use local upstream checkouts under `workplace/upstream/`.
+
+When cloning upstream repositories for local reference, clone them into the prescribed `workplace/upstream/` directory. Do not clone upstream repositories into the repository root, `runtime/`, `packages/`, or `contract/`.
+
+Recommended layout:
+
+```text
+mikuproject-mcp/
+  contract/
+    tools/
+    results/
+    resources/
+    errors/
+  packages/
+    node/
+    java/
+  runtime/
+    product-runtime/
+  workplace/
+    upstream/
+      mikuproject/
+      mikuproject-skills/
+```
+
+`contract/` is the shared MCP contract. `packages/node/` is the TypeScript implementation and reference implementation. `packages/java/` is a placeholder only.
+
+Files under `runtime/` are the configured or bundled execution artifacts used by the MCP server. Checkouts under `workplace/upstream/` are reference material and local development inputs. They should normally remain outside Git tracking except for placeholder files needed to keep the workspace directory shape.
+
+Use the following clone destinations:
+
+```text
+workplace/upstream/mikuproject/
+workplace/upstream/mikuproject-skills/
+```
+
+The upstream checkouts should be used to inspect and synchronize the following.
+
+- upstream `mikuproject` CLI contracts and AI-facing specifications
+- upstream `mikuproject` product behavior and artifact roles
+- `mikuproject-skills` operation map and workflow boundary rules
+- runtime artifact generation and smoke-test expectations
+
+The MCP repository may copy, bundle, or download runtime artifacts into `runtime/` according to its own packaging policy, but it should not treat `workplace/upstream/` itself as the installed runtime surface.
+
+The clean responsibility split is:
+
+```text
+mikuproject
+  -> upstream semantic owner
+
+mikuproject-skills
+  -> Agent Skills workflow design reference
+
+mikuproject-mcp
+  -> MCP protocol adapter
+```
+
+The first implementation should borrow heavily from `mikuproject-skills` design material, especially:
+
+- operation names and operation grouping
+- `mikuproject_workbook_json` as the practical state boundary
+- distinction between structural workbook `XLSX` and `WBS XLSX` report output
+- distinction between draft, patch, projection, workbook, report, and diagnostics artifacts
+- default local output discipline for state, report, and temporary files
+
+The first implementation should prefer local stdio transport. It should call
+runtime artifacts through fixed runtime adapter code. It should keep the tool
+names aligned with the existing `mikuproject-skills` operation map and upstream
+CLI correspondence.
+
+The CLI command tree is the naming source for MCP tools:
+
+- `ai spec` becomes `mikuproject_ai_spec`
+- `ai detect-kind` becomes `mikuproject_ai_detect_kind`
+- `state from-draft` becomes `mikuproject_state_from_draft`
+- `ai validate-patch` becomes `mikuproject_ai_validate_patch`
+- `state apply-patch` becomes `mikuproject_state_apply_patch`
+
+For `mikuproject-mcp`, the MCP server implementation is TypeScript. The
+TypeScript version establishes the MCP contract for tools, schemas, result
+shapes, resources, diagnostics, and local workspace behavior.
+
+`packages/java/` remains a placeholder only. Do not predesign another MCP server
+implementation in the current Node server documentation. If a concrete future
+requirement appears, handle that implementation design at that time.
+
+As of 2026-05-01, `mikuproject-mcp` includes a localhost-oriented stateless
+Streamable HTTP entrypoint. It keeps the same core tool names and follows the
+general miku MCP execution model. The HTTP entrypoint is a short-lived adapter
+for client-owned project data: it accepts explicit inline workbook/WBS/patch
+inputs or Base64 content, invokes the existing `mikuproject` runtime commands,
+and returns generated artifacts, diagnostics, diffs, summaries, or updated state
+for the client to store.
+
+The current HTTP entrypoint does not issue `Mcp-Session-Id`, rejects
+client-provided host path arguments for `tools/call`, and uses request-scoped
+temporary files only as adapter-internal runtime inputs when the upstream CLI
+requires a path. A hosted or non-localhost profile remains out of scope until
+authentication, storage policy, upload handling, artifact lifecycle management,
+audit, and runtime isolation are explicitly designed.

--- a/skills/igapyon-miku-soft-developer/references/new-project-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/new-project-workflow.md
@@ -1,0 +1,36 @@
+# New miku-soft Project Workflow
+
+Use this short workflow only after `igapyon-miku-soft-developer` has been explicitly activated.
+
+Detailed design guidance lives under [miku-soft-basic/](miku-soft-basic/). Keep this file as a routing checklist, not a second copy of the basic documents.
+
+## Before Creating Files
+
+Resolve the minimum facts needed to start:
+
+- project name and repository location
+- primary input and output
+- first delivery surface: main app, Java app, Agent Skill, MCP server, or a combination
+- whether README, docs, TODO, and workplace conventions should be initialized now
+
+Then read the relevant basic document selected by [architecture-rules.md](architecture-rules.md).
+
+## Basic Document Copy
+
+When creating a new miku-soft project or initializing a repository as miku-soft, copy the bundled basic documents from [miku-soft-basic/](miku-soft-basic/) into the target repository's `docs/` directory.
+
+- Copy the current newest file for each numbered topic.
+- Keep the `miku-soft-*.md` filenames unchanged.
+- Do not create a synchronization script.
+- After copying, mention the copied source and destination files.
+- If the target repository already has `miku-soft-*.md` files, compare versions and ask before replacing materially different same-version files.
+
+## Creation Checklist
+
+1. Inspect the target directory and git status.
+2. Create only the repository skeleton needed for the requested first delivery surface.
+3. Put product behavior in product code, public APIs, CLI, or bundled runtime artifacts, not in skill prose.
+4. Copy the miku-soft basic documents into `docs/` when initializing a miku-soft repository.
+5. Add README and TODO entries that match the actual initial state.
+6. Add focused tests or regression commands when there is executable behavior to protect.
+7. Regenerate any repository indexes required by the target repository.

--- a/skills/igapyon-miku-soft-developer/references/repo-operations.md
+++ b/skills/igapyon-miku-soft-developer/references/repo-operations.md
@@ -1,0 +1,15 @@
+# miku-soft Repository Operations
+
+Use this short repository note only after `igapyon-miku-soft-developer` has been explicitly activated.
+
+`igapyon-repo-conventions` is a prerequisite baseline for this skill. Apply its repository rules for `.gitignore`, `.DS_Store`, `workplace/`, `workplace/.gitkeep`, `.codex/skills/`, Java / Maven `.mvn/jvm.config`, and README documentation of repository operation rules.
+
+This file only records miku-soft-specific additions.
+
+## miku-soft Additions
+
+- For new miku-soft projects, copy the bundled basic documents from [miku-soft-basic/](miku-soft-basic/) into the target repository's `docs/` directory as described in [new-project-workflow.md](new-project-workflow.md).
+- Keep miku-soft basic document filenames unchanged when copying them into `docs/`.
+- Use README and TODO for the actual project state; avoid restating broad miku-soft theory that already lives in the basic documents.
+- Record unresolved miku-soft design, entrypoint, diagnostics, artifact-role, parity, or verification follow-ups in `TODO.md` or project docs.
+- Regenerate `index.json` or similar indexes with the target repository's documented command when indexed files change.


### PR DESCRIPTION
## 概要

miku-soft project の新規作成・既存保守ワークフロー向けに、`igapyon-miku-soft-developer` skill を追加しました。

この skill は明示的に指定された場合のみ発動し、miku-soft 作成・保守の相談だけでは存在案内に留める方針になっています。

## 変更内容

- `igapyon-miku-soft-developer` skill を追加
  - 明示発動のみの activation policy を定義
  - New project mode / Maintenance mode を定義
  - `igapyon-repo-conventions` を repository conventions の前提 skill として利用する構成を追加

- miku-soft 向け reference を追加
  - 発動条件: `activation-policy.md`
  - 基本文書の読み分け: `architecture-rules.md`
  - 新規 project 作成 workflow: `new-project-workflow.md`
  - 既存 project 保守 workflow: `maintenance-workflow.md`
  - miku-soft 固有の repo operation 補足: `repo-operations.md`

- miku-soft 基本文書セットを追加
  - overview design
  - main application design
  - Java application design
  - straight conversion guide
  - Agent Skills design
  - MCP design

- `index.json` を追加
  - `igapyon-miku-soft-developer` skill 配下の reference discovery 用 index を追加

- `README.md` を更新
  - repository 構成図に `igapyon-miku-soft-developer` を追加
  - 現在の skill 一覧に `igapyon-miku-soft-developer` の説明を追加