### PR TITLE
miku-javaclass2json記事に掲載先情報を追加

### DIFF
--- a/skills/igapyon-qiita-writer/index.json
+++ b/skills/igapyon-qiita-writer/index.json
@@ -95,8 +95,8 @@
       "path": "references/miku-javaclass2json/20260506-miku-javaclass2json-usage.md",
       "ext": "md",
       "dir": "references/miku-javaclass2json",
-      "size": 15260,
-      "summary": "--- title: [miku-javaclass2json] Java の .class / .jar を JSON / JSONL で索引化するアプリの使用方法 tags: Mikuku Java Maven JSON 生成AI author: igapyon slide: false ---"
+      "size": 15454,
+      "summary": "[miku-javaclass2json] Java の .class / .jar を JSON / JSONL で索引化するアプリの使用方法"
     },
     {
       "name": "20260330-mikuproject-ai-wbs-draft.md",

--- a/skills/igapyon-qiita-writer/references/miku-javaclass2json/20260506-miku-javaclass2json-usage.md
+++ b/skills/igapyon-qiita-writer/references/miku-javaclass2json/20260506-miku-javaclass2json-usage.md
@@ -1,10 +1,14 @@
+## [miku-javaclass2json] Java の .class / .jar を JSON / JSONL で索引化するアプリの使用方法
+
+- 掲載先: Qiita
+- URL: https://qiita.com/igapyon/items/5929580cc4ff4dac6329
+
 ---
 title: [miku-javaclass2json] Java の .class / .jar を JSON / JSONL で索引化するアプリの使用方法
-tags: Mikuku Java Maven JSON 生成AI
+tags: mikuku Java Maven JSON AI駆動開発
 author: igapyon
 slide: false
 ---
-
 ## はじめに
 
 `miku-javaclass2json-java` は、Java の `.class` ファイル、classes ディレクトリ、`.jar` ファイルを読み取り、JSON / JSONL の索引を生成するツールです。


### PR DESCRIPTION
## 概要

`miku-javaclass2json` のQiita記事参照に、掲載先情報とQiita URLを追加します。

## 変更内容

- `20260506-miku-javaclass2json-usage.md` の冒頭に記事タイトル、掲載先、Qiita URLを追加
- Qiita front matter のタグを調整
  - `Mikuku` を `mikuku` に変更
  - `生成AI` を `AI駆動開発` に変更
- `skills/igapyon-qiita-writer/index.json` の登録情報を更新
  - 記事サイズを更新
  - summary を記事タイトル中心の内容に更新