### PR TITLE
Java straight-conversion 手順の初期入力と Maven plugin 方針を整理

### DIFF
--- a/skills/igapyon-miku-soft-developer/index.json
+++ b/skills/igapyon-miku-soft-developer/index.json
@@ -23,7 +23,7 @@
       "path": "references/30-java-straight-conversion-workflow.md",
       "ext": "md",
       "dir": "references",
-      "size": 9669,
+      "size": 13642,
       "summary": "Java Straight Conversion Workflow"
     },
     {
@@ -103,7 +103,7 @@
       "path": "references/miku-soft-basic/miku-soft-30-straight-conversion-v20260425.md",
       "ext": "md",
       "dir": "references/miku-soft-basic",
-      "size": 55702,
+      "size": 57309,
       "summary": "Miku Software Straight Conversion Guide v20260425"
     },
     {

--- a/skills/igapyon-miku-soft-developer/references/30-java-straight-conversion-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/30-java-straight-conversion-workflow.md
@@ -1,7 +1,12 @@
 # Java Straight Conversion Workflow
 
 Use this workflow for creating or maintaining a Java straight-conversion
-version of a miku-soft Node.js / TypeScript upstream project.
+version of a miku-soft Node.js / TypeScript main application.
+
+In this workflow, `upstream` means the source miku-soft main application that
+corresponds to [10-node-app-workflow.md](10-node-app-workflow.md). It is
+normally the suffixless Node.js / TypeScript repository, while this workflow
+targets the Java companion repository, normally with a `-java` suffix.
 
 Detailed design guidance lives in:
 
@@ -10,6 +15,26 @@ Detailed design guidance lives in:
 
 Keep this file as the execution checklist. Load the detailed design documents
 only when a policy decision is unclear.
+
+## Required Initial Input
+
+At the beginning of a Java straight-conversion task, require the upstream
+Node.js / TypeScript main application GitHub repository URL: the repository
+that would be maintained using [10-node-app-workflow.md](10-node-app-workflow.md).
+If the user has not provided it yet, ask for it before inventory, scaffolding,
+or implementation work.
+
+Also confirm the upstream branch, tag, release, commit, or vendored snapshot
+that should be treated as the compatibility source. When the exact upstream
+state is unknown, use the GitHub repository URL as the first anchor and record
+the follow-up needed to pin the precise source revision.
+
+Also require one or more similar existing miku-soft Java companion repositories
+as sister-project references under `workplace/`. These are `-java` repositories
+at the same companion layer as the target Java repository, not the Node.js /
+TypeScript upstream. If the user has not provided them yet, ask for the closest
+available `-java` sister project source checkout path under `workplace/` before
+scaffolding or implementation work.
 
 ## First Reads
 
@@ -22,21 +47,67 @@ only when a policy decision is unclear.
 
 Confirm these before editing Java code:
 
-- upstream source repository and branch or vendored snapshot
+- upstream Node.js / TypeScript main application GitHub repository URL, and its
+  branch, tag, commit, release, or vendored snapshot
+- similar existing `-java` sister project source checkout under `workplace/`
 - target Java repository, artifactId, base package, and CLI class
 - Java source / target compatibility, normally `1.8`
 - Maven as the build tool
 - JUnit Jupiter as the test framework
 - primary verification command, normally `mvn test`
 - runtime packaging shape: executable fat jar, and distribution zip when useful
+- Maven plugin support is out of initial scope by default unless the developer
+  explicitly requests it at the start
 - whether the upstream body is vendored, connected as a remote, or cloned under
   `workplace/`
 - the intended compatibility target, such as CLI JSON parity, generated file
-  parity, Maven plugin behavior, or a narrower partial conversion
+  parity, Maven plugin behavior when explicitly requested, or a narrower
+  partial conversion
 
 Do not start by redesigning the upstream product for Java. Preserve upstream
 file boundaries, vocabulary, request / result shapes, diagnostics, and CLI
 behavior unless the user explicitly asks for a separate Java-side extension.
+
+## Sister Java Reference Projects
+
+For initial conversion or substantial maintenance, use one or more existing
+miku-soft `-java` companion repositories expanded under `workplace/` as
+sister-project references.
+
+Treat these sister projects as practical shape references for Maven layout,
+package naming, CLI entry points, core API boundaries, tests, docs, release
+workflows, distribution packaging, and Java-side extension separation. Use the
+basic documents as the source of design intent, and use the `workplace/`
+sister projects to confirm implementation details that are easy to miss.
+
+When multiple `-java` references are available, prefer the newer project version
+or the project closest to the target product shape, such as CLI-only, JSON
+contract, generated artifact, Maven plugin, or distribution zip.
+
+Do not copy `workplace/` contents into the target repository wholesale. Copy or
+adapt only the necessary patterns, and keep `workplace/` local-only according
+to repository convention rules.
+
+## Maven Plugin Scope
+
+Maven plugin support is optional for Java straight-conversion projects, and is
+off by default during initial conversion.
+
+The default initial target is to stabilize the runtime core, CLI or batch
+adapter, upstream parity, tests, packaging, and documentation. Maven plugin
+support adds module structure, Mojo classes, parameters, lifecycle assumptions,
+plugin smoke tests, and user-facing docs, so adding it too early can obscure
+the straight-conversion boundary.
+
+If the developer explicitly requests Maven plugin support at the start, include
+it in scope and fix the plugin artifactId, goal prefix, goals, parameters, and
+verification commands early. Otherwise, treat Maven plugin support as a
+Java-side extension that can be added after the runtime core contract is stable.
+
+Near the finishing stage, confirm whether Maven plugin support should remain
+out of scope, be recorded as a follow-up item, or be added as a final extension.
+Prefer adding it only when the product naturally performs build-time generation,
+validation, conversion, indexing, or report creation.
 
 ## Repository Shape
 
@@ -128,7 +199,8 @@ smaller safe slice:
 6. Port validation and diagnostic construction before broad processing logic.
 7. Port core processing behind a callable core API.
 8. Add CLI or batch adapters that delegate to the core API.
-9. Add Maven plugin modules only after the runtime core contract is stable.
+9. Add Maven plugin modules only when explicitly in scope, and only after the
+   runtime core contract is stable.
 10. Add packaging, distribution zip, release workflow, and documentation sync
     tests when they are part of the product contract.
 
@@ -154,7 +226,7 @@ Treat upstream-derived behavior as the default contract:
 Document Java-side runtime differences explicitly. Common examples include
 Java `Pattern` versus Node.js `RegExp`, Java charset behavior versus Node-side
 encoding libraries, ZIP / XML library differences, and Java-side Maven plugin
-or batch extensions.
+or batch extensions when they are in scope.
 
 Java-side extensions are allowed when useful, but keep them separate from the
 upstream contract in README, CLI specs, mapping documents, and tests.
@@ -171,7 +243,8 @@ Prefer focused regression commands that explain the changed area:
 - documentation synchronization tests
 - Node-vs-Java parity scripts when practical
 - packaged jar smoke scripts after `mvn package`
-- Maven plugin smoke scripts for plugin modules
+- Maven plugin smoke scripts for plugin modules, when plugin support is in
+  scope
 
 When parity scripts generate local fixtures or comparison outputs, write them
 under `workplace/` and keep those outputs untracked.
@@ -207,6 +280,8 @@ Before finishing a conversion task:
 - mapping documents reflect changed source, tests, or CLI contracts
 - README and docs agree with current runtime behavior
 - TODO or migration status records remaining work and latest verification
+- Maven plugin support is explicitly marked as out of scope, follow-up, or
+  implemented extension
 - focused regressions were run, or the reason for not running them is clear
 - `git status --short` has been checked
 - final diff does not include unrelated changes

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-30-straight-conversion-v20260425.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-30-straight-conversion-v20260425.md
@@ -78,6 +78,7 @@ At the start of straight conversion, fix at least the following items first.
 - Fix the primary test entrypoint to `mvn test`
 - Fix runtime packaging to a single fat jar
 - Decide whether to adopt a distribution zip depending on the processing target
+- Treat Maven plugin support as out of initial scope by default unless the developer explicitly requests it at the start
 - Create `workplace/` at the repository root, and track only `workplace/.gitkeep` in Git
 - Exclude all files under `workplace/` except `workplace/.gitkeep` from Git tracking
 - Do not add new features during straight conversion
@@ -112,6 +113,10 @@ Among the items above, the environment premises are fixed in the following sense
 - runtime packaging
   - Fix to a single fat jar
   - Add a distribution zip depending on the processing target
+- Maven plugin support
+  - Keep it out of the initial conversion scope by default
+  - Add it at the start only when the developer explicitly requests it
+  - Otherwise, revisit it as a finishing-stage or follow-up Java-side extension
 - local workspace
   - Place `workplace/` at the repository root
   - Track `workplace/.gitkeep` in Git
@@ -136,6 +141,7 @@ When starting straight conversion, fill in at least the following.
 - The primary test entrypoint has been fixed to `mvn test`
 - Runtime packaging has been fixed to a single fat jar
 - Whether to create a distribution zip has been decided depending on the processing target
+- Maven plugin support has been marked as initially out of scope unless explicitly requested by the developer
 - The policy to create `workplace/` at the repository root and track only `.gitkeep` in Git has been confirmed
 - The scope for not bringing in the GUI has been decided
 - If a CLI exists, how far the Node interface will be respected has been decided
@@ -172,6 +178,9 @@ First fix the following.
 - runtime packaging
   - Fix to a single fat jar
   - Add a distribution zip depending on the processing target
+- Maven plugin support
+  - Keep off by default for initial straight conversion
+  - Include it only when explicitly requested at the start, or defer it until the runtime core contract is stable
 - local workspace
   - Create `workplace/` at the repository root
   - Track only `workplace/.gitkeep` in Git
@@ -504,7 +513,7 @@ This section summarizes fixed policies, default policies, acceptable patterns, a
 Read the strength of individual sentences according to wording such as `fix`, `basically`, `allow`, and `example`.
 
 - Maven coordinates basically use `groupId = jp.igapyon` and `artifactId = <project>`
-- Artifact names for single fat jar, Maven plugin jar, and distribution zip are aligned to an `artifactId-version` style that is easy to trace from Maven coordinates
+- Artifact names for single fat jar, optional Maven plugin jar, and distribution zip are aligned to an `artifactId-version` style that is easy to trace from Maven coordinates
 - Runtime jar names inside distribution zips are also versioned like distribution file names
 - Place the CLI main class at `jp.igapyon.<project>.cli.<Project>Cli`
 - The CLI should not pack real processing into `main(String[] args)`; delegate to a testable entrypoint such as `run(String[] args, PrintStream out, PrintStream err)`
@@ -592,7 +601,7 @@ Main examples:
 
 - Organization of public entrypoints such as `CoreApi*`
 - Java CLI entrypoint
-- Java-side wrapper module for adding Maven plugin goals
+- Java-side wrapper module for adding Maven plugin goals, when explicitly in scope or added later
 - API / CLI entrypoints for retrieving AI-facing prompt markdown
 - single fat jar packaging
 - distribution zip packaging depending on the processing target
@@ -600,8 +609,13 @@ Main examples:
 
 These are not mixed as the same responsibility as the upstream body; they are treated separately as `Java-side original extensions`.
 
-In addition to the CLI runtime, Java-side execution paths such as Maven plugins may be considered first-class, high-priority paths for CLI / batch conversion tools.
-Especially for tools that fit naturally into a build process, such as artifact generation, validation, conversion, and index creation, Maven plugin support is highly worth considering.
+Maven plugin support is optional, and should be off by default for the initial straight-conversion scope.
+The initial priority is to stabilize the runtime core, CLI or batch entrypoint, upstream parity, regression tests, packaging, and documentation.
+Maven plugin support adds module structure, Mojo classes, parameters, lifecycle assumptions, plugin smoke tests, and user-facing documentation, so adding it too early can make the conversion harder to keep traceable.
+
+If the developer explicitly requests Maven plugin support at the start, include it in scope and fix the plugin artifactId, goal prefix, goals, parameters, and verification commands early.
+Otherwise, treat Maven plugin support as a finishing-stage or follow-up Java-side extension that can be added after the runtime core contract is stable.
+Especially for tools that fit naturally into a build process, such as artifact generation, validation, conversion, and index creation, Maven plugin support is worth reconsidering near the end of initial conversion.
 
 In that case, a multi-module Maven reactor repository structure may be used.
 
@@ -632,7 +646,7 @@ Design notes:
 
 ## Naming When Adding a Maven Plugin
 
-When adding a Maven plugin as a Java-side original extension, align the artifact name, prefix, and goal name at the beginning.
+When adding a Maven plugin as a Java-side original extension, align the artifact name, prefix, and goal name at the beginning of that plugin work.
 Maven has its own conventions here, and fixing these later tends to widen the range of user-facing command and README changes.
 
 Basic policy:
@@ -667,7 +681,7 @@ Findings:
 - If `artifactId`, `goalPrefix`, and `goal` drift apart, README and execution method explanations tend to become hard to understand
 - Whether short form succeeds depends not only on naming but also on plugin group resolution settings
 - If parameter names use different vocabulary in CLI and Maven plugin, synchronization cost increases across README, help, tests, and adapter implementation
-- If the main target of straight conversion is CLI / batch / report work and it naturally fits into a build process, plugin naming should be fixed early
+- If Maven plugin support is explicitly in scope, plugin naming should be fixed early in that plugin work
 - If the same directory / batch feature exists in both CLI and Maven plugin, keep the plugin goal as a thin adapter, and fix traversal, relative path resolution, output name decisions, and repeated conversion in runtime helper tests
 
 ## CLI Handling
@@ -686,7 +700,7 @@ However, the following may be added for Java-side operational convenience.
 
 - batch command
 - directory input option
-- Maven plugin goal
+- Maven plugin goal, when explicitly in scope or added after the runtime core is stable
 - minimal startup method differences for fat jar execution
 - auxiliary diagnostics that match Java runtime / file APIs
 
@@ -695,7 +709,7 @@ Even in this case, keep the upstream CLI body contract separate from Java-side o
 Findings:
 
 - If the CLI contract is vague at the beginning, synchronization cost for help / README / tests / diagnostics tends to increase later
-- For CLIs that naturally fit into a build process, providing a Maven plugin often greatly improves practicality for Java users
+- For CLIs that naturally fit into a build process, providing a Maven plugin can improve practicality for Java users, but it should still remain outside the initial scope unless explicitly requested
 - Java-side original batch / directory commands are convenient, but mixing them with upstream straight conversion easily breaks the upstream-following unit
 - Because JVM startup cost exists, it is reasonable for Java CLI to provide directory / batch processing even apart from Maven plugins
 - In directory mode, allowing `outputFile` or archive options from single-file mode as-is often makes meaning ambiguous, so mutual exclusion should be fixed in entrypoint validation
@@ -892,6 +906,7 @@ To treat the initial stage of straight conversion as complete, it should satisfy
 - `upstream test intent -> Java test` mapping table exists
 - focused regression commands exist
 - If a CLI exists, contracts for main commands / options / diagnostics are fixed
+- Maven plugin support has been explicitly marked as out of scope, follow-up, or implemented Java-side extension
 - The follow-up log contains at least several concrete `upstream file` examples
 - Determinism has been confirmed for major artifacts
 - Byte-level parity has been confirmed for artifacts with high comparison value, or the reason for not applying it has been documented


### PR DESCRIPTION
## 概要

`igapyon-miku-soft-developer` の Java straight-conversion 関連ドキュメントを更新し、Java companion 作成時に必要な前提確認と Maven plugin 対応の扱いを明確化します。

## 変更内容

- `30-java-straight-conversion-workflow.md` に、`upstream` が `10-node-app-workflow.md` に相当する Node.js / TypeScript main application であることを明記
- Java straight-conversion 開始時に、upstream GitHub repository URL と対象 revision 情報を確認する手順を追加
- 類似する既存 `-java` 姉妹プロジェクトを `workplace/` 配下の参照ソースとして要求する手順を追加
- `Sister Java Reference Projects` セクションを追加し、Maven layout、CLI、core API、tests、docs、release workflow などの参照方針を整理
- Maven plugin 対応は初期変換ではデフォルト OFF とし、開発者が最初から明示した場合のみ初期 scope に含める方針を追加
- Maven plugin は runtime core contract 安定後に後付けできる Java-side extension として扱い、仕上げ段階で out of scope / follow-up / implemented extension を確認する方針を追加
- `miku-soft-30-straight-conversion-v20260425.md` 側にも同じ Maven plugin 方針を反映
- `index.json` を更新

## 確認事項

- `mvn generate-resources` 実行済み