### PR TITLE
Release CLI bundle の patch suffix tag 例を追記

### DIFF
--- a/skills/igapyon-miku-soft-developer/index.json
+++ b/skills/igapyon-miku-soft-developer/index.json
@@ -15,7 +15,7 @@
       "path": "references/10-node-app-workflow.md",
       "ext": "md",
       "dir": "references",
-      "size": 10338,
+      "size": 10666,
       "summary": "Node App Workflow"
     },
     {

--- a/skills/igapyon-miku-soft-developer/references/10-node-app-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/10-node-app-workflow.md
@@ -89,6 +89,8 @@ For a Release CLI bundle request, the expected release assets are usually:
 - `<product>-<version>.mjs`
 - `<product>-sources-<version>.tgz`
 
+If the package version is `0.5.0`, accepted release tags include `v0.5.0`, `v0.5.0.1`, and `v0.5.0.2`. Reject unrelated version tags such as `v0.5.1` and `v0.6.0`. Use the tag version, without the leading `v`, in release asset filenames so a patch suffix tag such as `v0.5.0.1` produces assets such as `<product>-0.5.0.1.mjs`.
+
 If the current repository only has `npm pack` and does not yet generate `bundle/<product>.mjs` and `bundle/<product>-sources.tgz`, first report that gap and add or propose the bundle build / smoke path before wiring the GitHub Release upload.
 
 When the repository has a documented bundle build and smoke script, the expected local workflow file is normally `.github/workflows/release-cli-bundle.yml` with this shape, adapted to the product name and artifact paths:


### PR DESCRIPTION
## 概要

miku-soft developer の Node App Workflow に、Release CLI bundle で patch suffix 付き release tag を扱う場合の具体例を追記しました。

## 変更内容

- `references/10-node-app-workflow.md` に、`package.json` version `0.5.0` に対する release tag の許可・拒否例を追加
- `v0.5.0.1` のような patch suffix tag では、先頭の `v` を除いた tag version を release asset filename に使うことを明記
- `index.json` を再生成し、対象 reference file の size 情報を更新

## 補足

この変更により、Release CLI bundle workflow の説明上、次のような運用ルールが明確になります。

- 許可例: `v0.5.0`, `v0.5.0.1`, `v0.5.0.2`
- 拒否例: `v0.5.1`, `v0.6.0`
- asset filename 例: `<product>-0.5.0.1.mjs`