### PR TITLE
igapyon-miku-soft-developer に用途別ワークフローと main app 基本文書 v20260505 を追加

### DIFF
--- a/skills/igapyon-miku-soft-developer/SKILL.md
+++ b/skills/igapyon-miku-soft-developer/SKILL.md
@@ -26,10 +26,11 @@ Prerequisite: use `igapyon-repo-conventions` as the repository-conventions basel
 2. Read [references/architecture-rules.md](references/architecture-rules.md).
 3. For new project work, read [references/new-project-workflow.md](references/new-project-workflow.md).
 4. For existing project work, read [references/maintenance-workflow.md](references/maintenance-workflow.md).
-5. Read [references/repo-operations.md](references/repo-operations.md) for miku-soft-specific additions.
-6. Inspect the target repository before editing.
-7. Preserve unrelated user changes.
-8. Keep product behavior in the product core or upstream runtime artifacts, not in the skill instructions.
+5. Read the specific workflow reference when relevant: [references/10-node-app-workflow.md](references/10-node-app-workflow.md), [references/30-java-straight-conversion-workflow.md](references/30-java-straight-conversion-workflow.md), [references/40-agent-skills-workflow.md](references/40-agent-skills-workflow.md), or [references/50-mcp-workflow.md](references/50-mcp-workflow.md).
+6. Read [references/repo-operations.md](references/repo-operations.md) for miku-soft-specific additions.
+7. Inspect the target repository before editing.
+8. Preserve unrelated user changes.
+9. Keep product behavior in the product core or upstream runtime artifacts, not in the skill instructions.
 
 Use `index.json` when you need to discover the available bundled reference files, but treat `SKILL.md` and files under `references/` as the source of truth.
 

--- a/skills/igapyon-miku-soft-developer/index.json
+++ b/skills/igapyon-miku-soft-developer/index.json
@@ -3,6 +3,38 @@
   "basePath": ".",
   "files": [
     {
+      "name": "10-node-app-workflow.md",
+      "path": "references/10-node-app-workflow.md",
+      "ext": "md",
+      "dir": "references",
+      "size": 2756,
+      "summary": "Node App Workflow"
+    },
+    {
+      "name": "30-java-straight-conversion-workflow.md",
+      "path": "references/30-java-straight-conversion-workflow.md",
+      "ext": "md",
+      "dir": "references",
+      "size": 1386,
+      "summary": "Java Straight Conversion Workflow"
+    },
+    {
+      "name": "40-agent-skills-workflow.md",
+      "path": "references/40-agent-skills-workflow.md",
+      "ext": "md",
+      "dir": "references",
+      "size": 1174,
+      "summary": "Agent Skills Workflow"
+    },
+    {
+      "name": "50-mcp-workflow.md",
+      "path": "references/50-mcp-workflow.md",
+      "ext": "md",
+      "dir": "references",
+      "size": 1169,
+      "summary": "MCP Workflow"
+    },
+    {
       "name": "activation-policy.md",
       "path": "references/activation-policy.md",
       "ext": "md",
@@ -35,12 +67,12 @@
       "summary": "Miku Software Overview Design v20260427"
     },
     {
-      "name": "miku-soft-10-mainapp-design-v20260501.md",
-      "path": "references/miku-soft-basic/miku-soft-10-mainapp-design-v20260501.md",
+      "name": "miku-soft-10-mainapp-design-v20260505.md",
+      "path": "references/miku-soft-basic/miku-soft-10-mainapp-design-v20260505.md",
       "ext": "md",
       "dir": "references/miku-soft-basic",
-      "size": 59100,
-      "summary": "Miku Software Main Application Design v20260425"
+      "size": 62953,
+      "summary": "Miku Software Main Application Design v20260505"
     },
     {
       "name": "miku-soft-20-javaapp-design-v20260501.md",
@@ -79,7 +111,7 @@
       "path": "references/new-project-workflow.md",
       "ext": "md",
       "dir": "references",
-      "size": 1874,
+      "size": 2363,
       "summary": "New miku-soft Project Workflow"
     },
     {
@@ -95,7 +127,7 @@
       "path": "SKILL.md",
       "ext": "md",
       "dir": "",
-      "size": 2744,
+      "size": 3128,
       "summary": "--- name: igapyon-miku-soft-developer description: Use only when the user explicitly asks to use igapyon-miku-soft-developer or explicitly asks to apply the miku-soft developer skill. If the user says they want to create a new miku-soft project, maintain a"
     }
   ]

