### PR TITLE
Release CLI bundle と npm pack tarball の違いを明記

### DIFF
--- a/skills/igapyon-miku-soft-developer/index.json
+++ b/skills/igapyon-miku-soft-developer/index.json
@@ -15,7 +15,7 @@
       "path": "references/10-node-app-workflow.md",
       "ext": "md",
       "dir": "references",
-      "size": 9511,
+      "size": 10338,
       "summary": "Node App Workflow"
     },
     {

--- a/skills/igapyon-miku-soft-developer/references/10-node-app-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/10-node-app-workflow.md
@@ -63,7 +63,7 @@ If the repository does not yet have a bundle artifact script, do not assume the 
 - source archive
 - generated documentation bundle
 
-Then ask or record which release asset should be attached, unless the user has clearly specified it.
+Then ask or record which release asset should be attached, unless the user has clearly specified it. Do not treat `npm pack` output as the default release CLI bundle. An npm pack tarball is a package publication artifact named by npm as `<package-name>-<version>.tgz`; it is not the same artifact role as a single-file CLI runtime plus source archive.
 
 Creating or editing a local workflow file is allowed repository work. Pushing branches, opening pull requests, publishing releases, running `npm publish`, configuring secrets, or uploading release assets remains a human GitHub or registry operation as described in [repo-operations.md](repo-operations.md).
 
@@ -80,8 +80,16 @@ Check these points:
 - The release tag version is checked against `package.json` `version`; if patch suffix tags are allowed, the accepted suffix rule is explicit.
 - Runtime and source assets are copied from `bundle/` into a release staging directory with product and version in the filename.
 - Upload uses the GitHub Release tag and only the prepared miku-soft CLI assets, normally `<product>-<version>.mjs` and `<product>-sources-<version>.tgz`.
+- Do not implement a Release CLI bundle workflow by running `npm pack` and uploading `release-assets/*.tgz` unless the user explicitly asked for the npm package tarball as the release asset.
 - Do not add a broad repository source ZIP or generic source archive as a custom uploaded release asset.
 - Actions runtime compatibility settings, such as Node.js version or JavaScript action runtime flags, are kept only when the reference project or current repository needs them.
+
+For a Release CLI bundle request, the expected release assets are usually:
+
+- `<product>-<version>.mjs`
+- `<product>-sources-<version>.tgz`
+
+If the current repository only has `npm pack` and does not yet generate `bundle/<product>.mjs` and `bundle/<product>-sources.tgz`, first report that gap and add or propose the bundle build / smoke path before wiring the GitHub Release upload.
 
 When the repository has a documented bundle build and smoke script, the expected local workflow file is normally `.github/workflows/release-cli-bundle.yml` with this shape, adapted to the product name and artifact paths:
 


### PR DESCRIPTION
## 概要

`igapyon-miku-soft-developer` の Node.js workflow guidance に、Release CLI bundle と `npm pack` tarball を混同しないための説明を追加します。

GitHub Release に添付する Release CLI bundle では、通常 `<product>-<version>.mjs` と `<product>-sources-<version>.tgz` を期待することを明記し、`npm pack` の出力を既定の release CLI bundle として扱わないようにします。

## 変更内容

- `10-node-app-workflow.md` の GitHub Actions intent resolution に、`npm pack` output を default release CLI bundle として扱わない方針を追加
- `npm pack` tarball は npm が `<package-name>-<version>.tgz` として命名する package publication artifact であり、single-file CLI runtime plus source archive とは artifact role が異なることを明記
- Release Bundle Workflow のチェック項目に、明示的に npm package tarball を要求された場合を除き、`npm pack` と `release-assets/*.tgz` upload で Release CLI bundle workflow を実装しない方針を追加
- Release CLI bundle request で通常期待する release assets を明記
  - `<product>-<version>.mjs`
  - `<product>-sources-<version>.tgz`
- repository が `npm pack` しか持たず、`bundle/<product>.mjs` と `bundle/<product>-sources.tgz` を生成していない場合は、GitHub Release upload より先に bundle build / smoke path の不足として報告し、追加または提案する方針を追加
- `igapyon-miku-soft-developer/index.json` を更新

## 確認事項

- 対象コミットの diff では、生成コマンドや検証コマンドの実行結果は確認できませんでした。