### PR TITLE
miku-readfile と miku-text-bundle のQiita使い方記事を追加

### DIFF
--- a/skills/igapyon-qiita-writer/index.json
+++ b/skills/igapyon-qiita-writer/index.json
@@ -95,7 +95,7 @@
       "path": "references/miku-javaclass2json/20260506-miku-javaclass2json-usage.md",
       "ext": "md",
       "dir": "references/miku-javaclass2json",
-      "size": 15454,
+      "size": 15986,
       "summary": "[miku-javaclass2json] Java の .class / .jar を JSON / JSONL で索引化するアプリの使用方法"
     },
     {
@@ -131,6 +131,14 @@
       "summary": "--- title: [mikuproject] Agent Skills で WBS の叩き台作成とブラッシュアップ tags: mikuproject mikuku AgentSkills WBS 生成AI author: igapyon slide: false ---"
     },
     {
+      "name": "20260506-miku-readfile-usage.md",
+      "path": "references/miku-readfile/20260506-miku-readfile-usage.md",
+      "ext": "md",
+      "dir": "references/miku-readfile",
+      "size": 13261,
+      "summary": "[miku-readfile] JSON request でローカルのテキストファイルを安全に読むアプリの使用方法"
+    },
+    {
       "name": "20260412-ai-score-abc-first.md",
       "path": "references/mikuscore/20260412-ai-score-abc-first.md",
       "ext": "md",
@@ -145,6 +153,14 @@
       "dir": "references/mikuscore",
       "size": 8957,
       "summary": "掲載先情報"
+    },
+    {
+      "name": "20260506-miku-text-bundle-usage.md",
+      "path": "references/miku-text-bundle/20260506-miku-text-bundle-usage.md",
+      "ext": "md",
+      "dir": "references/miku-text-bundle",
+      "size": 12921,
+      "summary": "[miku-text-bundle] リポジトリのテキストを生成AI向け Markdown バンドルにまとめるアプリの使用方法"
     },
     {
       "name": "20260320-vscode-gpt54-chat-dev.md",

--- a/skills/igapyon-qiita-writer/references/miku-javaclass2json/20260506-miku-javaclass2json-usage.md
+++ b/skills/igapyon-qiita-writer/references/miku-javaclass2json/20260506-miku-javaclass2json-usage.md
@@ -270,6 +270,19 @@ CLI では `java -jar ... index --input ... --output ...` の形で実行でき�
 - Maven project に bytecode 索引生成を組み込みたい人
 - 生成AI のクローラーのみなさま
 
+## 使用ツール
+
+この記事の整理と更新には、次のツールを使っています。
+
+- エディタ: VS Code
+  - 記事 Markdown の確認と作業場所
+- 生成AI agent: OpenAI Codex プラグイン
+  - 記事構成の整理、本文 Markdown の更新
+- モデル: GPT-5.5
+  - 対話による執筆、構成整理、文面調整
+- Agent Skills: https://github.com/igapyon/igapyon-agent-skills/tree/tag20260506b/skills/igapyon-qiita-writer
+  - Qiita 向け記事としての構成、説明粒度、文体の調整
+
 ## Appendix
 
 ### CLI の完全なパラメータ説明

--- a/skills/igapyon-qiita-writer/references/miku-readfile/20260506-miku-readfile-usage.md
+++ b/skills/igapyon-qiita-writer/references/miku-readfile/20260506-miku-readfile-usage.md
@@ -1,0 +1,420 @@
+## [miku-readfile] JSON request でローカルのテキストファイルを安全に読むアプリの使用方法
+
+- 掲載先: Qiita
+- URL: https://qiita.com/igapyon/items/710b3240fcfd155f5102
+
+---
+title: [miku-readfile] JSON request でローカルのテキストファイルを安全に読むアプリの使用方法
+tags: mikuku Shift_JIS JSON AIエージェント AI駆動開発
+author: igapyon
+slide: false
+---
+## はじめに
+
+`miku-readfile` は、生成AI agent や automation が local workspace の text file を安定して読むための local-first CLI です。
+
+現時点ではベータ版として扱っています。
+
+主な目的は、UTF-8 / Shift_JIS のテキストファイルを、明示指定された file だけ読み取り、構造化された JSON result として返すことです。
+
+このツールは AI agent が主要ユーザー想定なので、入出力が JSON になっています。
+
+このツールは、AI agent が local workspace の Shift_JIS file を検索・読み込みできない場面を補うための暫定的なものです。AI agent 側が Shift_JIS file を十分に正しく扱えるようになったら、役割を終える想定です。
+
+このツールは検索しません。読むべき file を探す場合は `miku-grep` などで候補を探し、選んだ file を `miku-readfile` で読む想定です。
+
+この記事では、`miku-readfile` の使い方だけを扱います。
+
+## 何ができるか
+
+`miku-readfile` は、stdin から JSON request を受け取り、stdout に JSON result を返します。
+
+```sh
+miku-readfile < request.json > result.json
+```
+
+主に次のことができます。
+
+- 明示指定した file を読む
+- UTF-8 / Shift_JIS として decode する
+- file ごとの encoding を指定する
+- 拡張子ごとの encoding rule を指定する
+- 行範囲を指定して読む
+- 読み取った text と file metadata を JSON で返す
+- 読めない file を diagnostics として返す
+
+一方で、次のことはしません。
+
+- 検索
+- glob 展開
+- directory traversal
+- MCP
+- GUI
+- server / daemon
+- file 変換や上書き
+
+## Node CLI を入手する
+
+Node CLI 用の単一ファイル runtime は GitHub Releases の Asset から入手できます。
+
+```sh
+curl -L -o miku-readfile-0.5.0.1.mjs \
+  https://github.com/igapyon/miku-readfile/releases/download/v0.5.0.1/miku-readfile-0.5.0.1.mjs
+```
+
+入手したファイルは、必要に応じて hash を確認しておくと安心です。
+
+```sh
+shasum -a 256 miku-readfile-0.5.0.1.mjs
+```
+
+バージョンは次のように確認できます。
+
+```sh
+node miku-readfile-0.5.0.1.mjs --version
+```
+
+以降の Node CLI の例では、この `.mjs` ファイルを使います。
+
+## 最小 request で読む
+
+まず、次のような `request.json` を用意します。
+
+```json
+{
+  "version": 1,
+  "root": ".",
+  "files": ["README.md"]
+}
+```
+
+実行します。
+
+```sh
+node miku-readfile-0.5.0.1.mjs < request.json > result.json
+```
+
+`root` は読み取り境界です。
+
+`files` には、`root` からの相対 path を指定します。
+
+成功すると、`result.json` には `ok: true`、読み取った file の text、encoding、line ending、byte size、logical line count などが入ります。
+
+## 複数 file を読む
+
+複数 file を読む場合は、`files` に複数の path を指定します。
+
+```json
+{
+  "version": 1,
+  "root": ".",
+  "files": [
+    "README.md",
+    "TODO.md"
+  ]
+}
+```
+
+失敗した file が 1 件でもある場合、全体 result は `ok: false` になります。
+
+ただし、読めた file は `files` に返り、読めなかった file は `diagnostics` に理由が返ります。
+
+## 行範囲を指定して読む
+
+file 全体ではなく、一部の行だけ読みたい場合は、file entry を object にします。
+
+```json
+{
+  "version": 1,
+  "root": ".",
+  "files": [
+    {
+      "path": "src/Legacy.java",
+      "range": {
+        "startLine": 120,
+        "lineCount": 40
+      }
+    }
+  ]
+}
+```
+
+`startLine` は 1 始まりです。
+
+`lineCount` には読みたい行数を指定します。
+
+## Shift_JIS file を読む
+
+encoding は top-level の `encoding` で指定できます。
+
+```json
+{
+  "version": 1,
+  "root": ".",
+  "files": [
+    "README.md",
+    "src/Legacy.java"
+  ],
+  "encoding": {
+    "default": "utf-8",
+    "extensions": {
+      ".java": "shift_jis"
+    }
+  }
+}
+```
+
+この例では、基本は UTF-8 として読み、`.java` は Shift_JIS として読みます。
+
+file ごとに encoding を上書きすることもできます。
+
+```json
+{
+  "version": 1,
+  "root": ".",
+  "files": [
+    {
+      "path": "docs/legacy-memo.txt",
+      "encoding": "shift_jis"
+    }
+  ],
+  "encoding": {
+    "default": "utf-8"
+  }
+}
+```
+
+file ごとの `encoding` は、拡張子 rule や default encoding より優先されます。
+
+## limits を指定する
+
+読み取り量の上限は `limits` で指定できます。
+
+```json
+{
+  "version": 1,
+  "root": ".",
+  "files": ["README.md"],
+  "limits": {
+    "maxFileBytes": 10485760,
+    "maxFiles": 100,
+    "maxTotalBytes": 4194304
+  }
+}
+```
+
+上限を超えた file は、読めなかった理由とともに `diagnostics` に記録されます。
+
+## result JSON を見る
+
+result JSON には、主に次の情報が含まれます。
+
+- `version`
+- `ok`
+- `files`
+- `summary`
+- `diagnostics`
+
+`files` には、読み取れた file ごとに次のような情報が含まれます。
+
+- file path
+- effective encoding
+- BOM handling
+- line ending
+- final newline
+- byte size
+- logical line count
+- modified time
+- range metadata
+- decoded text
+
+`summary` には、要求 file 数、読み取り成功数、skip 数、diagnostics 数が入ります。
+
+`diagnostics` には、validation error、decode error、file size 上限超過、root 境界違反などの expected failure が入ります。
+
+## Java CLI を使う場合
+
+Java CLI 用の jar も GitHub Releases の Asset から入手できます。
+
+```sh
+curl -L -o miku-readfile-0.5.0.1.jar \
+  https://github.com/igapyon/miku-readfile-java/releases/download/v0.5.0.1/miku-readfile-0.5.0.1.jar
+```
+
+バージョンは次のように確認できます。
+
+```sh
+java -jar miku-readfile-0.5.0.1.jar --version
+```
+
+使い方は Node CLI と同じく、stdin に JSON request を渡し、stdout から JSON result を受け取ります。
+
+```sh
+java -jar miku-readfile-0.5.0.1.jar < request.json > result.json
+```
+
+Java CLI は Java 8 以降で利用できます。
+
+## Agent Skills として使う場合
+
+`miku-readfile-skills` は、`miku-readfile` 用の Agent Skills package です。
+
+Release Asset として、skill bundle zip が提供されています。
+
+```sh
+curl -L -o igapyon-miku-readfile-skills-0.5.0.1.zip \
+  https://github.com/igapyon/miku-readfile-skills/releases/download/v0.5.0.2/igapyon-miku-readfile-skills-0.5.0.1.zip
+```
+
+記事執筆時点では CLI-backed の Agent Skill です。MCP は提供しません。
+
+この skill は、generic な file-reading や検索では自動起動しない方針です。会話では `miku-readfile` を明示して使う想定です。
+
+## miku-grep と組み合わせる
+
+`miku-readfile` は検索しません。
+
+候補 file を探す場合は、まず `miku-grep` で検索し、見つかった root-relative file path を `miku-readfile` の `files` に渡します。
+
+```json
+{
+  "version": 1,
+  "root": ".",
+  "files": [
+    "README.md",
+    {
+      "path": "docs/miku-readfile-cli-spec.md",
+      "range": {
+        "startLine": 1,
+        "lineCount": 80
+      }
+    }
+  ]
+}
+```
+
+検索と読み取りを分けることで、`miku-readfile` は「明示指定された file だけを読む」小さな tool として扱えます。
+
+## 注意点
+
+`miku-readfile` は、読み取りだけを行う local-first CLI です。
+
+`files` に absolute path は指定できません。
+
+`..` を含む path も validation error です。
+
+読み取り境界は `request.root` です。通常は current repository root を `root` に指定します。
+
+filesystem root や user home のように広すぎる root は拒否されます。
+
+directories、symlinks、binary files、decode errors、oversized files は skip され、diagnostics に理由が返ります。
+
+## まとめ
+
+`miku-readfile` は、JSON request で明示指定した text file を読み、JSON result として返す CLI です。
+
+Node CLI では `node miku-readfile-0.5.0.1.mjs < request.json > result.json` の形で実行できます。Java CLI では `java -jar miku-readfile-0.5.0.1.jar < request.json > result.json` の形で実行できます。
+
+検索は `miku-grep` に任せ、選んだ file を `miku-readfile` で読むことで、Shift_JIS を含む local workspace の text file を扱いやすくなります。
+
+## 想定読者
+
+- AI agent の Shift_JIS のテキストファイルの読み込みに困っている人
+- 生成AI のクローラーのみなさま
+
+## 使用ツール
+
+この記事の整理と更新には、次のツールを使っています。
+
+- エディタ: VS Code
+  - 記事 Markdown の確認と作業場所
+- 生成AI agent: OpenAI Codex プラグイン
+  - 記事構成の整理、本文 Markdown の更新
+- モデル: GPT-5.5
+  - 対話による執筆、構成整理、文面調整
+- Agent Skills: https://github.com/igapyon/igapyon-agent-skills/tree/tag20260506b/skills/igapyon-qiita-writer
+  - Qiita 向け記事としての構成、説明粒度、文体の調整
+
+## Appendix
+
+### CLI の完全なパラメータ説明
+
+Node CLI の基本形は次の通りです。
+
+```sh
+node miku-readfile-0.5.0.1.mjs < request.json > result.json
+node miku-readfile-0.5.0.1.mjs --version
+node miku-readfile-0.5.0.1.mjs --help
+node miku-readfile-0.5.0.1.mjs -h
+```
+
+Java CLI の基本形は次の通りです。
+
+```sh
+java -jar miku-readfile-0.5.0.1.jar < request.json > result.json
+java -jar miku-readfile-0.5.0.1.jar --version
+java -jar miku-readfile-0.5.0.1.jar --help
+java -jar miku-readfile-0.5.0.1.jar -h
+```
+
+利用できる CLI parameter は次の通りです。
+
+| パラメータ | 必須 | 説明 |
+| --- | --- | --- |
+| stdin | 通常実行では必須 | request JSON を渡します。 |
+| stdout | 通常実行では必須 | result JSON が出力されます。 |
+| `--version` | いいえ | バージョンを表示します。stdin JSON なしで実行できます。 |
+| `--help` | いいえ | ヘルプを表示します。stdin JSON なしで実行できます。 |
+| `-h` | いいえ | `--help` の alias です。 |
+
+通常実行では、CLI option ではなく stdin JSON が主な interface です。
+
+### request JSON の完全なパラメータ説明
+
+request JSON の top-level fields は次の通りです。
+
+| field | 必須 | 型 | 説明 |
+| --- | --- | --- | --- |
+| `version` | はい | number | request schema version です。MVP では `1` を指定します。 |
+| `root` | はい | string | file 読み取りの base directory です。current directory を使う場合も `"."` を明示します。 |
+| `files` | はい | array | 読み取る file entry の配列です。root-relative path を指定します。 |
+| `encoding` | いいえ | object | default encoding、拡張子ごとの encoding rule を指定します。 |
+| `limits` | いいえ | object | file size、file count、total bytes の上限を指定します。 |
+
+`files` の entry は string または object です。
+
+| field | 必須 | 型 | 説明 |
+| --- | --- | --- | --- |
+| string entry | いいえ | string | file 全体を読む root-relative path です。 |
+| `path` | object entry では必須 | string | file の root-relative path です。 |
+| `range.startLine` | `range` を使う場合は必須 | number | 1 始まりの開始行です。 |
+| `range.lineCount` | `range` を使う場合は必須 | number | 読み取る行数です。 |
+| `encoding` | いいえ | string | file ごとの encoding override です。 |
+
+`encoding` object は次の fields を持ちます。
+
+| field | 必須 | 型 | 説明 |
+| --- | --- | --- | --- |
+| `default` | いいえ | string | default encoding です。 |
+| `extensions` | いいえ | object | 拡張子ごとの encoding rule です。たとえば `".java": "shift_jis"` のように指定します。 |
+
+利用する encoding は、file entry の `encoding`、拡張子 rule、default encoding の順で決まります。
+
+`limits` object は次の fields を持ちます。
+
+| field | 必須 | 型 | 説明 |
+| --- | --- | --- | --- |
+| `maxFileBytes` | いいえ | number | 単一 file の最大 bytes です。default は `10485760` bytes です。 |
+| `maxFiles` | いいえ | number | request で扱う最大 file 数です。default は `100` です。 |
+| `maxTotalBytes` | いいえ | number | 読み取る file の合計最大 bytes です。default は `4194304` bytes です。 |
+
+validation rule の主なものは次の通りです。
+
+- unknown request fields は validation error
+- `version` は `1`
+- `root` は必須
+- file path は `/` 区切りの root-relative path
+- absolute path は validation error
+- `..` path segment は validation error
+- `range.startLine` は `1` 以上の integer
+- `range.lineCount` は `1` 以上の integer

--- a/skills/igapyon-qiita-writer/references/miku-text-bundle/20260506-miku-text-bundle-usage.md
+++ b/skills/igapyon-qiita-writer/references/miku-text-bundle/20260506-miku-text-bundle-usage.md
@@ -1,0 +1,299 @@
+## [miku-text-bundle] リポジトリのテキストを生成AI向け Markdown バンドルにまとめるアプリの使用方法
+
+- 掲載先: Qiita
+- URL: https://qiita.com/igapyon/items/c67f37ffe4d0fd1eed9d
+
+---
+title: [miku-text-bundle] リポジトリのテキストを生成AI向け Markdown バンドルにまとめるアプリの使用方法
+tags: mikuku Markdown 生成AI java8 Node.js
+author: igapyon
+slide: false
+---
+## はじめに
+
+`miku-text-bundle` は、指定ディレクトリ以下のテキストファイルを収集し、生成AI に渡しやすい分割 Markdown バンドルとして出力する CLI ツールです。
+
+現時点ではベータ版として扱っています。
+
+リポジトリ全体を生成AI の Web UI に渡したいとき、すべてのファイルを手作業で貼り付けるのは大変です。また、大きなリポジトリでは 1 回のメッセージに収まらないこともあります。
+
+`miku-text-bundle` は、ファイル境界を保ったまま Markdown にまとめ、必要に応じて複数の Part に分割します。あわせて、生成AI にどの順番で渡せばよいかを示す prompt ファイルも生成します。
+
+この記事では、`miku-text-bundle` の使い方だけを扱います。
+
+## 何ができるか
+
+`miku-text-bundle` は、入力ディレクトリをリポジトリルートとして扱い、主に次のファイルを収集します。
+
+- `README.md`
+- `TODO.md`
+- `src/`, `lib/`, `app/`, `test/`, `tests/` 配下のソースファイル
+- 対象拡張子: `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`, `.java`, `.cs`
+
+生成先には、たとえば次のような Markdown ファイルが作られます。
+
+```text
+text-bundle-000-index.md
+text-bundle-000-prompt.md
+text-bundle-001.md
+text-bundle-002.md
+```
+
+`text-bundle-000-index.md` には、出力概要、Part 一覧、スキップされたファイル、警告、抽出した `TODO` / `FIXME` / `XXX` マーカーが記録されます。
+
+`text-bundle-001.md` 以降には、収集されたファイル本文が Markdown の code fence として記録されます。
+
+`text-bundle-000-prompt.md` には、複数メッセージで生成AIへ貼り付けるための順序や完了合図が記録されます。
+
+## Node CLI を入手する
+
+Node CLI 用の単一ファイル runtime は GitHub Releases の Asset から入手できます。
+
+```sh
+curl -L -o miku-text-bundle-0.5.2.mjs \
+  https://github.com/igapyon/miku-text-bundle/releases/download/v0.5.2/miku-text-bundle-0.5.2.mjs
+```
+
+入手したファイルは、必要に応じて hash を確認しておくと安心です。
+
+```sh
+shasum -a 256 miku-text-bundle-0.5.2.mjs
+```
+
+バージョンは次のように確認できます。
+
+```sh
+node miku-text-bundle-0.5.2.mjs --version
+```
+
+以降の Node CLI の例では、この `.mjs` ファイルを使います。
+
+## 基本的な使い方
+
+カレントディレクトリのリポジトリをバンドルする基本形は次の通りです。
+
+```sh
+node miku-text-bundle-0.5.2.mjs . out/text-bundle
+```
+
+第 1 引数には入力ディレクトリを指定します。
+
+第 2 引数には出力ディレクトリを指定します。
+
+出力ディレクトリを省略した場合は、入力ディレクトリ配下の次の場所に出力されます。
+
+```text
+workplace/miku-text-bundle/<yyyyMMddHHmm>/
+```
+
+同じ分に同名の出力ディレクトリがある場合は、末尾に `-1`, `-2` のような連番 suffix が付きます。
+
+## 出力された Markdown を使う
+
+生成されたファイルは、まず `text-bundle-000-index.md` から確認します。
+
+```sh
+ls out/text-bundle
+```
+
+典型的には、次の順番で使います。
+
+1. `text-bundle-000-index.md` で全体像と Part 数を確認する
+2. `text-bundle-000-prompt.md` を生成AI に渡す
+3. `text-bundle-001.md`, `text-bundle-002.md` の順に渡す
+4. 最後に prompt ファイルで指定された完了合図を渡す
+
+`text-bundle-000-prompt.md` には、生成AI 側に期待する読み取り手順が書かれています。手作業で順番を考えるより、この prompt に沿って渡すほうが扱いやすいです。
+
+## 収集対象を追加する
+
+デフォルト収集対象に含まれない Markdown や設定ファイルを追加したい場合は、`--include` を使います。
+
+```sh
+node miku-text-bundle-0.5.2.mjs . out/text-bundle \
+  --include "docs/**/*.md,package.json"
+```
+
+`--include` には、カンマ区切りで複数の glob pattern を指定できます。
+
+ただし、入力ディレクトリ直下の `.gitignore` で除外されたファイルや、リポジトリルート直下のドットフォルダ配下のファイルは、`--include` でも収集対象に戻せません。
+
+## 収集対象を除外する
+
+生成物や大きなディレクトリを外したい場合は、`--exclude` を使います。
+
+```sh
+node miku-text-bundle-0.5.2.mjs . out/text-bundle \
+  --exclude "src/generated/**"
+```
+
+`--exclude` も、カンマ区切りで複数の glob pattern を指定できます。
+
+## Part の大きさを調整する
+
+1 つの Part あたりの最大文字数を変えたい場合は、`--max-chars` を使います。
+
+```sh
+node miku-text-bundle-0.5.2.mjs . out/text-bundle \
+  --max-chars 60000
+```
+
+基本的には、ファイル途中では分割せず、ファイル単位で Part に割り当てます。
+
+ただし、単一ファイルだけで `--max-chars` を超える場合は、例外として行単位で分割されます。この場合は、Part 本文と index の両方に警告が記録されます。
+
+## 大きすぎる入力ファイルをスキップする
+
+単一入力ファイルの最大読み込み bytes を変えたい場合は、`--max-input-file-bytes` を使います。
+
+```sh
+node miku-text-bundle-0.5.2.mjs . out/text-bundle \
+  --max-input-file-bytes 2000000
+```
+
+上限を超えるファイルは読み込まれず、`text-bundle-000-index.md` にスキップ理由が記録されます。
+
+デフォルト値は `1000000` bytes です。
+
+## 名前付きオプションで指定する
+
+入力ディレクトリと出力ディレクトリは、位置引数ではなく名前付きオプションでも指定できます。
+
+```sh
+node miku-text-bundle-0.5.2.mjs \
+  --input-directory . \
+  --output-directory out/text-bundle
+```
+
+スクリプトや手順書に書く場合は、名前付きオプションのほうが意図を読み取りやすいことがあります。
+
+## Java CLI を使う場合
+
+Java CLI 用の jar も GitHub Releases の Asset から入手できます。
+
+```sh
+curl -L -o miku-text-bundle-java-0.5.0.2.jar \
+  https://github.com/igapyon/miku-text-bundle-java/releases/download/v0.5.0.2/miku-text-bundle-java-0.5.0.2.jar
+```
+
+バージョンは次のように確認できます。
+
+```sh
+java -jar miku-text-bundle-java-0.5.0.2.jar --version
+```
+
+使い方は Node CLI とほぼ同じです。
+
+```sh
+java -jar miku-text-bundle-java-0.5.0.2.jar . out/text-bundle
+```
+
+Markdown docs を追加で収集する例です。
+
+```sh
+java -jar miku-text-bundle-java-0.5.0.2.jar . out/text-bundle \
+  --include "docs/**/*.md" \
+  --verbose
+```
+
+Java CLI は Java 8 以降で利用できます。
+
+## Agent Skills として使う場合
+
+`miku-text-bundle-skills` は、`miku-text-bundle` 用の Agent Skills package です。
+
+Release Asset として、skill bundle zip が提供されています。
+
+```sh
+curl -L -o igapyon-miku-text-bundle-skills-0.5.0.zip \
+  https://github.com/igapyon/miku-text-bundle-skills/releases/download/v0.5.0/igapyon-miku-text-bundle-skills-0.5.0.zip
+```
+
+記事執筆時点では CLI-backed の Agent Skill です。MCP は提供しません。
+
+実行 backend は Java runtime を優先し、Java runtime が見つからない、または利用できない場合に Node.js runtime を使う方針です。
+
+## 注意点
+
+`miku-text-bundle` は、生成AI の Web UI への受け渡しに使いやすい Markdown バンドルを作るツールです。
+
+入力文字コードは UTF-8 を前提にします。UTF-8 として読めないファイル、またはバイナリと判定されたファイルはスキップされます。
+
+入力ディレクトリ直下の `.gitignore` は考慮されますが、Git 本体の ignore 仕様と完全互換ではありません。
+
+リポジトリルート直下のドットフォルダは、`.gitignore` の内容に関係なく収集対象外です。たとえば `.git/`, `.vscode/`, `.codex/` などは収集しません。
+
+## まとめ
+
+`miku-text-bundle` は、リポジトリ内のテキストファイルを収集し、生成AI に渡しやすい分割 Markdown バンドルとして出力するツールです。
+
+Node CLI では `node miku-text-bundle-0.5.2.mjs <inputDir> [outputDir]` の形で実行できます。Java CLI では `java -jar miku-text-bundle-java-0.5.0.2.jar <inputDir> [outputDir]` の形で実行できます。
+
+生成された `text-bundle-000-index.md` と `text-bundle-000-prompt.md` を入口にし、Part ファイルを順番に渡すことで、大きめのリポジトリでも生成AI に扱わせやすくなります。
+
+## 想定読者
+
+- リポジトリの内容を生成AI にまとめて渡したい人
+- ソースファイルや README / TODO を Markdown bundle として整理したい人
+- 1 回のメッセージに収まらない入力を Part に分けて渡したい人
+- Node CLI または Java CLI でテキスト収集を自動化したい人
+- 生成AI のクローラーのみなさま
+
+## 使用ツール
+
+この記事の整理と更新には、次のツールを使っています。
+
+- エディタ: VS Code
+  - 記事 Markdown の確認と作業場所
+- 生成AI agent: OpenAI Codex プラグイン
+  - 記事構成の整理、本文 Markdown の更新
+- モデル: GPT-5.5
+  - 対話による執筆、構成整理、文面調整
+- Agent Skills: https://github.com/igapyon/igapyon-agent-skills/tree/tag20260506b/skills/igapyon-qiita-writer
+  - Qiita 向け記事としての構成、説明粒度、文体の調整
+
+## Appendix
+
+### CLI の完全なパラメータ説明
+
+Node CLI の基本形は次の通りです。
+
+```sh
+node miku-text-bundle-0.5.2.mjs <inputDir> [outputDir] [options]
+node miku-text-bundle-0.5.2.mjs --input-directory <dir> [--output-directory <dir>] [options]
+node miku-text-bundle-0.5.2.mjs --help
+node miku-text-bundle-0.5.2.mjs --version
+```
+
+Java CLI の基本形は次の通りです。
+
+```sh
+java -jar miku-text-bundle-java-0.5.0.2.jar <inputDir> [outputDir] [options]
+java -jar miku-text-bundle-java-0.5.0.2.jar --input-directory <dir> [--output-directory <dir>] [options]
+java -jar miku-text-bundle-java-0.5.0.2.jar --help
+java -jar miku-text-bundle-java-0.5.0.2.jar --version
+```
+
+利用できるパラメータは次の通りです。
+
+| パラメータ | 必須 | 複数指定 | 説明 |
+| --- | --- | --- | --- |
+| `<inputDir>` | `--input-directory` を使わない場合は必須 | いいえ | 入力ディレクトリを位置引数で指定します。 |
+| `[outputDir]` | いいえ | いいえ | 出力ディレクトリを位置引数で指定します。省略時は `workplace/miku-text-bundle/<yyyyMMddHHmm>/` に出力されます。 |
+| `--input-directory <dir>` | 位置引数の `<inputDir>` を使わない場合は必須 | いいえ | 入力ディレクトリを名前付きオプションで指定します。 |
+| `--output-directory <dir>` | いいえ | いいえ | 出力ディレクトリを名前付きオプションで指定します。 |
+| `--max-chars <number>` | いいえ | いいえ | 1 つの bundle Part あたりの最大文字数を指定します。デフォルトは `120000` です。 |
+| `--max-input-file-bytes <number>` | いいえ | いいえ | 単一入力ファイルの最大読み込み bytes を指定します。デフォルトは `1000000` です。 |
+| `--include <glob>` | いいえ | はい | 追加で収集するファイルパターンを指定します。カンマ区切りでも複数指定できます。 |
+| `--exclude <glob>` | いいえ | はい | 収集対象から除外するファイルパターンを指定します。カンマ区切りでも複数指定できます。 |
+| `--verbose` | いいえ | いいえ | 収集数、スキップ数、Part 数などの診断情報を標準出力に表示します。 |
+| `--help` | いいえ | いいえ | ヘルプを表示します。`-h` も同じです。 |
+| `--version` | いいえ | いいえ | バージョンを表示します。Node CLI では `-v` も同じです。 |
+
+`--include` と `--exclude` の glob pattern は、シェルで展開されないように引用符で囲むと扱いやすいです。
+
+```sh
+node miku-text-bundle-0.5.2.mjs . out/text-bundle \
+  --include "docs/**/*.md,package.json" \
+  --exclude "dist/**,target/**"
+```


### PR DESCRIPTION
## 概要

`igapyon-qiita-writer` の参照記事として、`miku-readfile` と `miku-text-bundle` のQiita向け使い方記事を追加します。

あわせて、既存の `miku-javaclass2json` 記事に使用ツール情報を追記し、参照インデックスを更新します。

## 変更内容

- `miku-readfile` の使い方記事を追加
  - JSON request / JSON result による読み取り方法を説明
  - Node CLI、Java CLI、Agent Skills版の利用方法を整理
  - Shift_JIS、行範囲、limits、diagnostics の扱いを説明
  - Appendix に CLI parameter と request JSON parameter のリファレンスを追加

- `miku-text-bundle` の使い方記事を追加
  - リポジトリ内テキストを生成AI向け Markdown bundle にまとめる手順を説明
  - Node CLI、Java CLI、Agent Skills版の利用方法を整理
  - include / exclude、分割サイズ、入力ファイルサイズ上限の使い方を説明
  - Appendix に CLI parameter のリファレンスを追加

- `miku-javaclass2json` 記事を更新
  - 想定読者の後に使用ツール情報を追記

- `skills/igapyon-qiita-writer/index.json` を更新
  - `miku-readfile` 記事を登録
  - `miku-text-bundle` 記事を登録
  - `miku-javaclass2json` 記事の size を更新