--- a/skills/igapyon-miku-soft-developer/references/10-node-app-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/10-node-app-workflow.md
@@ -1,0 +1,53 @@
+# Node App Workflow
+
+Use this workflow for creating or maintaining a miku-soft Node.js / TypeScript main application.
+
+Detailed design guidance lives in [miku-soft-basic/miku-soft-10-mainapp-design-v20260505.md](miku-soft-basic/miku-soft-10-mainapp-design-v20260505.md). Keep this file as the execution checklist.
+
+## First Reads
+
+1. Read [architecture-rules.md](architecture-rules.md).
+2. Read the main application basic document.
+3. Inspect existing README, docs, TODO, package metadata, source layout, CLI scripts, tests, and generated indexes.
+
+## Reference Projects
+
+For new Node app creation, prefer starting from one or more similar existing miku-soft projects expanded under `workplace/`.
+
+If the user has not provided reference projects, ask them to provide the closest existing miku-soft examples before scaffolding the new app. Treat those examples as shape references for repository layout, package metadata, CLI contracts, tests, docs, and build artifacts.
+
+When multiple references are available, prefer the newer project version or the project closest to the requested product shape. Use the basic documents as the source of design intent, and use `workplace/` references to confirm practical implementation details that are easy to miss.
+
+Do not copy `workplace/` contents into the target repository wholesale. Copy or adapt only the necessary patterns, and keep `workplace/` local-only according to repository convention rules.
+
+## Shape Detection
+
+Before editing, identify which Node app shape the repository currently uses:
+
+- Single-file Web App plus CLI: check `index.html`, product-named HTML, `index-src.html`, `src/`, `lht-cmn/`, build scripts, CLI scripts, and browser or UI tests.
+- CLI / structured JSON tool: check `src/main.ts`, `src/*types.ts`, CLI specs under `docs/`, `bin`, `exports`, `types`, and stdout / stderr contract tests.
+- Bundled runtime artifact: check `bundle/`, `scripts/build-cli-bundle.mjs`, `scripts/build-cli-runtime.mjs`, smoke scripts, and package `files`.
+- AI-facing operation surface: check projection, patch, validation, summary, diagnostics, or state-oriented docs and tests.
+
+Use the detected shape to decide which contracts must be preserved. Do not force every repository into every shape.
+
+## Checklist
+
+1. Keep the semantic center in product code, not in Web UI event handlers or skill prose.
+2. Separate product core, Web UI, CLI, tests, docs, and generated artifacts when the repository structure supports it.
+3. Define CLI inputs, outputs, exit behavior, diagnostics, and artifact roles when CLI behavior exists.
+4. Keep local-first behavior and avoid adding network assumptions unless the product explicitly requires them.
+5. Update README, docs, TODO, tests, and indexes when the main application contract changes.
+
+## Node-Specific Checklist
+
+When a Node app change touches executable behavior, check the relevant local contracts:
+
+- `package.json` scripts such as `build`, `test`, `cli`, `typecheck`, `smoke`, `smoke:bundle`, and `pack:check`
+- TypeScript configuration and emitted runtime paths such as `dist/`, `src/js/`, generated HTML, or `bundle/*.mjs`
+- CLI metadata such as `bin`, `exports`, `types`, `engines`, and package `files`
+- CLI behavior for `--help`, `--version`, stdin, stdout, stderr, exit code, diagnostics, and usage errors
+- tests for core API, CLI subprocess behavior, encoding, path security, limits, diagnostics, fixtures, golden output, roundtrip behavior, or UI wiring
+- generated artifacts that should be rebuilt instead of hand-edited
+
+Run the smallest relevant command first, then broader build or smoke commands when the changed contract warrants them.

