### PR TITLE
Java straight-conversion の release workflow 方針を tag push 対応込みで更新

### DIFF
--- a/skills/igapyon-miku-soft-developer/assets/java-straight-conversion/.github/workflows/release-cli-runtime.yml
+++ b/skills/igapyon-miku-soft-developer/assets/java-straight-conversion/.github/workflows/release-cli-runtime.yml
@@ -1,6 +1,9 @@
 name: Release CLI runtime
 
 on:
+  push:
+    tags:
+      - "v*"
   release:
     types:
       - published
@@ -64,5 +67,6 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.tag_name || github.event.release.tag_name || github.ref_name }}
           files: release-assets/*
+          overwrite_files: true
           draft: false
           prerelease: false

--- a/skills/igapyon-miku-soft-developer/index.json
+++ b/skills/igapyon-miku-soft-developer/index.json
@@ -23,7 +23,7 @@
       "path": "references/30-java-straight-conversion-workflow.md",
       "ext": "md",
       "dir": "references",
-      "size": 13642,
+      "size": 14513,
       "summary": "Java Straight Conversion Workflow"
     },
     {
@@ -99,12 +99,12 @@
       "summary": "Miku Software Java Application Design v20260426"
     },
     {
-      "name": "miku-soft-30-straight-conversion-v20260425.md",
-      "path": "references/miku-soft-basic/miku-soft-30-straight-conversion-v20260425.md",
+      "name": "miku-soft-30-straight-conversion-v20260506.md",
+      "path": "references/miku-soft-basic/miku-soft-30-straight-conversion-v20260506.md",
       "ext": "md",
       "dir": "references/miku-soft-basic",
-      "size": 57309,
-      "summary": "Miku Software Straight Conversion Guide v20260425"
+      "size": 58564,
+      "summary": "Miku Software Straight Conversion Guide v20260506"
     },
     {
       "name": "miku-soft-40-agentskills-design-v20260501.md",

--- a/skills/igapyon-miku-soft-developer/references/30-java-straight-conversion-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/30-java-straight-conversion-workflow.md
@@ -11,7 +11,7 @@ targets the Java companion repository, normally with a `-java` suffix.
 Detailed design guidance lives in:
 
 - [miku-soft-basic/miku-soft-20-javaapp-design-v20260501.md](miku-soft-basic/miku-soft-20-javaapp-design-v20260501.md)
-- [miku-soft-basic/miku-soft-30-straight-conversion-v20260425.md](miku-soft-basic/miku-soft-30-straight-conversion-v20260425.md)
+- [miku-soft-basic/miku-soft-30-straight-conversion-v20260506.md](miku-soft-basic/miku-soft-30-straight-conversion-v20260506.md)
 
 Keep this file as the execution checklist. Load the detailed design documents
 only when a policy decision is unclear.
@@ -134,8 +134,21 @@ Bundled starter templates are available under
     resolution is affected by IPv6 behavior.
 - `.github/workflows/release-cli-runtime.yml`
   - GitHub Release asset workflow for a single CLI runtime jar and source jar.
+  - Trigger from `push` tags matching `v*`, published GitHub Releases, and
+    manual dispatch with an explicit `tag_name`.
+  - Keep the `push` tag trigger when migrating an existing sister project that
+    already releases by running `git push origin vX.Y.Z`.
+  - The workflow checks the release tag version against `pom.xml`, builds from
+    the release tag, stages `<artifact>-<version>.jar` and
+    `<artifact>-sources-<version>.jar`, verifies the runtime jar with Java 8
+    using `java -jar ... --version`, and uploads only the staged jar assets.
+  - The template uses `softprops/action-gh-release` so tag-push releases can
+    create or update the GitHub Release assets for that tag. Keep
+    `permissions: contents: write` and explicit asset overwrite behavior.
   - Replace `__ARTIFACT_ID__` with the Maven artifactId before use.
-  - Adjust target paths for multi-module runtime repositories.
+  - Adjust target paths for multi-module runtime repositories so the runtime
+    module's `target/` directory is used instead of the aggregator root
+    `target/`.
 - `pom-cli-runtime.xml`
   - Starter `pom.xml` for a single-module CLI runtime jar with Java 1.8,
     JUnit Jupiter, Jackson, source jar, shaded runtime jar, and dist zip.

--- a/skills/igapyon-miku-soft-developer/references/architecture-rules.md
+++ b/skills/igapyon-miku-soft-developer/references/architecture-rules.md
@@ -13,7 +13,7 @@ Read only the document needed for the current task:
 - [miku-soft-basic/miku-soft-00-overview-design-v20260427.md](miku-soft-basic/miku-soft-00-overview-design-v20260427.md): overall miku-soft stance and product-type overview
 - [miku-soft-basic/miku-soft-10-mainapp-design-v20260505.md](miku-soft-basic/miku-soft-10-mainapp-design-v20260505.md): main application, Web UI, CLI, local-first behavior, diagnostics, and shared conventions
 - [miku-soft-basic/miku-soft-20-javaapp-design-v20260501.md](miku-soft-basic/miku-soft-20-javaapp-design-v20260501.md): Java CLI, Maven, Java runtime boundary, packaging, and Java-side maintenance
-- [miku-soft-basic/miku-soft-30-straight-conversion-v20260425.md](miku-soft-basic/miku-soft-30-straight-conversion-v20260425.md): Node.js / TypeScript to Java straight conversion
+- [miku-soft-basic/miku-soft-30-straight-conversion-v20260506.md](miku-soft-basic/miku-soft-30-straight-conversion-v20260506.md): Node.js / TypeScript to Java straight conversion
 - [miku-soft-basic/miku-soft-40-agentskills-design-v20260501.md](miku-soft-basic/miku-soft-40-agentskills-design-v20260501.md): Agent Skills versions and agent-facing local workflow packages
 - [miku-soft-basic/miku-soft-50-mcp-design-v20260501.md](miku-soft-basic/miku-soft-50-mcp-design-v20260501.md): MCP server versions, tools, resources, prompts, transport, and protocol adapter boundaries
 

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-30-straight-conversion-v20260506.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-30-straight-conversion-v20260506.md
@@ -1,4 +1,4 @@
-# Miku Software Straight Conversion Guide v20260425
+# Miku Software Straight Conversion Guide v20260506
 
 ## Purpose
 
@@ -515,6 +515,13 @@ Read the strength of individual sentences according to wording such as `fix`, `b
 - Maven coordinates basically use `groupId = jp.igapyon` and `artifactId = <project>`
 - Artifact names for single fat jar, optional Maven plugin jar, and distribution zip are aligned to an `artifactId-version` style that is easy to trace from Maven coordinates
 - Runtime jar names inside distribution zips are also versioned like distribution file names
+- When a Java CLI runtime publishes GitHub Release assets, keep the release workflow compatible with `push` tags matching `v*`, published GitHub Releases, and manual dispatch with an explicit tag
+- Preserve existing tag-push release operation, such as `git push origin vX.Y.Z`, when migrating a sister Java project to the shared release workflow template
+- Check that the release tag version matches `pom.xml` `version`, or document any accepted dot-suffix rule such as `v0.5.0.1` for `0.5.0`
+- Stage runtime and source jar assets with versioned names such as `<artifact>-<version>.jar` and `<artifact>-sources-<version>.jar`, and upload only those staged assets to the GitHub Release
+- Run a Java 8 `java -jar ... --version` smoke test against the staged runtime jar before uploading release assets
+- In multi-module repositories, point release asset preparation at the runtime module's `target/` directory, not the aggregator root `target/`
+- A release workflow may use `softprops/action-gh-release` for tag-push creation or update of GitHub Release assets, with `contents: write` permission and explicit asset overwrite behavior; use `gh release view/create/upload` only when the repository needs more detailed release existence, body, or note control
 - Place the CLI main class at `jp.igapyon.<project>.cli.<Project>Cli`
 - The CLI should not pack real processing into `main(String[] args)`; delegate to a testable entrypoint such as `run(String[] args, PrintStream out, PrintStream err)`
 - In principle, confine `System.exit` to the end of the CLI main, and return exit codes from core APIs and CLI implementation logic

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-40-agentskills-design-v20260501.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-40-agentskills-design-v20260501.md
@@ -33,7 +33,7 @@ Use the shared design documents together as follows.
   - describes the upstream product design and semantic center
 - `docs/miku-soft-20-javaapp-design-v20260501.md`
   - describes Java runtime versions when they exist
-- `docs/miku-soft-30-straight-conversion-v20260425.md`
+- `docs/miku-soft-30-straight-conversion-v20260506.md`
   - describes how Java versions are created from upstream main applications
 - `docs/miku-soft-40-agentskills-design-v20260501.md`
   - describes how Agent Skills versions should expose miku workflows to AI agents


### PR DESCRIPTION
## 概要

miku-soft developer の Java straight-conversion 向け release workflow テンプレートと関連ドキュメントを更新しました。

既存の `git push origin vX.Y.Z` による tag push release 運用を維持しつつ、GitHub Release publish と manual dispatch にも対応する方針を明文化しています。

## 変更内容

- Java CLI runtime release workflow テンプレートに `push` tag `v*` 起動を追加
- `softprops/action-gh-release` の asset 上書き挙動として `overwrite_files: true` を明示
- Java straight-conversion workflow に release workflow テンプレートの運用方針を追記
  - `push` tags `v*`
  - published GitHub Releases
  - `workflow_dispatch` with `tag_name`
  - tag version と `pom.xml` version の整合
  - runtime jar / sources jar の release asset 化
  - Java 8 での `java -jar ... --version` smoke
  - multi-module 時の runtime module `target/` 参照
- straight conversion 基本ガイドを `v20260506` にリネーム
- リネームに伴い関連リンクと `index.json` を更新

## 確認

- `mvn generate-resources` 実行済み
- workflow YAML の parse 確認済み