### PR TITLE
Java straight-conversion の release workflow 方針を tag push 中心に整理

### DIFF
--- a/skills/igapyon-miku-soft-developer/assets/java-straight-conversion/.github/workflows/release-cli-runtime.yml
+++ b/skills/igapyon-miku-soft-developer/assets/java-straight-conversion/.github/workflows/release-cli-runtime.yml
@@ -4,9 +4,6 @@ on:
   push:
     tags:
       - "v*"
-  release:
-    types:
-      - published
   workflow_dispatch:
     inputs:
       tag_name:
@@ -24,13 +21,13 @@ env:
 jobs:
   release-cli-runtime:
     runs-on: ubuntu-latest
-    if: startsWith(github.event.release.tag_name || github.event.inputs.tag_name || github.ref_name, 'v')
+    if: startsWith(github.event.inputs.tag_name || github.ref_name, 'v')
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag_name || github.event.release.tag_name || github.ref }}
+          ref: ${{ github.event.inputs.tag_name || github.ref }}
 
       - name: Set up Java 21 for build
         uses: actions/setup-java@v4
@@ -44,7 +41,7 @@ jobs:
 
       - name: Prepare release assets
         env:
-          TAG_NAME: ${{ github.event.inputs.tag_name || github.event.release.tag_name || github.ref_name }}
+          TAG_NAME: ${{ github.event.inputs.tag_name || github.ref_name }}
         run: |
           set -euo pipefail
           VERSION="${TAG_NAME#v}"
@@ -77,7 +74,7 @@ jobs:
       - name: Upload CLI runtime to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.inputs.tag_name || github.event.release.tag_name || github.ref_name }}
