### PR TITLE
igapyon-miku-soft-developer に CI baseline 確認を追加

### DIFF
--- a/skills/igapyon-miku-soft-developer/index.json
+++ b/skills/igapyon-miku-soft-developer/index.json
@@ -15,7 +15,7 @@
       "path": "references/10-node-app-workflow.md",
       "ext": "md",
       "dir": "references",
-      "size": 5322,
+      "size": 7083,
       "summary": "Node App Workflow"
     },
     {
@@ -71,7 +71,7 @@
       "path": "references/maintenance-workflow.md",
       "ext": "md",
       "dir": "references",
-      "size": 1147,
+      "size": 1304,
       "summary": "Existing miku-soft Maintenance Workflow"
     },
     {

--- a/skills/igapyon-miku-soft-developer/references/10-node-app-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/10-node-app-workflow.md
@@ -27,10 +27,27 @@ Before editing, identify which Node app shape the repository currently uses:
 - Single-file Web App plus CLI: check `index.html`, product-named HTML, `index-src.html`, `src/`, `lht-cmn/`, build scripts, CLI scripts, and browser or UI tests.
 - CLI / structured JSON tool: check `src/main.ts`, `src/*types.ts`, CLI specs under `docs/`, `bin`, `exports`, `types`, and stdout / stderr contract tests.
 - Bundled runtime artifact: check `bundle/`, `scripts/build-cli-bundle.mjs`, `scripts/build-cli-runtime.mjs`, smoke scripts, and package `files`.
+- GitHub Actions CI baseline: check `.github/workflows/`, PR / push triggers, dependency install, and primary verification commands.
 - Release CLI bundle: check `.github/workflows/release-cli-bundle.yml`, release asset naming, version checks, `bundle/*.mjs`, `bundle/*-sources.tgz`, and `smoke:bundle`.
 - AI-facing operation surface: check projection, patch, validation, summary, diagnostics, or state-oriented docs and tests.
 
 Use the detected shape to decide which contracts must be preserved. Do not force every repository into every shape.
+
+## GitHub Actions CI Baseline
+
+For Node.js / TypeScript main applications, inspect the CI baseline during late-stage hardening and release-readiness work, especially when `package.json` provides `build`, `test`, `typecheck`, `smoke`, or similar verification scripts.
+
+Check these points:
+
+- `.github/workflows/` exists when the repository is expected to run GitHub Actions checks.
+- A CI workflow, normally `.github/workflows/ci.yml`, runs on `push` and `pull_request`.
+- The workflow installs dependencies with `npm ci`.
+- The workflow runs the repository's primary verification command, usually `npm run build`, and also `npm test`, `npm run typecheck`, `npm run smoke`, or `npm run verify` when those scripts are the documented local contract.
+- For release-readiness, audit or package dry-run expectations are represented either by a local script such as `npm run verify`, by CI, or by a documented manual release check. Do not make `npm audit --audit-level=moderate` mandatory for every CI baseline unless the repository has adopted that policy.
+
+If CI is missing, report it as a release-readiness gap, not as a product implementation bug. When the user has asked to proceed in an initial release, late-stage hardening, or release-readiness context, add or propose a minimal local workflow file such as `.github/workflows/ci.yml` when that is within the requested work.
+
+Creating or editing a local workflow file is allowed repository work. Pushing branches, opening pull requests, publishing releases, or uploading release assets remains a human GitHub operation as described in [repo-operations.md](repo-operations.md).
 
 ## Release Bundle Workflow
 

--- a/skills/igapyon-miku-soft-developer/references/maintenance-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/maintenance-workflow.md
@@ -22,7 +22,8 @@ Then inspect git status.
 2. Read the relevant basic document selected by [architecture-rules.md](architecture-rules.md).
 3. Make the smallest change that preserves the documented boundary.
 4. Update README, docs, TODO, tests, or indexes when the change affects them.
-5. Run relevant verification.
-6. Review git diff and status before finishing.
+5. When the work is release-readiness or late-stage hardening, inspect CI / GitHub Actions status and report missing baseline CI as a release-readiness gap.
+6. Run relevant verification.
+7. Review git diff and status before finishing.
 
 Do not update only one entrypoint when repository evidence shows the requested behavior belongs to shared product semantics.

--- a/skills/igapyon-qiita-writer/index.json
+++ b/skills/igapyon-qiita-writer/index.json
@@ -67,6 +67,14 @@
       "summary": "掲載先情報"
     },
     {
+      "name": "20260505-general-ai-agent-skills-basic.md",
+      "path": "references/general/20260505-general-ai-agent-skills-basic.md",
+      "ext": "md",
+      "dir": "references/general",
+      "size": 10551,
+      "summary": "掲載先情報"
+    },
+    {
       "name": "20260412-miku-abc-player-intro.md",
       "path": "references/miku-abc-player/20260412-miku-abc-player-intro.md",
       "ext": "md",


### PR DESCRIPTION
## 概要

`igapyon-miku-soft-developer` の Node.js / TypeScript main application 向け workflow に、GitHub Actions CI baseline の確認観点を追加します。

late-stage hardening / release-readiness の文脈で、ローカル検証だけでなく PR / push 時の継続検証が整っているかを確認できるようにします。

## 変更内容

- `10-node-app-workflow.md` の Shape Detection に GitHub Actions CI baseline を追加
- `10-node-app-workflow.md` に `GitHub Actions CI Baseline` 節を追加
  - `.github/workflows/` の有無
  - `push` / `pull_request` trigger
  - `npm ci`
  - `npm run build` などの primary verification command
  - `npm test` / `npm run typecheck` / `npm run smoke` / `npm run verify` が documented local contract の場合の扱い
- `npm audit --audit-level=moderate` は全 CI baseline の必須項目ではなく、release-readiness の確認候補として扱う方針を明記
- CI がない場合は product implementation bug ではなく release-readiness gap として報告する方針を追加
- ローカル workflow ファイルの作成・編集は可、push / PR / Release / release asset upload は人間側の GitHub 操作として扱う境界を明記
- `maintenance-workflow.md` の Change Checklist に、release-readiness / late-stage hardening 時の CI / GitHub Actions status 確認を追加
- `index.json` を再生成
  - `igapyon-miku-soft-developer/index.json`
  - `igapyon-qiita-writer/index.json`

## 確認事項

- `mvn generate-resources` 実行済み
- `git diff --check` 実行済み