### PR TITLE
igapyon-github-writer にブランチ状況確認ワークフローを追加

### DIFF
--- a/skills/igapyon-github-writer/SKILL.md
+++ b/skills/igapyon-github-writer/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: igapyon-github-writer
-description: Use only when the user explicitly asks to draft GitHub PR text, GitHub Release notes, or GitHub About text from repository evidence, or explicitly mentions igapyon-github-writer. If the user only asks whether such a skill exists, mention this skill as an available option but do not apply it until asked.
+description: Use only when the user explicitly asks to draft GitHub PR text, GitHub Release notes, GitHub About text, or asks to inspect the current branch status using igapyon-github-writer. If the user only asks whether such a skill exists, mention this skill as an available option but do not apply it until asked.
 ---
 
 # igapyon-github-writer
 
-This skill drafts Markdown text for GitHub surfaces from local repository evidence.
+This skill drafts Markdown text for GitHub surfaces from local repository evidence. It can also report the current branch status as preparation for GitHub writing work.
 
-Use it only for writing text to paste into GitHub. Do not create PRs, tags, releases, issues, branches, commits, or remote changes unless the user separately asks for that operation.
+Use it only for GitHub writing text and the local branch-status checks that prepare that writing. Do not create PRs, tags, releases, issues, branches, commits, or remote changes unless the user separately asks for that operation.
 
-Do not use this skill for generic commit summaries, changelogs, or repository cleanup unless the user explicitly asks for GitHub PR, GitHub Release, GitHub About text, or names this skill.
+Do not use this skill for generic commit summaries, changelogs, branch inspection, or repository cleanup unless the user explicitly asks for GitHub PR, GitHub Release, GitHub About text, branch status through this skill, or names this skill.
 
 If the user asks whether there is a skill for GitHub PR, Release, or About text, mention this skill as an available option, but do not apply it until the user asks to use it.
 
@@ -22,6 +22,7 @@ Examples:
 - PR mode: `pr textつくりたい`, `PR文面を作りたい`, `pull request本文`, `プルリク説明`, `PRタイトルと本文`
 - Release mode: `release textつくりたい`, `リリース文を作りたい`, `release notes`, `リリースノート`, `GitHub Release本文`
 - About mode: `GitHub Aboutを書きたい`, `About文`, `リポジトリ説明`, `GitHub説明文`
+- Branch Status mode: `github-writerでブランチ状況`, `今のブランチの状況`, `PR前にブランチ状態を見たい`, `現在ブランチの確認`
 
 If the mode is clear but required evidence is missing, do not draft yet. Ask for the missing target:
 
@@ -31,12 +32,12 @@ If the mode is clear but required evidence is missing, do not draft yet. Ask for
 
 ## Core Workflow
 
-1. Identify whether the request is for PR, Release, or About text.
+1. Identify whether the request is for PR, Release, About text, or Branch Status.
 2. Read [references/github-writing-rules.md](references/github-writing-rules.md) before drafting.
-3. Read the mode-specific reference: [references/pr-writing.md](references/pr-writing.md), [references/release-writing.md](references/release-writing.md), or [references/about-writing.md](references/about-writing.md).
+3. Read the mode-specific reference: [references/pr-writing.md](references/pr-writing.md), [references/release-writing.md](references/release-writing.md), [references/about-writing.md](references/about-writing.md), or [references/branch-status.md](references/branch-status.md).
 4. Inspect only the repository evidence needed for the requested mode.
-5. Draft from evidence without inventing unsupported facts.
-6. Return the final Markdown block using the format required by the references.
+5. Draft or report from evidence without inventing unsupported facts.
+6. Return the final answer using the format required by the selected reference.
 
 ## Reference Use
 
@@ -47,6 +48,7 @@ Use these mode-specific references:
 - [references/pr-writing.md](references/pr-writing.md) for GitHub PR title and body drafting
 - [references/release-writing.md](references/release-writing.md) for GitHub Release title and body drafting
 - [references/about-writing.md](references/about-writing.md) for GitHub About text drafting
+- [references/branch-status.md](references/branch-status.md) for current branch status reporting before GitHub writing work
 
 Use `index.json` as the discovery index when you need to confirm the available bundled reference files, but treat `SKILL.md` and files under `references/` as the source of truth.
 
@@ -58,4 +60,4 @@ Before finishing:
 
 - ensure the final answer contains no absolute paths, home directories, or working directories
 - ensure unsupported items are marked `未確認`, `要確認`, or omitted
-- ensure the final answer is wrapped with `~~~~markdown` and `~~~~`
+- for PR, Release, and About modes, ensure the final answer is wrapped with `~~~~markdown` and `~~~~`

