### PR TITLE
Node/Java のソート順差異を miku-soft review 観点に追加

### DIFF
--- a/skills/igapyon-miku-soft-developer/index.json
+++ b/skills/igapyon-miku-soft-developer/index.json
@@ -182,7 +182,7 @@
       "path": "references/review/node-cli.md",
       "ext": "md",
       "dir": "references/review",
-      "size": 14615,
+      "size": 16469,
       "summary": "Node.js CLI Review"
     },
     {
@@ -190,7 +190,7 @@
       "path": "references/review/README.md",
       "ext": "md",
       "dir": "references/review",
-      "size": 3208,
+      "size": 4799,
       "summary": "miku-soft Review Notes"
     },
     {

--- a/skills/igapyon-miku-soft-developer/references/review/README.md
+++ b/skills/igapyon-miku-soft-developer/references/review/README.md
@@ -29,8 +29,10 @@ Use this order for broad reviews:
 1. Classify the repository layer and product surfaces.
 2. Check local-first and no-surprise execution behavior for each surface.
 3. Check shared product semantics and artifact vocabulary across surfaces.
-4. Check release automation, version consistency, and packaged artifacts.
-5. Report findings in severity order using the relevant review output block.
+4. Check deterministic ordering where outputs, diagnostics, generated indexes,
+   or packaged file lists are compared across runtimes.
+5. Check release automation, version consistency, and packaged artifacts.
+6. Report findings in severity order using the relevant review output block.
 
 Release automation is a common implementation gap in miku-soft repositories.
 Treat it as a cross-cutting review area whenever the repository has tags,
@@ -45,6 +47,35 @@ that initial version.
 
 Normal miku-soft project versions should not use a `-SNAPSHOT` suffix unless
 the repository documents a product-specific reason.
+
+## Sort Order Baseline
+
+Node.js and Java runtimes can produce different string ordering when one side
+uses locale-aware collation and the other side uses natural language, Unicode,
+or platform defaults. Treat sorting as a product contract whenever ordered
+paths, diagnostics, generated indexes, archive entries, reports, or JSON arrays
+are user-visible or used for parity tests.
+
+The repository should choose and document one string ordering rule for each
+ordered artifact:
+
+- deterministic UTF-16 code unit order, equivalent to Java
+  `String.compareTo`, for machine-facing paths, diagnostic codes, stable JSON,
+  and automation contracts
+- explicit locale collation, such as Japanese collation, only when the product
+  intentionally presents human-facing Japanese order
+- numeric or domain-specific comparators for positions, line numbers, dates,
+  ticks, outline numbers, and other structured values
+
+Do not rely on JavaScript `localeCompare` without an explicit locale and
+tie-breaker, Java `Collator` without an explicit locale and tie-breaker, raw
+filesystem traversal order, default `Map` or object key order, or platform
+locale defaults when cross-runtime parity matters.
+
+When locale collation is intentional, add a deterministic tie-breaker such as
+UTF-16 code unit comparison so Node.js and Java can agree on equal collation
+groups. Parity tests should include mixed ASCII and Japanese names when the
+product sorts user-facing paths or labels.
 
 ## Shared Terms
 

--- a/skills/igapyon-miku-soft-developer/references/review/node-cli.md
+++ b/skills/igapyon-miku-soft-developer/references/review/node-cli.md
@@ -173,6 +173,38 @@ The CLI may expose batch, directory, or automation-oriented features that do not
 belong in the Web UI. Treat those as CLI-side operational extensions only when
 their semantics and artifact roles are documented.
 
+## Node and Java Sort Parity Checks
+
+Some miku-soft Node.js products later receive Java straight conversions. Review
+string sorting as an explicit compatibility contract because JavaScript and
+Java defaults can differ.
+
+Check these points:
+
+- ordered paths, diagnostics, generated indexes, archive entries, reports, and
+  JSON arrays have documented sort keys and comparator semantics
+- machine-facing path and diagnostic-code ordering uses deterministic UTF-16
+  code unit order when Java parity is expected, equivalent to Java
+  `String.compareTo`
+- human-facing Japanese ordering uses an explicit locale collation rule and a
+  deterministic tie-breaker, not ambient runtime defaults
+- JavaScript code does not use bare `localeCompare`, `Array.prototype.sort()`
+  on strings, object key iteration, `Map` insertion order, or filesystem
+  traversal order as an implicit product order
+- Java code does not use `Collator`, `Collections.sort`, `TreeMap`, `TreeSet`,
+  `Path.compareTo`, or filesystem traversal order without checking that the
+  resulting order matches the Node contract
+- numeric, date, tick, position, line, column, and outline ordering use numeric
+  or domain-specific comparators rather than string comparison
+- parity tests include names that reveal ordering differences, such as mixed
+  ASCII and Japanese filenames or labels, when sorted output is part of the
+  contract
+
+If the repository intentionally changes sort behavior in the Java version,
+review whether README, CLI docs, golden outputs, and migration notes describe
+the difference as a product decision. Otherwise, treat Node/Java sort drift as
+a parity defect.
+
 ## Local Safety Checks
 
 Several miku-soft CLIs are intended for AI agents reading or searching local
@@ -304,6 +336,9 @@ Use this severity guidance during Review mode:
   implicit, or hard to infer from the command and docs.
 - Medium: Web UI and CLI defaults or artifact vocabulary diverge without a
   documented runtime or workflow reason.
+- Medium: Node and Java versions can emit different sorted paths, diagnostics,
+  generated indexes, archive entries, reports, or JSON arrays because the sort
+  order is undocumented or relies on runtime defaults.
 - Medium: bundle artifacts are present but lack smoke checks, clear naming, or
   downstream placement instructions.
 - Low: minor naming, docs, or package metadata issues make the CLI harder to


### PR DESCRIPTION
## 概要

`igapyon-miku-soft-developer` の review note に、Node.js 版と Java 版のソート順差異を確認する観点を追加しました。

文字列ソートを製品契約として扱う方針を `review/README.md` に追加し、`node-cli.md` には Node/Java parity 向けの具体的なチェック項目と Severity Guidance を追加しています。

## 変更内容

- `references/review/README.md` に `Sort Order Baseline` を追加
  - ordered paths、diagnostics、generated indexes、archive entries、reports、JSON arrays などの並び順をレビュー対象として明文化
  - machine-facing な順序では Java `String.compareTo` 相当の deterministic UTF-16 code unit order を使う方針を追加
  - 人間向け日本語順では explicit locale collation と deterministic tie-breaker を使う方針を追加
  - runtime default、filesystem traversal order、暗黙の object / Map order に依存しない観点を追加

- `references/review/node-cli.md` に `Node and Java Sort Parity Checks` を追加
  - Node.js と Java の default sort / collation 差異を parity defect として確認する観点を追加
  - `localeCompare`、`Array.prototype.sort()`、Java `Collator`、`Collections.sort`、`TreeMap`、`TreeSet`、`Path.compareTo` などを暗黙の製品順序にしない確認項目を追加
  - 数値、日付、tick、position、line、column、outline などは domain-specific comparator を使う観点を追加
  - mixed ASCII / Japanese names を含む parity test の観点を追加

- `node-cli.md` の Severity Guidance に、Node/Java 間の sorted output drift を Medium finding として追加

- `skills/igapyon-miku-soft-developer/index.json` を更新
  - 更新後の `README.md` / `node-cli.md` の size metadata を反映