### PR TITLE
igapyon-miku-soft-developer に構想・命名前段ワークフローを追加

### DIFF
--- a/skills/igapyon-miku-soft-developer/SKILL.md
+++ b/skills/igapyon-miku-soft-developer/SKILL.md
@@ -13,6 +13,7 @@ Use it only after the user explicitly asks to use `igapyon-miku-soft-developer` 
 
 After the skill is explicitly active, choose one mode:
 
+- Concept and naming mode: clarify the app concept and decide the miku-soft base repository name before creating files.
 - New project mode: create a new miku-soft project or initialize a repository as a miku-soft project.
 - Maintenance mode: inspect, update, or repair an existing miku-soft project.
 
@@ -24,13 +25,14 @@ Prerequisite: use `igapyon-repo-conventions` as the repository-conventions basel
 
 1. Read [references/activation-policy.md](references/activation-policy.md) if activation behavior is relevant.
 2. Read [references/architecture-rules.md](references/architecture-rules.md).
-3. For new project work, read [references/new-project-workflow.md](references/new-project-workflow.md).
-4. For existing project work, read [references/maintenance-workflow.md](references/maintenance-workflow.md).
-5. Read the specific workflow reference when relevant: [references/10-node-app-workflow.md](references/10-node-app-workflow.md), [references/30-java-straight-conversion-workflow.md](references/30-java-straight-conversion-workflow.md), [references/40-agent-skills-workflow.md](references/40-agent-skills-workflow.md), or [references/50-mcp-workflow.md](references/50-mcp-workflow.md).
-6. Read [references/repo-operations.md](references/repo-operations.md) for miku-soft-specific additions.
-7. Inspect the target repository before editing.
-8. Preserve unrelated user changes.
-9. Keep product behavior in the product core or upstream runtime artifacts, not in the skill instructions.
+3. For concept and naming work, read [references/00-concept-naming-workflow.md](references/00-concept-naming-workflow.md).
+4. For new project work, read [references/new-project-workflow.md](references/new-project-workflow.md).
+5. For existing project work, read [references/maintenance-workflow.md](references/maintenance-workflow.md).
+6. Read the specific workflow reference when relevant: [references/10-node-app-workflow.md](references/10-node-app-workflow.md), [references/30-java-straight-conversion-workflow.md](references/30-java-straight-conversion-workflow.md), [references/40-agent-skills-workflow.md](references/40-agent-skills-workflow.md), or [references/50-mcp-workflow.md](references/50-mcp-workflow.md).
+7. Read [references/repo-operations.md](references/repo-operations.md) for miku-soft-specific additions.
+8. Inspect the target repository before editing.
+9. Preserve unrelated user changes.
+10. Keep product behavior in the product core or upstream runtime artifacts, not in the skill instructions.
 
 Use `index.json` when you need to discover the available bundled reference files, but treat `SKILL.md` and files under `references/` as the source of truth.
 

--- a/skills/igapyon-miku-soft-developer/index.json
+++ b/skills/igapyon-miku-soft-developer/index.json
@@ -3,6 +3,14 @@
   "basePath": ".",
   "files": [
     {
+      "name": "00-concept-naming-workflow.md",
+      "path": "references/00-concept-naming-workflow.md",
+      "ext": "md",
+      "dir": "references",
+      "size": 2571,
+      "summary": "Concept and Naming Workflow"
+    },
+    {
       "name": "10-node-app-workflow.md",
       "path": "references/10-node-app-workflow.md",
       "ext": "md",
@@ -49,6 +57,14 @@
       "dir": "references",
       "size": 2019,
       "summary": "miku-soft Architecture Rules"
+    },
+    {
+      "name": "existing-miku-soft-repositories.md",
+      "path": "references/existing-miku-soft-repositories.md",
+      "ext": "md",
+      "dir": "references",
+      "size": 3591,
+      "summary": "Existing igapyon miku-soft Repositories"
     },
     {
       "name": "maintenance-workflow.md",
@@ -111,7 +127,7 @@
       "path": "references/new-project-workflow.md",
       "ext": "md",
       "dir": "references",
-      "size": 2363,
+      "size": 3683,
       "summary": "New miku-soft Project Workflow"
     },
     {
@@ -119,7 +135,7 @@
       "path": "references/repo-operations.md",
       "ext": "md",
       "dir": "references",
-      "size": 1189,
+      "size": 1507,
       "summary": "miku-soft Repository Operations"
     },
     {
@@ -127,7 +143,7 @@
       "path": "SKILL.md",
       "ext": "md",
       "dir": "",
-      "size": 3128,
+      "size": 3372,
       "summary": "--- name: igapyon-miku-soft-developer description: Use only when the user explicitly asks to use igapyon-miku-soft-developer or explicitly asks to apply the miku-soft developer skill. If the user says they want to create a new miku-soft project, maintain a"
     }
   ]

