### PR TITLE
miku-soft Java release workflow テンプレートを Maven 標準命名に対応

### DIFF
--- a/skills/igapyon-miku-soft-developer/assets/java-straight-conversion/.github/workflows/release-cli-runtime.yml
+++ b/skills/igapyon-miku-soft-developer/assets/java-straight-conversion/.github/workflows/release-cli-runtime.yml
@@ -19,6 +19,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  RUNTIME_TARGET_DIR: "target"
 
 jobs:
   release-cli-runtime:
@@ -31,6 +32,13 @@ jobs:
         with:
           ref: ${{ github.event.inputs.tag_name || github.event.release.tag_name || github.ref }}
 
+      - name: Set up Java 21 for build
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
       - name: Build
         run: mvn -B package
 
@@ -40,7 +48,9 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${TAG_NAME#v}"
-          POM_VERSION="$(awk -F'[<>]' '/<version>/{print $3; exit}' pom.xml)"
+          ARTIFACT_ID="$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)"
+          POM_VERSION="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
+          echo "RELEASE_ARTIFACT_ID=${ARTIFACT_ID}" >> "${GITHUB_ENV}"
           case "${VERSION}" in
             "${POM_VERSION}"|"${POM_VERSION}".*) ;;
             *)
@@ -50,8 +60,8 @@ jobs:
           esac
 
           mkdir -p release-assets
-          cp target/__ARTIFACT_ID__.jar "release-assets/__ARTIFACT_ID__-${VERSION}.jar"
-          cp target/__ARTIFACT_ID__-sources.jar "release-assets/__ARTIFACT_ID__-sources-${VERSION}.jar"
+          cp "${RUNTIME_TARGET_DIR}/${ARTIFACT_ID}-${POM_VERSION}.jar" "release-assets/${ARTIFACT_ID}-${VERSION}.jar"
+          cp "${RUNTIME_TARGET_DIR}/${ARTIFACT_ID}-${POM_VERSION}-sources.jar" "release-assets/${ARTIFACT_ID}-sources-${VERSION}.jar"
 
       - name: Set up Java 8 for runtime verification
         uses: actions/setup-java@v4
@@ -60,7 +70,9 @@ jobs:
           java-version: "8"
 
       - name: Verify CLI runtime asset
-        run: java -jar release-assets/__ARTIFACT_ID__-[0-9]*.jar --version
+        run: |
+          set -euo pipefail
+          java -jar release-assets/${RELEASE_ARTIFACT_ID}-[0-9]*.jar --version
 
       - name: Upload CLI runtime to GitHub Release
         uses: softprops/action-gh-release@v2

--- a/skills/igapyon-miku-soft-developer/assets/java-straight-conversion/pom-cli-runtime.xml
+++ b/skills/igapyon-miku-soft-developer/assets/java-straight-conversion/pom-cli-runtime.xml
@@ -35,7 +35,6 @@
   </dependencies>
 
   <build>
-    <finalName>__ARTIFACT_ID__</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/skills/igapyon-miku-soft-developer/index.json
+++ b/skills/igapyon-miku-soft-developer/index.json
@@ -23,7 +23,7 @@
       "path": "references/30-java-straight-conversion-workflow.md",
       "ext": "md",
       "dir": "references",