--- a/skills/igapyon-miku-soft-developer/references/30-java-straight-conversion-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/30-java-straight-conversion-workflow.md
@@ -1,0 +1,25 @@
+# Java Straight Conversion Workflow
+
+Use this workflow for creating or maintaining a Java straight-conversion version of a miku-soft Node.js / TypeScript upstream project.
+
+Detailed design guidance lives in:
+
+- [miku-soft-basic/miku-soft-20-javaapp-design-v20260501.md](miku-soft-basic/miku-soft-20-javaapp-design-v20260501.md)
+- [miku-soft-basic/miku-soft-30-straight-conversion-v20260425.md](miku-soft-basic/miku-soft-30-straight-conversion-v20260425.md)
+
+Keep this file as the execution checklist.
+
+## First Reads
+
+1. Read [architecture-rules.md](architecture-rules.md).
+2. Read the Java application and straight conversion basic documents.
+3. Inspect upstream evidence, existing Java source, mapping documents, tests, build files, README, docs, TODO, and workplace instructions.
+
+## Checklist
+
+1. Confirm the upstream source and target Java repository before editing.
+2. Preserve upstream-following ability and avoid Java-first redesign unless the user explicitly asks for a separate extension.
+3. Keep upstream-derived behavior and Java-side original extensions documented separately.
+4. Maintain or create mapping notes when file/class responsibility tracking matters.
+5. Prefer focused regression commands that compare behavior, CLI contracts, diagnostics, or generated artifacts.
+6. Update README, docs, TODO, tests, build files, and indexes when conversion assumptions change.

--- a/skills/igapyon-miku-soft-developer/references/40-agent-skills-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/40-agent-skills-workflow.md
@@ -1,0 +1,21 @@
+# Agent Skills Workflow
+
+Use this workflow for creating or maintaining a miku-soft Agent Skills package.
+
+Detailed design guidance lives in [miku-soft-basic/miku-soft-40-agentskills-design-v20260501.md](miku-soft-basic/miku-soft-40-agentskills-design-v20260501.md). Keep this file as the execution checklist.
+
+## First Reads
+
+1. Read [activation-policy.md](activation-policy.md) for strict activation behavior.
+2. Read [architecture-rules.md](architecture-rules.md).
+3. Read the Agent Skills basic document.
+4. Inspect the upstream product README, runtime artifacts, CLI/API contracts, existing skill files, references, assets, tests, README, docs, TODO, and generated indexes.
+
+## Checklist
+
+1. Keep the skill as a workflow adapter over upstream product behavior.
+2. Do not duplicate product logic in `SKILL.md` or references.
+3. Keep `SKILL.md` lean and put detailed workflow material under `references/`.
+4. Define activation behavior narrowly when the skill can affect broad repository work.
+5. Describe runtime artifact lookup, artifact roles, diagnostics, and handoff points when relevant.
+6. Update indexes and validation output after adding or changing skill files.

--- a/skills/igapyon-miku-soft-developer/references/50-mcp-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/50-mcp-workflow.md
@@ -1,0 +1,20 @@
+# MCP Workflow
+
+Use this workflow for creating or maintaining a miku-soft MCP server.
+
+Detailed design guidance lives in [miku-soft-basic/miku-soft-50-mcp-design-v20260501.md](miku-soft-basic/miku-soft-50-mcp-design-v20260501.md). Keep this file as the execution checklist.
+
+## First Reads
+
+1. Read [architecture-rules.md](architecture-rules.md).
+2. Read the MCP basic document.
+3. Inspect upstream product contracts, existing MCP tools/resources/prompts, schemas, runtime artifacts, tests, README, docs, TODO, and generated indexes.
+
+## Checklist
+
+1. Treat the MCP server as a protocol adapter over upstream product APIs, CLI runtime, or local files.
+2. Keep tool names, input schemas, result schemas, resource URI roles, artifact roles, and error categories stable and documented.
+3. Prefer local stdio execution as the first target unless the repository explicitly targets another transport.
+4. Do not let client-specific compatibility behavior redefine product semantics or the core MCP contract.
+5. Preserve diagnostics, warnings, and artifact roles in structured results.
+6. Update README, docs, TODO, tests, contract files, and indexes when MCP surface changes.

--- a/skills/igapyon-miku-soft-developer/references/architecture-rules.md
+++ b/skills/igapyon-miku-soft-developer/references/architecture-rules.md
@@ -11,7 +11,7 @@ Do not create or rely on a synchronization script for these documents. When a ta
 Read only the document needed for the current task:
 
 - [miku-soft-basic/miku-soft-00-overview-design-v20260427.md](miku-soft-basic/miku-soft-00-overview-design-v20260427.md): overall miku-soft stance and product-type overview