--- a/skills/igapyon-miku-soft-developer/references/00-concept-naming-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/00-concept-naming-workflow.md
@@ -1,0 +1,52 @@
+# Concept and Naming Workflow
+
+Use this workflow after `igapyon-miku-soft-developer` has been explicitly activated and before creating a 10 main application repository.
+
+This phase supports deciding what the app should be and what the project should be called. It may end with only a decided product concept and repository name.
+
+During this phase, the target repository does not exist or is not yet the working target. Do not create, edit, or write files for the future target project while running this workflow. Present the result to the user as Markdown text in the conversation instead.
+
+## Goal
+
+Before scaffolding a repository, establish:
+
+- the app's practical user problem
+- the target input and output
+- the smallest useful first version
+- the likely 10 main application shape
+- the base repository name
+
+## Workflow
+
+1. Ask for or infer the rough app idea in one or two sentences.
+2. Clarify the core workflow: what the user gives the app, what the app does, and what artifact or view the user gets back.
+3. Identify whether the first deliverable should be a 10 main application. Do not jump to 20 Java, 40 Agent Skills, or 50 MCP unless the user explicitly asks for those companion layers first.
+4. Propose one to three repository names using the `miku-<domain>` pattern.
+5. Compare candidates with [existing-miku-soft-repositories.md](existing-miku-soft-repositories.md) and current GitHub information when exact current availability matters.
+6. Select a final base name with the user.
+7. Only after the name is decided and the user asks to proceed with creation, continue to [new-project-workflow.md](new-project-workflow.md) for repository location, first delivery surface details, docs, TODO, workplace conventions, and scaffolding.
+
+## Naming Rules
+
+- New base application repositories should start with `miku-`.
+- Older compact names such as `mikuproject` and `mikuscore` are historical names, not the preferred pattern for new projects.
+- Avoid names already used by existing `igapyon` `miku*` repositories.
+- Avoid names that would make a base application look like a companion repository.
+- Reserve `-java` for 20 Java applications.
+- Reserve `-skills` for 40 Agent Skills repositories.
+- Reserve `-mcp` for 50 MCP server repositories.
+
+## Output Shape
+
+When this phase completes, summarize the decision as Markdown text in the conversation. Do not write this summary into a file during the 00 phase.
+
+```md
+## Concept and Naming Result
+
+- App concept:
+- Input:
+- Output:
+- First target layer: 10 main application
+- Repository name:
+- Reasoning:
+```

