### PR TITLE
miku-soft Node app 文書に Release CLI bundle 運用を追加

### DIFF
--- a/skills/igapyon-miku-soft-developer/index.json
+++ b/skills/igapyon-miku-soft-developer/index.json
@@ -7,7 +7,7 @@
       "path": "references/10-node-app-workflow.md",
       "ext": "md",
       "dir": "references",
-      "size": 3653,
+      "size": 5322,
       "summary": "Node App Workflow"
     },
     {
@@ -71,7 +71,7 @@
       "path": "references/miku-soft-basic/miku-soft-10-mainapp-design-v20260505.md",
       "ext": "md",
       "dir": "references/miku-soft-basic",
-      "size": 62953,
+      "size": 64302,
       "summary": "Miku Software Main Application Design v20260505"
     },
     {

--- a/skills/igapyon-miku-soft-developer/references/10-node-app-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/10-node-app-workflow.md
@@ -27,9 +27,28 @@ Before editing, identify which Node app shape the repository currently uses:
 - Single-file Web App plus CLI: check `index.html`, product-named HTML, `index-src.html`, `src/`, `lht-cmn/`, build scripts, CLI scripts, and browser or UI tests.
 - CLI / structured JSON tool: check `src/main.ts`, `src/*types.ts`, CLI specs under `docs/`, `bin`, `exports`, `types`, and stdout / stderr contract tests.
 - Bundled runtime artifact: check `bundle/`, `scripts/build-cli-bundle.mjs`, `scripts/build-cli-runtime.mjs`, smoke scripts, and package `files`.
+- Release CLI bundle: check `.github/workflows/release-cli-bundle.yml`, release asset naming, version checks, `bundle/*.mjs`, `bundle/*-sources.tgz`, and `smoke:bundle`.
 - AI-facing operation surface: check projection, patch, validation, summary, diagnostics, or state-oriented docs and tests.
 
 Use the detected shape to decide which contracts must be preserved. Do not force every repository into every shape.
+
+## Release Bundle Workflow
+
+When a Node CLI main app publishes a single-file runtime artifact through GitHub Releases, inspect the release workflow before changing build, bundle, version, or package metadata.
+
+Check these points:
+
+- The workflow is triggered by GitHub Release publication and, when useful, `workflow_dispatch` with an explicit `tag_name`.
+- The workflow only attaches release assets for version tags, normally `v*`.
+- The checkout ref uses the release tag or manually supplied tag, not an unrelated branch tip.
+- The workflow runs dependency install, build, asset preparation, and `smoke:bundle` before upload.
+- The release tag version is checked against `package.json` `version`; if patch suffix tags are allowed, the accepted suffix rule is explicit.
+- Runtime and source assets are copied from `bundle/` into a release staging directory with product and version in the filename.
+- Upload uses the GitHub Release tag and only the prepared miku-soft CLI assets, normally `<product>-<version>.mjs` and `<product>-sources-<version>.tgz`.
+- Do not add a broad repository source ZIP or generic source archive as a custom uploaded release asset.
+- Actions runtime compatibility settings, such as Node.js version or JavaScript action runtime flags, are kept only when the reference project or current repository needs them.
+
+Do not treat Release asset upload as a substitute for local bundle verification. The local build and smoke contract should remain valid without GitHub Actions.
 
 ## Checklist
 

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-10-mainapp-design-v20260505.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-10-mainapp-design-v20260505.md
@@ -348,6 +348,23 @@ For downstream Agent Skills or other local automation, a build may produce a sin
 
 A source archive such as `bundle/<product>-sources.tgz` may be useful for rebuild, audit, or downstream confirmation. Treat these files as generated artifacts: rebuild them through documented commands and verify them with smoke tests rather than editing them directly.
 
+#### GitHub Release CLI Assets
+
+When a CLI-oriented main application publishes a single-file runtime artifact, GitHub Releases may carry the runnable bundle and its source archive as release assets.
+
+This release path is a distribution layer over the local build contract. It should not be the only place where the bundle is created or verified. The repository should still provide local commands that build the bundle and verify it with a smoke test.
+
+Recommended release asset behavior is as follows.
+
+- Trigger release-asset attachment from published GitHub Releases and, when useful, manual dispatch with an explicit tag.
+- Restrict release bundle upload to version tags such as `v*`.
+- Check that the release tag version matches `package.json` `version`, or document any accepted dot-suffix rule.
+- Build from the release tag, not from an unrelated branch state.
+- Stage release assets with product and version in their filenames, such as `<product>-<version>.mjs` and `<product>-sources-<version>.tgz`.
+- Upload only those prepared miku-soft CLI assets as custom release assets; do not add broad repository source archives as extra uploaded assets.
+- Run the bundle smoke test before uploading release assets.
+- Keep GitHub Actions runtime compatibility settings local to the workflow and do not let them change the product runtime contract.
+
 ### `workplace/` Directory Principles
 
 The repository root of a main application contains a `workplace/` directory for local work.


### PR DESCRIPTION
## 概要

`igapyon-miku-soft-developer` の Node app 向け文書に、GitHub Release へ CLI bundle を添付する運用観点を追加します。

## 変更内容

- `10-node-app-workflow.md` に Release CLI bundle の形状確認を追加
  - `.github/workflows/release-cli-bundle.yml`
  - release asset naming
  - version checks
  - `bundle/*.mjs`
  - `bundle/*-sources.tgz`
  - `smoke:bundle`

- `10-node-app-workflow.md` に `## Release Bundle Workflow` を追加
  - GitHub Release 公開時や `workflow_dispatch` での release asset 添付を確認する流れを定義
  - `v*` タグ、release tag checkout、`package.json` version 整合、build / smoke / upload の確認観点を追加
  - custom release asset は miku-soft CLI 用の `.mjs` と `-sources.tgz` を基本とし、広い repository source archive を追加アップロードしない方針を明記

- `miku-soft-10-mainapp-design-v20260505.md` に `#### GitHub Release CLI Assets` を追加
  - GitHub Release はローカル build / smoke 契約の上にある配布層として整理
  - release asset のタグ条件、version整合、ファイル名、bundle smoke test、GitHub Actions runtime設定の扱いを記述

- `index.json` を更新
  - 更新された Node app workflow と main application 基本文書のサイズを反映