-- [miku-soft-basic/miku-soft-10-mainapp-design-v20260501.md](miku-soft-basic/miku-soft-10-mainapp-design-v20260501.md): main application, Web UI, CLI, local-first behavior, diagnostics, and shared conventions
+- [miku-soft-basic/miku-soft-10-mainapp-design-v20260505.md](miku-soft-basic/miku-soft-10-mainapp-design-v20260505.md): main application, Web UI, CLI, local-first behavior, diagnostics, and shared conventions
 - [miku-soft-basic/miku-soft-20-javaapp-design-v20260501.md](miku-soft-basic/miku-soft-20-javaapp-design-v20260501.md): Java CLI, Maven, Java runtime boundary, packaging, and Java-side maintenance
 - [miku-soft-basic/miku-soft-30-straight-conversion-v20260425.md](miku-soft-basic/miku-soft-30-straight-conversion-v20260425.md): Node.js / TypeScript to Java straight conversion
 - [miku-soft-basic/miku-soft-40-agentskills-design-v20260501.md](miku-soft-basic/miku-soft-40-agentskills-design-v20260501.md): Agent Skills versions and agent-facing local workflow packages

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-10-mainapp-design-v20260505.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-10-mainapp-design-v20260505.md
@@ -1,4 +1,4 @@
-# Miku Software Main Application Design v20260425
+# Miku Software Main Application Design v20260505
 
 This memo organizes design characteristics commonly seen across the software series whose names start with `miku`.
 
@@ -87,6 +87,8 @@ The shared direction is as follows.
 In this document, a main application means an application in the miku series that is neither a Java straight-conversion version nor an Agent Skills version, and that uses Node.js as its basic runtime.
 
 Main applications may be Web UI applications, CLI-only applications, or applications that provide both. A Web UI is common but not required. A CLI-only tool such as an index generator is still a main application when it stands as the primary product, accepts real local input, and produces verifiable artifacts.
+
+CLI-only main applications are especially common when the product value is a structured operation for AI agents, scripts, or automation. Tools such as local file search, local file reading, and index generation can be complete products without a Web UI when their CLI contract, JSON output, diagnostics, documentation, and tests are stable enough for repeated use.
 
 Main applications are practical tools for safely reading existing files in a local environment, structuring them, and passing them to another representation.
 
@@ -297,6 +299,8 @@ The following sections turn the cross-cutting principles into practical reposito
 
 ### Distribution and Build Principles
 
+#### Web Distribution Shape
+
 For main applications with a Web UI, split development-time source files from distribution-time single-file artifacts.
 
 Distribution artifacts should generally be designed as Single-file Web Apps. They should open in a Web browser, require no additional installation or server startup, and allow core functionality to be used offline.
@@ -304,6 +308,8 @@ Distribution artifacts should generally be designed as Single-file Web Apps. The
 For Web distribution, the basic structure is to place `index.html` as a landing page and launch the actual main HTML from it. The main HTML is generated as a product-named single-file app, such as `miku-xlsx2md.html`, `miku-docx2md.html`, `mikuproject.html`, or `mikuscore.html`.
 
 The landing page generally displays the build date. Links from the landing page to the main HTML include URL parameters such as the build date so old single-file apps are less likely to be opened from the browser cache.
+
+#### Generated Web Artifacts
 
 The basic shape is as follows.
 
@@ -321,6 +327,27 @@ The basic shape is as follows.
 
 This shape balances development-time maintainability with ease of distribution for users.
 
+### Node Package and Runtime Artifact Principles
+
+CLI-oriented main applications may also be distributed as Node.js packages or as single-file Node.js runtime artifacts.
+
+#### Package Metadata
+
+When a main application exposes a Node package surface, keep package metadata aligned with the actual runtime contract:
+
+- `bin`: command-line entrypoint
+- `exports`: programmatic entrypoint when provided
+- `types`: TypeScript declaration entrypoint when provided
+- `files`: package contents intended for publication or dry-run checks
+- `engines`: supported Node.js runtime range
+- scripts such as `build`, `test`, `cli`, `typecheck`, `smoke`, `smoke:bundle`, and `pack:check`
+
+#### Single-file Node Runtime Artifacts
+
+For downstream Agent Skills or other local automation, a build may produce a single-file Node.js CLI runtime artifact such as `bundle/<product>.mjs`. When this shape is used, keep the generated runtime artifact distinct from development-time `dist/` output.
+
+A source archive such as `bundle/<product>-sources.tgz` may be useful for rebuild, audit, or downstream confirmation. Treat these files as generated artifacts: rebuild them through documented commands and verify them with smoke tests rather than editing them directly.
+
 ### `workplace/` Directory Principles
 
 The repository root of a main application contains a `workplace/` directory for local work.