--- a/skills/igapyon-miku-soft-developer/references/existing-miku-soft-repositories.md
+++ b/skills/igapyon-miku-soft-developer/references/existing-miku-soft-repositories.md
@@ -1,0 +1,70 @@
+# Existing igapyon miku-soft Repositories
+
+This file summarizes public `igapyon` GitHub repositories whose names start with `miku`, checked on 2026-05-05.
+
+Use this list as a naming reference before creating a new miku-soft project. Treat GitHub as the source of truth when exact current availability matters.
+
+Source:
+
+- https://api.github.com/users/igapyon/repos?per_page=100&sort=full_name
+- https://api.github.com/users/igapyon/repos?per_page=100&page=2&sort=full_name
+
+## Naming Pattern
+
+- Older base applications may use compact `miku...` names, such as `mikuproject` and `mikuscore`.
+- New base applications should start with `miku-` and use the `miku-<domain>` pattern.
+- Java companion repositories use `-java`.
+- Agent Skill companion repositories use `-skills`.
+- MCP companion repositories use `-mcp`.
+- Avoid using a companion suffix for the first base application unless that repository is specifically the companion layer.
+
+## Repository List by miku-soft Layer
+
+### 10 Main Applications
+
+These are base product repositories. New repositories in this layer should prefer `miku-<domain>`.
+
+| Repository | Language | Notes |
+| --- | --- | --- |
+| `miku-abc-player` | HTML | ABC-centered single-file web app for ABC, MusicXML, MIDI, and MuseScore preview, playback, editing, and export. |
+| `miku-docx2md` | HTML | Browser-local DOCX to Markdown conversion. |
+| `miku-grep` | TypeScript | Grep-style text search tool. |
+| `miku-indexgen` | TypeScript | Generates flat `index.json` and optional `index.md` for reference discovery. |
+| `miku-readfile` | TypeScript | Local-first CLI for reading explicitly selected text files as JSON. |
+| `miku-unicode-guard` | TypeScript | CLI tool for detecting suspicious Unicode characters in Markdown and source files. |
+| `miku-xlsx2md` | JavaScript | Single-file Web App for extracting Excel workbook content as Markdown. |
+| `mikuproject` | JavaScript | Single-file Web App for MS Project XML conversion, WBS reports, and AI-facing JSON views. |
+| `mikuscore` | JavaScript | MusicXML-first score converter for notation and AI workflow bridges. |
+
+### 20 Java Applications
+
+These are Java companion repositories and use the `-java` suffix.
+
+| Repository | Language | Notes |
+| --- | --- | --- |
+| `miku-grep-java` | Java | Java companion for `miku-grep`. |
+| `miku-indexgen-java` | Java | Java companion for `miku-indexgen`, including CLI and Maven plugin support. |
+| `miku-readfile-java` | Java | Java companion for `miku-readfile`. |
+| `miku-xlsx2md-java` | Java | Java companion for `miku-xlsx2md`. |
+| `mikuproject-java` | Java | Java companion for `mikuproject`. |
+| `mikuscore-java` | Java | Java companion for `mikuscore`, currently in progress. |
+
+### 40 Agent Skills
+
+These are Agent Skills companion repositories and use the `-skills` suffix.
+
+| Repository | Language | Notes |
+| --- | --- | --- |
+| `miku-grep-skills` | JavaScript | Agent Skills package for structured local grep workflows. |
+| `miku-readfile-skills` | JavaScript | Agent Skills package for `miku-readfile`. |
+| `mikuproject-skills` | JavaScript | Agent Skills package for `mikuproject` workflows. |
+| `mikuproject-skills-java` | JavaScript | Abandoned project. Out of maintenance scope and not an active naming precedent. |
+| `mikuscore-skills` | JavaScript | Agent Skills package for `mikuscore` music and score workflows. |
+
+### 50 MCP Servers
+
+These are MCP server companion repositories and use the `-mcp` suffix.
+
+| Repository | Language | Notes |
+| --- | --- | --- |
+| `mikuproject-mcp` | JavaScript | Local stdio MCP server adapter for `mikuproject`. |

--- a/skills/igapyon-miku-soft-developer/references/new-project-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/new-project-workflow.md
@@ -6,12 +6,18 @@ Detailed design guidance lives under [miku-soft-basic/](miku-soft-basic/). Keep 
 
 ## Before Creating Files
 
+If the app concept or repository name is not decided yet, first use [00-concept-naming-workflow.md](00-concept-naming-workflow.md). Do not ask for full scaffolding details until the app specification outline and base repository name are settled.
+
+Start with project naming before asking for the full scaffolding details. Discuss the intended product concept, propose or validate the repository name, and compare it with [existing-miku-soft-repositories.md](existing-miku-soft-repositories.md) and current GitHub information when exact current availability matters. New base application names should start with `miku-`; older compact `miku...` names are existing historical names, not the preferred pattern for new projects. Avoid duplicate names and avoid names that would confuse a base application with its `-java`, `-skills`, or `-mcp` companion repository.
+
 Resolve the minimum facts needed to start:
 
 - project name and repository location
 - primary input and output
 - first delivery surface: main app, Java app, Agent Skill, MCP server, or a combination
 - whether README, docs, TODO, and workplace conventions should be initialized now