+          tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
           files: release-assets/*
           overwrite_files: true
           draft: false

--- a/skills/igapyon-miku-soft-developer/index.json
+++ b/skills/igapyon-miku-soft-developer/index.json
@@ -23,7 +23,7 @@
       "path": "references/30-java-straight-conversion-workflow.md",
       "ext": "md",
       "dir": "references",
-      "size": 16010,
+      "size": 16068,
       "summary": "Java Straight Conversion Workflow"
     },
     {
@@ -103,7 +103,7 @@
       "path": "references/miku-soft-basic/miku-soft-30-straight-conversion-v20260506.md",
       "ext": "md",
       "dir": "references/miku-soft-basic",
-      "size": 59888,
+      "size": 59821,
       "summary": "Miku Software Straight Conversion Guide v20260506"
     },
     {

--- a/skills/igapyon-miku-soft-developer/references/30-java-straight-conversion-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/30-java-straight-conversion-workflow.md
@@ -134,10 +134,16 @@ Bundled starter templates are available under
     resolution is affected by IPv6 behavior.
 - `.github/workflows/release-cli-runtime.yml`
   - GitHub Release asset workflow for a single CLI runtime jar and source jar.
-  - Trigger from `push` tags matching `v*`, published GitHub Releases, and
-    manual dispatch with an explicit `tag_name`.
+  - Trigger from `push` tags matching `v*` and manual dispatch with an
+    explicit `tag_name`.
   - Keep the `push` tag trigger when migrating an existing sister project that
     already releases by running `git push origin vX.Y.Z`.
+  - Do not trigger this shared template from GitHub Release `published` events
+    by default. When `softprops/action-gh-release` creates or updates the
+    GitHub Release from a tag-push workflow, a separate release-published
+    trigger can cause a second run for the same tag.
+  - Use `workflow_dispatch` with an explicit `tag_name` when release assets need
+    to be recreated or attached to an existing GitHub Release manually.
   - The workflow checks the release tag version against `pom.xml`, builds from
     the release tag, stages `<artifact>-<version>.jar` and
     `<artifact>-sources-<version>.jar`, verifies the runtime jar with Java 8
@@ -161,11 +167,6 @@ Bundled starter templates are available under
   - The template uses `softprops/action-gh-release` so tag-push releases can
     create or update the GitHub Release assets for that tag. Keep
     `permissions: contents: write` and explicit asset overwrite behavior.
-  - When `softprops/action-gh-release` creates a release with the workflow's
-    `GITHUB_TOKEN`, GitHub Actions normally suppresses recursive workflow
-    triggering from that token-created event. If a human later publishes or
-    republishes the same tag's GitHub Release, the release trigger may run
-    again and update the same staged assets.
   - Adjust `RUNTIME_TARGET_DIR` for multi-module runtime repositories so the
     runtime module's `target/` directory, such as `miku-xlsx2md/target`, is used
     instead of the aggregator root `target/`.

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-30-straight-conversion-v20260506.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-30-straight-conversion-v20260506.md
@@ -515,8 +515,9 @@ Read the strength of individual sentences according to wording such as `fix`, `b
 - Maven coordinates basically use `groupId = jp.igapyon` and `artifactId = <project>`
 - Artifact names for single fat jar, optional Maven plugin jar, and distribution zip are aligned to an `artifactId-version` style that is easy to trace from Maven coordinates
 - Runtime jar names inside distribution zips are also versioned like distribution file names
-- When a Java CLI runtime publishes GitHub Release assets, keep the release workflow compatible with `push` tags matching `v*`, published GitHub Releases, and manual dispatch with an explicit tag
+- When a Java CLI runtime publishes GitHub Release assets, keep the shared release workflow compatible with `push` tags matching `v*` and manual dispatch with an explicit tag
 - Preserve existing tag-push release operation, such as `git push origin vX.Y.Z`, when migrating a sister Java project to the shared release workflow template
+- Do not trigger the shared release workflow from GitHub Release `published` events by default; with `softprops/action-gh-release`, tag push should create or update the GitHub Release and assets, and manual reruns should use `workflow_dispatch`
 - Check that the release tag version matches `pom.xml` `version`, or document any accepted dot-suffix rule such as `v0.5.0.1` for `0.5.0`
 - Set up the build JDK explicitly, normally Temurin Java 21 with Maven cache, before `mvn -B package`; set up Java 8 separately for the packaged runtime smoke test
 - Use Maven standard output names as the release workflow copy source by default, such as `target/<artifactId>-<project.version>.jar` and `target/<artifactId>-<project.version>-sources.jar`; if the repository intentionally uses a fixed `<finalName>`, document that and adjust the release workflow copy source explicitly
@@ -525,7 +526,6 @@ Read the strength of individual sentences according to wording such as `fix`, `b
 - Stage runtime and source jar assets with versioned names such as `<artifact>-<version>.jar` and `<artifact>-sources-<version>.jar`, and upload only those staged assets to the GitHub Release
 - Run a Java 8 `java -jar ... --version` smoke test against the staged runtime jar before uploading release assets
 - In multi-module repositories, point release asset preparation at the runtime module's `target/` directory, not the aggregator root `target/`; make that target directory an explicit workflow setting such as `RUNTIME_TARGET_DIR`
-- When a tag-push workflow creates a GitHub Release with `GITHUB_TOKEN`, recursive workflow triggering from that token-created event is normally suppressed; if a human later publishes or republishes the same tag's release, the release trigger may run again and update the same staged assets
 - A release workflow may use `softprops/action-gh-release` for tag-push creation or update of GitHub Release assets, with `contents: write` permission and explicit asset overwrite behavior; use `gh release view/create/upload` only when the repository needs more detailed release existence, body, or note control
 - Place the CLI main class at `jp.igapyon.<project>.cli.<Project>Cli`
 - The CLI should not pack real processing into `main(String[] args)`; delegate to a testable entrypoint such as `run(String[] args, PrintStream out, PrintStream err)`


### PR DESCRIPTION
## 概要

`igapyon-miku-soft-developer` の Java straight-conversion 向け release workflow テンプレートと参照文書を更新し、GitHub Release asset workflow の起動条件を `push` tag と手動実行中心に整理しました。

## 変更内容

- `release-cli-runtime.yml` から GitHub Release `published` event trigger を削除
- workflow 内の tag 解決を `workflow_dispatch` の `tag_name` または `github.ref_name` に整理
- `softprops/action-gh-release` による tag-push release 作成・更新を前提にした説明へ更新
- 既存 Release に asset を再作成・再添付する場合は、明示的な `tag_name` を指定した `workflow_dispatch` を使う方針を追記
- `miku-soft-30-straight-conversion-v20260506.md` 側の release workflow 方針も同じ内容に同期
- 参照文書更新に伴い `index.json` を再生成

## 確認事項

- テスト実行はコミット内容からは未確認