@@ -335,6 +362,8 @@ The name is standardized as `workplace`. If past text or typos use `workspace`, 
 
 ### Role Split Between README and docs
 
+#### README
+
 `README.md` is an entry document for ordinary users.
 
 README should mainly contain the following.
@@ -346,15 +375,21 @@ README should mainly contain the following.
 - Major options
 - Links to additional information
 
+#### docs
+
 Developer details, design memos, internal structure, implementation specifications, test policy, and future notes are stored as Markdown under `docs/`.
 
 README may link to `docs/`, but its body should stay as the first explanation users read. Do not make README too heavy with internal design or developer details.
 
 ### Managing External-Publishing Documents Under `docs/articles`
 
+#### Purpose
+
 Main applications may place drafts and outlines for external publishing under `docs/articles/`, separate from user-facing README and developer-facing docs.
 
 `docs/articles/` is not the product specification itself. It is a working area for organizing product introductions, development experience, implementation knowledge, and problem awareness for external media. Original manuscripts, article notes, outlines, and drafts for published articles are kept as Markdown.
+
+#### Directory Shape
 
 The basic shape is as follows.
 
@@ -371,6 +406,8 @@ The roles of media-specific directories are also separated.
 - `docs/articles/note/` contains articles that emphasize narrative flow, such as background, problem awareness, experience, and thinking
 
 This separation keeps technical articles and experience articles from mixing too much, even when they discuss the same subject. For example, feature introductions and Markdown output specifications for `miku-xlsx2md` can be organized for Qiita, while the experience of implementing and documenting with generative AI can be organized for Note.
+
+#### Feedback to Product Docs
 
 `docs/articles/` is not a replacement for README or specifications. Constraints, implementation knowledge, bugs, and improvement ideas found while writing articles are returned to README, formal docs, TODO, or test fixtures as needed. Article writing is external publishing, but it is also treated as a review workflow for making the product explainable.
 
@@ -405,9 +442,13 @@ This policy permits a little extra code only when an upstream exists. Normal mai
 
 ### Core and Thin Entry Principles
 
+#### Shared Core
+
 Main applications push processing called from UI, CLI, tests, and Agent Skills toward the same core as much as possible.
 
 CLI and Web UI are designed as thin entry points that call a shared core, not as separate implementations.
+
+#### Thin Entrypoints
 
 This principle appears in forms such as the following.
 
@@ -422,9 +463,13 @@ When adding a thin layer to publish a CLI, keep that layer responsible for optio
 
 ### Public API Surface Principles
 
+#### API Boundary
+
 Main applications provide a UI-independent public API surface when needed.
 
 The public API surface does not expose everything inside the application. It gathers operations needed by Agent Skills, CLI, tests, MCP, or future integrations as small, stable entry points.
+
+#### API Contents
 
 The public API surface emphasizes the following.
 
@@ -439,9 +484,13 @@ This policy lets features built for Web UI be used with the same meaning from CL
 
 ### Runtime Difference Adapter Principles
 
+#### Runtime-specific Boundaries
+
 Main applications may run in both Web browsers and Node.js CLI.
 
 In that case, runtime-specific parts such as DOM, XML parser, file, Blob, download, encoding, and ZIP saving should not be scattered directly through core logic.
+
+#### Adapter Shape
 
 Runtime differences are contained in adapters or loaders as follows.
 
@@ -455,11 +504,17 @@ This separation makes it easier to use the same core in both Single-file Web App
 
 ### Diagnostics and Summary Principles
 
+#### Diagnostics
+
 Main applications treat diagnostics and summaries as formal output surfaces, not as byproducts.
 
 Diagnostics are not mere error messages. They are information for users, developers, and AI agents to trace conversion decisions, fallback, unsupported areas, loss, warnings, suspicious input, and output constraints.
 
+#### Summaries
+
 Summaries are used to quickly understand the whole input or conversion result.
+
+#### Diagnostic Shape
 
 The principles are as follows.
 
@@ -476,9 +531,13 @@ This makes it possible to judge not only whether conversion succeeded, but also 
 
 ### Option and Mode Principles
 
+#### Mode Scope
+
 Main applications avoid adding too many options and modes.
 
 However, important trade-offs that users must choose because of the target conversion should be exposed as modes.