+
+Do not ask whether the agent should perform GitHub repository creation or other GitHub operations. Those operations are handled by the human, as defined in [repo-operations.md](repo-operations.md).
 
 Then read the relevant basic document selected by [architecture-rules.md](architecture-rules.md).
 
@@ -21,6 +27,8 @@ For first delivery surface details, read the relevant specific workflow:
 - [30-java-straight-conversion-workflow.md](30-java-straight-conversion-workflow.md): Java straight conversion
 - [40-agent-skills-workflow.md](40-agent-skills-workflow.md): Agent Skills package
 - [50-mcp-workflow.md](50-mcp-workflow.md): MCP server
+
+When showing a generic new-project example, use the Node.js / TypeScript main application form from `10-node-app-workflow.md` first. Do not use an MCP server example unless the user has already asked for MCP or the surrounding context clearly points to MCP.
 
 ## Basic Document Copy
 

--- a/skills/igapyon-miku-soft-developer/references/repo-operations.md
+++ b/skills/igapyon-miku-soft-developer/references/repo-operations.md
@@ -8,6 +8,7 @@ This file only records miku-soft-specific additions.
 
 ## miku-soft Additions
 
+- GitHub operations are a human responsibility. Do not create GitHub repositories, push branches or tags, open pull requests, publish releases, or upload release assets as part of this skill workflow. The agent may prepare local files, inspect local git state, and draft GitHub-facing text or instructions when asked.
 - For new miku-soft projects, copy the bundled basic documents from [miku-soft-basic/](miku-soft-basic/) into the target repository's `docs/` directory as described in [new-project-workflow.md](new-project-workflow.md).
 - Keep miku-soft basic document filenames unchanged when copying them into `docs/`.
 - Use README and TODO for the actual project state; avoid restating broad miku-soft theory that already lives in the basic documents.


### PR DESCRIPTION
## 概要

`igapyon-miku-soft-developer` skill に、miku-soft の新規 10 main application 作成へ入る前段として、アプリ仕様の整理とプロジェクト名決定を支援するワークフローを追加しました。

あわせて、既存の `miku*` リポジトリ一覧を参照資料として追加し、新規プロジェクトでは `miku-<domain>` 形式を優先する命名ルールや、GitHub 操作は人間が担当する前提を明文化しています。

## 変更内容

- `SKILL.md` に `Concept and naming mode` を追加
- 新規参照資料 `00-concept-naming-workflow.md` を追加
  - 10 main application 作成前に、アプリの目的、入力、出力、最小初期版、ベースリポジトリ名を整理する流れを定義
  - 00 フェーズ中はターゲット repo 向けのファイル作成・編集を行わず、結果を会話上の Markdown として返すルールを追加
- 新規参照資料 `existing-miku-soft-repositories.md` を追加
  - 既存 `miku*` リポジトリを 10 / 20 / 40 / 50 の miku-soft レイヤー別に分類
  - 新規 base application は `miku-<domain>` を優先する命名規則を明記
  - `mikuproject-skills-java` は廃棄済みでメンテ対象外として明記
- `new-project-workflow.md` を更新
  - アプリ仕様 outline と base repository name が未決定の場合は、先に 00 concept and naming workflow を使うよう誘導
  - 汎用例は MCP ではなく 10 Node.js / TypeScript main application から始めるルールを追加
  - GitHub repository 作成などの GitHub 操作をエージェントに依頼する確認をしないルールを追加
- `repo-operations.md` を更新
  - GitHub repository 作成、push、tag、PR 作成、release 公開、release asset upload は人間担当と明記
- `index.json` を再生成し、追加・更新した参照資料を反映