--- a/skills/igapyon-github-writer/index.json
+++ b/skills/igapyon-github-writer/index.json
@@ -11,6 +11,14 @@
       "summary": "GitHub About Writing"
     },
     {
+      "name": "branch-status.md",
+      "path": "references/branch-status.md",
+      "ext": "md",
+      "dir": "references",
+      "size": 2672,
+      "summary": "GitHub Branch Status"
+    },
+    {
       "name": "github-writing-rules.md",
       "path": "references/github-writing-rules.md",
       "ext": "md",
@@ -39,8 +47,8 @@
       "path": "SKILL.md",
       "ext": "md",
       "dir": "",
-      "size": 3680,
-      "summary": "--- name: igapyon-github-writer description: Use only when the user explicitly asks to draft GitHub PR text, GitHub Release notes, or GitHub About text from repository evidence, or explicitly mentions igapyon-github-writer. If the user only asks whether su"
+      "size": 4271,
+      "summary": "--- name: igapyon-github-writer description: Use only when the user explicitly asks to draft GitHub PR text, GitHub Release notes, GitHub About text, or asks to inspect the current branch status using igapyon-github-writer. If the user only asks whether su"
     }
   ]
 }

--- a/skills/igapyon-github-writer/references/branch-status.md
+++ b/skills/igapyon-github-writer/references/branch-status.md
@@ -1,0 +1,80 @@
+# GitHub Branch Status
+
+Use this workflow when the user asks only to understand the current branch state before PR or release writing.
+
+This mode reports repository evidence. It does not draft PR text, release notes, or About text unless the user separately asks for that mode.
+
+## Safety Rules
+
+- Do not run `git fetch`, `git pull`, `git push`, `gh pr create`, or any remote-changing command unless the user explicitly asks.
+- Do not create branches, commits, tags, releases, issues, or pull requests.
+- Do not modify files.
+- Use local Git evidence only.
+- If upstream tracking is missing, report it as `未設定` or `未確認`.
+
+## Basic Behavior
+
+By default, first report the current branch state with `git status -sb`, including the branch relationship and uncommitted files.
+
+Also report the newest three `tag*` tags and newest three `v*` tags. These tag groups are checked separately because repositories may use both local operation tags such as `tagYYYYMMDD` and release-style version tags such as `vX.Y.Z`.
+
+If a tag group has no matches, report that clearly instead of omitting it.
+
+## Evidence Commands
+
+Inspect the smallest useful local evidence:
+
+```sh
+git status -sb
+git branch --show-current
+git rev-parse --abbrev-ref --symbolic-full-name @{u}
+git rev-list --left-right --count @{u}...HEAD
+git log --oneline --decorate --max-count=20
+git diff --stat
+git diff --cached --stat
+git tag --list 'tag*' --sort=-creatordate --format='%(creatordate:iso8601-strict) %(refname:short)'
+git tag --list 'v*' --sort=-creatordate --format='%(creatordate:iso8601-strict) %(refname:short)'
+```
+
+If an upstream command fails because no upstream is configured, continue without treating it as a fatal error.
+
+For tag output, show only the newest three `tag*` tags and newest three `v*` tags in the report. If either pattern has no matches, report that clearly.
+
+When an upstream exists, inspect the ahead / behind commits only when useful:
+
+```sh
+git log --oneline --decorate @{u}..HEAD
+git log --oneline --decorate HEAD..@{u}
+```
+
+## Report Shape
+
+Return a concise Japanese Markdown report. Do not wrap the report in `~~~~markdown` unless the user asks for paste-ready Markdown.
+
+Use this shape:
+
+```markdown
+## ブランチ状況
+
+- 現在ブランチ: ...
+- upstream: ...
+- ahead / behind: ...
+- working tree: ...
+- staged: ...
+- untracked: ...
+
+## 直近コミット
+
+- ...
+
+## 最近のタグ
+
+- `tag*`: ...
+- `v*`: ...
+
+## 注意点
+
+- ...
+```
+
+Omit sections that have no useful content. Add `## 注意点` only when there is something material to call out, such as no upstream, dirty working tree, staged changes, untracked files, or local commits not on upstream.

--- a/skills/igapyon-miku-soft-developer/index.json
+++ b/skills/igapyon-miku-soft-developer/index.json
@@ -7,7 +7,7 @@
       "path": "references/10-node-app-workflow.md",
       "ext": "md",
       "dir": "references",
-      "size": 2756,
+      "size": 3653,
       "summary": "Node App Workflow"
     },
     {


### PR DESCRIPTION
## 概要

`igapyon-github-writer` に、PR文面やRelease文の作成前に現在ブランチの状態を確認するための Branch Status mode を追加します。

## 変更内容

- `igapyon-github-writer` のスキル定義を更新
  - PR / Release / About に加えて、Branch Status mode を扱えるように説明とモード選択を追加
  - ブランチ状況確認はGitHub文面作成の準備作業として位置づけ
  - PR / Release / About 以外では、必ずしも `~~~~markdown` ラップを要求しないように検証条件を調整

- `references/branch-status.md` を追加
  - 現在ブランチ、upstream、ahead / behind、working tree、staged、untracked を確認する手順を定義
  - `git status -sb` を基本確認として明記
  - `tag*` と `v*` の最近3件をそれぞれ確認する基本所作を追加
  - `git fetch` / `git pull` / `git push` / PR作成など、明示依頼なしで実行しない安全ルールを追加
  - ブランチ状況レポートの日本語Markdown出力形を定義

- `index.json` を更新
  - 追加された `branch-status.md` をインデックスに反映
  - `igapyon-github-writer` のスキル説明更新を反映

- `igapyon-miku-soft-developer/index.json` を更新
  - 既存の Node App Workflow 文書サイズ変更をインデックスに反映