+
+#### Examples
 
 Examples:
 
@@ -487,6 +546,8 @@ Examples:
 - balanced / border / planner-aware
 - replace / merge / patch
 - diagnostics text / json
+
+#### Mode Criteria
 
 When adding a mode, satisfy the following.
 
@@ -500,9 +561,13 @@ Modes are placed for users to choose conversion policy, not to expose internal c
 
 ### UI Design Principles
 
+#### UI Role
+
 Main applications with a Web UI use `lht-cmn` Web Components to keep consistency across the series.
 
 UI is centered on the actual work surface rather than an explanatory landing page.
+
+#### Basic UI Flow
 
 The basic UI flow is as follows.
 
@@ -512,6 +577,8 @@ The basic UI flow is as follows.
 - Save required artifacts
 
 The UI clearly treats processing as local so users do not mistakenly think their files are being sent to an external server.
+
+#### UI Boundary
 
 Even when a Web UI exists, the center of the main application is not the UI itself. It is the processing that reads local files, structures them, and outputs artifacts. Avoid states whose meaning exists only in the UI.
 
@@ -525,7 +592,13 @@ For this reason, miku main applications prefer reliable operations on real files
 
 ### CLI Design Principles
 
+#### CLI Role
+
 Main applications with a CLI consider both batch workflows that replace manual work and invocation from AI agents.
+
+CLI is not a helper for UI. It is a formal entry point for AI agent workflows and automation.
+
+#### Basic CLI Contract
 
 CLI emphasizes the following.
 
@@ -538,11 +611,27 @@ CLI emphasizes the following.
 - Make success and failure judgeable by exit code
 - Make the same operation reproducible in tests and CI
 
-CLI is not a helper for UI. It is a formal entry point for AI agent workflows and automation.
+#### Structured Output and Error Handling
+
+For CLI-only structured tools, stdout is often the primary machine-readable result surface. In that shape, keep stdout dedicated to result JSON or another documented payload, send progress / diagnostics / runtime-level messages to stderr, and treat `--help` and `--version` as explicit metadata exceptions that may print plain text without requiring stdin JSON.
+
+When a command can safely construct a result object for validation or semantic failures, returning the normal result shape with diagnostics can be better than switching to ad hoc stderr-only output. Reserve stderr-only output for usage errors, malformed input, or unexpected failures where the normal result shape cannot be constructed safely.
+
+#### Verbose and Progress Output
 
 As in `miku-indexgen --verbose`, target, output destination, current scan location, discovered files, and timing breakdowns are emitted incrementally when useful, rather than only summarized at the end. This lets humans and AI agents notice stalls, incorrect target ranges, or unexpected input earlier during processing.
 
 This kind of progress / timing output is not confused with primary output or structured diagnostics. Text artifacts remain stable through file or stdout contracts, while binary artifacts remain stable through explicit file-output or documented binary-safe stdout contracts. Incremental logs use an easy-to-identify prefix such as `verbose:`, and representative lines are fixed in tests.
+
+#### Local File Safety
+
+Local-first CLI tools that read files or directories should make filesystem boundaries explicit.
+
+When the CLI accepts a root directory or file list, document how relative paths are resolved. Prefer returning result paths relative to the selected root rather than absolute paths, and normalize result path separators where cross-platform consumers need stable output.
+
+For text-reading tools, encoding behavior should be part of the public contract. Do not silently guess or replace unreadable text when that would hide data loss. Use documented encoding defaults, encoding rules, size limits, binary detection, and decode-error diagnostics.
+
+Limits and security decisions should be visible in structured results or diagnostics. Examples include skipped files, unreadable files, path escape attempts, decode failures, size limits, and regex or query restrictions. Add focused tests for these failure and warning paths, not only for successful output.
 
 ## Common Patterns Observed Across the Series
 

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-40-agentskills-design-v20260501.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-40-agentskills-design-v20260501.md
@@ -29,7 +29,7 @@ This document is not a detailed specification for one skill repository. Reposito
 
 Use the shared design documents together as follows.
 
-- `docs/miku-soft-10-mainapp-design-v20260501.md`
+- `docs/miku-soft-10-mainapp-design-v20260505.md`
   - describes the upstream product design and semantic center
 - `docs/miku-soft-20-javaapp-design-v20260501.md`
   - describes Java runtime versions when they exist

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-50-mcp-design-v20260501.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-50-mcp-design-v20260501.md
@@ -39,7 +39,7 @@ This document is not a detailed specification for one MCP repository. Repository
 
 Use the shared design documents together as follows.
 