-      "size": 14513,
+      "size": 16010,
       "summary": "Java Straight Conversion Workflow"
     },
     {
@@ -103,7 +103,7 @@
       "path": "references/miku-soft-basic/miku-soft-30-straight-conversion-v20260506.md",
       "ext": "md",
       "dir": "references/miku-soft-basic",
-      "size": 58564,
+      "size": 59888,
       "summary": "Miku Software Straight Conversion Guide v20260506"
     },
     {

--- a/skills/igapyon-miku-soft-developer/references/30-java-straight-conversion-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/30-java-straight-conversion-workflow.md
@@ -142,16 +142,39 @@ Bundled starter templates are available under
     the release tag, stages `<artifact>-<version>.jar` and
     `<artifact>-sources-<version>.jar`, verifies the runtime jar with Java 8
     using `java -jar ... --version`, and uploads only the staged jar assets.
+  - The template uses Maven standard output names as its copy source:
+    `<artifactId>-<project.version>.jar` and
+    `<artifactId>-<project.version>-sources.jar`. Keep this default unless the
+    target repository intentionally sets `<finalName>` to a fixed runtime name,
+    in which case update the copy source paths explicitly.
+  - The template obtains `project.version` with
+    `mvn help:evaluate -Dexpression=project.version -q -DforceStdout` rather
+    than by reading the first `<version>` tag, so parent POM and multi-module
+    layouts are less likely to resolve the wrong version.
+  - The template obtains `project.artifactId` with
+    `mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout`, so
+    the release asset copy source and staged asset names do not need a
+    hard-coded artifactId.
+  - Set up the build JDK explicitly, normally Temurin Java 21 with Maven cache,
+    before `mvn -B package`; set up Java 8 separately for the packaged runtime
+    smoke test.
   - The template uses `softprops/action-gh-release` so tag-push releases can
     create or update the GitHub Release assets for that tag. Keep
     `permissions: contents: write` and explicit asset overwrite behavior.
-  - Replace `__ARTIFACT_ID__` with the Maven artifactId before use.
-  - Adjust target paths for multi-module runtime repositories so the runtime
-    module's `target/` directory is used instead of the aggregator root
-    `target/`.
+  - When `softprops/action-gh-release` creates a release with the workflow's
+    `GITHUB_TOKEN`, GitHub Actions normally suppresses recursive workflow
+    triggering from that token-created event. If a human later publishes or
+    republishes the same tag's GitHub Release, the release trigger may run
+    again and update the same staged assets.
+  - Adjust `RUNTIME_TARGET_DIR` for multi-module runtime repositories so the
+    runtime module's `target/` directory, such as `miku-xlsx2md/target`, is used
+    instead of the aggregator root `target/`.
 - `pom-cli-runtime.xml`
   - Starter `pom.xml` for a single-module CLI runtime jar with Java 1.8,
     JUnit Jupiter, Jackson, source jar, shaded runtime jar, and dist zip.
+  - The starter follows Maven standard artifact naming, so the package output
+    is normally `target/<artifactId>-<version>.jar` and
+    `target/<artifactId>-<version>-sources.jar`.
   - Copy to `pom.xml`, then replace `__ARTIFACT_ID__`, `__VERSION__`,
     `__PROJECT_NAME__`, `__DESCRIPTION__`, `__GITHUB_REPOSITORY__`, and
     `__MAIN_CLASS__`.

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-30-straight-conversion-v20260506.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-30-straight-conversion-v20260506.md
@@ -518,9 +518,14 @@ Read the strength of individual sentences according to wording such as `fix`, `b
 - When a Java CLI runtime publishes GitHub Release assets, keep the release workflow compatible with `push` tags matching `v*`, published GitHub Releases, and manual dispatch with an explicit tag
 - Preserve existing tag-push release operation, such as `git push origin vX.Y.Z`, when migrating a sister Java project to the shared release workflow template
 - Check that the release tag version matches `pom.xml` `version`, or document any accepted dot-suffix rule such as `v0.5.0.1` for `0.5.0`
+- Set up the build JDK explicitly, normally Temurin Java 21 with Maven cache, before `mvn -B package`; set up Java 8 separately for the packaged runtime smoke test
+- Use Maven standard output names as the release workflow copy source by default, such as `target/<artifactId>-<project.version>.jar` and `target/<artifactId>-<project.version>-sources.jar`; if the repository intentionally uses a fixed `<finalName>`, document that and adjust the release workflow copy source explicitly
+- Obtain the Maven project version for release checks with `mvn help:evaluate -Dexpression=project.version -q -DforceStdout` in shared templates, instead of assuming that the first `<version>` tag in `pom.xml` is the project version
+- Obtain the Maven artifactId with `mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout` in shared release workflow templates, so release asset source paths and staged names do not depend on a hard-coded artifactId
 - Stage runtime and source jar assets with versioned names such as `<artifact>-<version>.jar` and `<artifact>-sources-<version>.jar`, and upload only those staged assets to the GitHub Release
 - Run a Java 8 `java -jar ... --version` smoke test against the staged runtime jar before uploading release assets
-- In multi-module repositories, point release asset preparation at the runtime module's `target/` directory, not the aggregator root `target/`
+- In multi-module repositories, point release asset preparation at the runtime module's `target/` directory, not the aggregator root `target/`; make that target directory an explicit workflow setting such as `RUNTIME_TARGET_DIR`
+- When a tag-push workflow creates a GitHub Release with `GITHUB_TOKEN`, recursive workflow triggering from that token-created event is normally suppressed; if a human later publishes or republishes the same tag's release, the release trigger may run again and update the same staged assets
 - A release workflow may use `softprops/action-gh-release` for tag-push creation or update of GitHub Release assets, with `contents: write` permission and explicit asset overwrite behavior; use `gh release view/create/upload` only when the repository needs more detailed release existence, body, or note control
 - Place the CLI main class at `jp.igapyon.<project>.cli.<Project>Cli`
 - The CLI should not pack real processing into `main(String[] args)`; delegate to a testable entrypoint such as `run(String[] args, PrintStream out, PrintStream err)`


### PR DESCRIPTION
## 概要

`igapyon-miku-soft-developer` の Java straight-conversion 向け release workflow テンプレートを更新し、Maven 標準の artifact 名を前提にした release asset 作成へ寄せました。

あわせて、release workflow 方針を説明する reference 文書と `index.json` を更新しています。

## 変更内容

- Java straight-conversion 用の `release-cli-runtime.yml` を更新
  - build 用 JDK として Temurin Java 21 + Maven cache の setup step を追加
  - release asset のコピー元を Maven 標準命名の `<artifactId>-<project.version>.jar` / `<artifactId>-<project.version>-sources.jar` に変更
  - `project.version` を `awk` ではなく `mvn help:evaluate` で取得するように変更
  - `project.artifactId` も `mvn help:evaluate` で取得し、workflow 内の artifactId ハードコードを削減
  - multi-module repo 向けに `RUNTIME_TARGET_DIR` を導入
  - Java 8 smoke test で staged runtime jar を検証する処理を維持

- `pom-cli-runtime.xml` を Maven 標準命名に寄せるため、固定の `<finalName>__ARTIFACT_ID__</finalName>` を削除

- Java straight-conversion workflow の説明を更新
  - release workflow が Maven 標準 artifact 名をコピー元にすることを明記
  - `project.version` / `project.artifactId` を `mvn help:evaluate` で取得する方針を追記
  - multi-module repo では `RUNTIME_TARGET_DIR` を調整する方針を明記
  - starter POM の出力 jar 名が Maven 標準命名になることを追記

- straight conversion 基本文書を更新
  - release workflow の version / artifactId 取得方針を追記
  - fixed `<finalName>` を使う repo では copy source を明示調整する必要があることを追記

- `igapyon-miku-soft-developer/index.json` を再生成