-- `docs/miku-soft-10-mainapp-design-v20260501.md`
+- `docs/miku-soft-10-mainapp-design-v20260505.md`
   - describes the upstream product design and semantic center
 - `docs/miku-soft-40-agentskills-design-v20260501.md`
   - describes how Agent Skills versions expose miku workflows to AI agents

--- a/skills/igapyon-miku-soft-developer/references/new-project-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/new-project-workflow.md
@@ -15,6 +15,13 @@ Resolve the minimum facts needed to start:
 
 Then read the relevant basic document selected by [architecture-rules.md](architecture-rules.md).
 
+For first delivery surface details, read the relevant specific workflow:
+
+- [10-node-app-workflow.md](10-node-app-workflow.md): Node.js / TypeScript main application
+- [30-java-straight-conversion-workflow.md](30-java-straight-conversion-workflow.md): Java straight conversion
+- [40-agent-skills-workflow.md](40-agent-skills-workflow.md): Agent Skills package
+- [50-mcp-workflow.md](50-mcp-workflow.md): MCP server
+
 ## Basic Document Copy
 
 When creating a new miku-soft project or initializing a repository as miku-soft, copy the bundled basic documents from [miku-soft-basic/](miku-soft-basic/) into the target repository's `docs/` directory.
@@ -29,8 +36,9 @@ When creating a new miku-soft project or initializing a repository as miku-soft,
 
 1. Inspect the target directory and git status.
 2. Create only the repository skeleton needed for the requested first delivery surface.
-3. Put product behavior in product code, public APIs, CLI, or bundled runtime artifacts, not in skill prose.
-4. Copy the miku-soft basic documents into `docs/` when initializing a miku-soft repository.
-5. Add README and TODO entries that match the actual initial state.
-6. Add focused tests or regression commands when there is executable behavior to protect.
-7. Regenerate any repository indexes required by the target repository.
+3. Follow the specific workflow for the selected first delivery surface.
+4. Put product behavior in product code, public APIs, CLI, or bundled runtime artifacts, not in skill prose.
+5. Copy the miku-soft basic documents into `docs/` when initializing a miku-soft repository.
+6. Add README and TODO entries that match the actual initial state.
+7. Add focused tests or regression commands when there is executable behavior to protect.
+8. Regenerate any repository indexes required by the target repository.


### PR DESCRIPTION
## 概要

`igapyon-miku-soft-developer` スキルについて、miku-soft の作成・保守作業を用途別ワークフローへ分け、Node main application 向け基本文書を `v20260505` に更新します。

## 変更内容

- `SKILL.md` から用途別ワークフロー参照への導線を追加
  - Node.js / TypeScript main application
  - Java straight conversion
  - Agent Skills package
  - MCP server

- Node.js / TypeScript main application 用の実行チェックリストを追加
  - 新規 Node app 作成時に、類似する既存 miku-soft を `workplace/` 以下へ展開して参照する方針を追加
  - リポジトリ形状の検出観点を追加
  - Node package metadata、CLI contract、bundle artifact、テスト観点の確認項目を追加

- Java straight conversion / Agent Skills / MCP 用の個別ワークフロー文書を追加
  - それぞれの基本文書への参照
  - 初期確認事項
  - 実作業時のチェックリスト

- main application 基本文書を `miku-soft-10-mainapp-design-v20260505.md` として更新
  - CLI-only main application の位置づけを強化
  - Node package metadata / runtime artifact / structured CLI contract / local file safety などの観点を追加
  - 見出し構成を整理し、CLI や推奨規約の確認観点を細分化

- 関連文書の参照を `miku-soft-10-mainapp-design-v20260505.md` に更新
  - `architecture-rules.md`
  - Agent Skills 基本文書
  - MCP 基本文書

- `new-project-workflow.md` を更新
  - 新規 miku-soft 作成時に、選択した first delivery surface に応じた個別ワークフローを読む流れを追加
  - 基本文書コピーと個別ワークフロー適用の順序を整理

- `index.json` を更新
  - 追加されたワークフロー文書
  - 更新された main application 基本文書
  - 更新後のファイルサイズと summary