### PR TITLE
Qiita / Note writer skill の references 正本ルールを明確化

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - 1 skill = 1 directory
 - skill ごとの詳細仕様は各 `SKILL.md` に書く
 - skill の具体ルール、例、長めの手順は `references/` 配下に置く
+- Qiita / Note 記事 Markdown は、各 writer skill 配下の `references/` を正本として管理する
 - skill を新規作成・更新した後は、`SKILL.md` が必要な `references/` を案内していること、必要に応じて `index.json` を参照することを確認する
 - repo 全体の運用ルールはこの `README.md` に書く
 - 作業メモは repo 直下の `TODO.md` に集約する
@@ -69,17 +70,19 @@ skill を利用する際は、`SKILL.md` を入口とし、具体ルール、例
 `skill-creator` などで skill を作成した直後は、必要な具体ルールを `SKILL.md` に詰め込みすぎず、`references/` へ分離します。  
 また、参照資料の全体像を探す必要がある skill では、`SKILL.md` に `index.json` を discovery index として使う旨を明記します。
 
-特に、`references/` 以下の `miku` から始まるディレクトリ内のファイルは、ほかのリポジトリに正本がある記事やメモを、この repo で利用しやすいようにコピーしたものです。  
-この repo では、それらのコピーを skill と一緒に `.codex/skills/` へ複写して利用する前提です。
+Qiita / Note 記事 Markdown は、各 writer skill 配下の `references/` を正本として管理します。
 
-正本側の更新を取り込む必要がある場合は、必要なタイミングでこの repo 側のコピーを更新します。
+- Qiita 技術記事の正本: `skills/igapyon-qiita-writer/references/`
+- Note 記事の正本: `skills/igapyon-note-writer/references/`
 
-一方、`references/general/` は、この repo を正本として管理する一般記事用の置き場です。  
-`miku` 系プロダクトに分類されない Qiita / Note 記事は、必要に応じて各 writer skill の `references/general/` に置きます。
+`references/general/` は、特定の `miku` 系プロダクトに分類されない一般記事用の置き場です。  
+`miku` 系プロダクトの記事は、各 writer skill の `references/<project>/` に置きます。
+
+`workplace/*/docs/articles/` などに記事メモや旧配置の Markdown が残っている場合でも、記事として更新・公開対象にする正本は writer skill 配下の `references/` です。
 
 ## docs/articles 集約状況
 
-記事管理は、Qiita 向け記事を `skills/igapyon-qiita-writer/references/`、Note 向け記事を `skills/igapyon-note-writer/references/` に集約する方針です。
+記事管理は、Qiita 向け記事を `skills/igapyon-qiita-writer/references/`、Note 向け記事を `skills/igapyon-note-writer/references/` に集約し、そこを正本として扱う方針です。
 
 2026-05-06 時点で、`workplace/*/docs/articles/qiita/` 配下の有意な記事本文は、`README.md` と `TEMPLATE.md` を除き、すべて `skills/igapyon-qiita-writer/references/` 側に同一内容で存在することを確認済みです。
 

--- a/skills/igapyon-note-writer/SKILL.md
+++ b/skills/igapyon-note-writer/SKILL.md
@@ -100,7 +100,10 @@ Note 掲載用の属性情報が必要な場合は、次の形を基本にしま
 
 ## Reference Usage
 
-`references/` 配下の記事は、Note 記事の実例集として使います。
+`references/` 配下の記事は、Note 記事の正本であり、Note 記事の実例集としても使います。
+
+Note 記事を新規作成・更新する場合は、`skills/igapyon-note-writer/references/` 配下の Markdown を正本として扱います。  
+`workplace/*/docs/articles/note/` などに旧配置や作業メモがある場合でも、公開・更新対象の本文はこの skill 配下の `references/` に置きます。
 
 主に見る観点は次の通りです。
 

--- a/skills/igapyon-note-writer/index.json
+++ b/skills/igapyon-note-writer/index.json
@@ -103,7 +103,7 @@
       "path": "SKILL.md",
       "ext": "md",
       "dir": "",
-      "size": 6869,
+      "size": 7234,
       "summary": "--- name: igapyon-note-writer description: Use only when the user explicitly asks for igapyon-note-writer, asks to create or revise a Japanese Note article in igapyon style, or clearly requests Note-ready Markdown with title and hashtag suggestions. If the"
     }
   ]

--- a/skills/igapyon-qiita-writer/SKILL.md
+++ b/skills/igapyon-qiita-writer/SKILL.md
@@ -99,7 +99,10 @@ slide: false
 
 ## Reference Usage
 
-`references/` 配下の記事は、Qiita 記事の実例集として使います。
+`references/` 配下の記事は、Qiita 技術記事の正本であり、Qiita 記事の実例集としても使います。
+
+Qiita 記事を新規作成・更新する場合は、`skills/igapyon-qiita-writer/references/` 配下の Markdown を正本として扱います。  
+`workplace/*/docs/articles/qiita/` などに旧配置や作業メモがある場合でも、公開・更新対象の本文はこの skill 配下の `references/` に置きます。
 
 主に見る観点は次の通りです。
 

--- a/skills/igapyon-qiita-writer/index.json
+++ b/skills/igapyon-qiita-writer/index.json
@@ -247,7 +247,7 @@
       "path": "SKILL.md",
       "ext": "md",
       "dir": "",
-      "size": 6665,
+      "size": 7040,
       "summary": "--- name: igapyon-qiita-writer description: Use only when the user explicitly asks for igapyon-qiita-writer, asks to create or revise a Japanese Qiita technical article in igapyon style, or clearly requests Qiita-ready Markdown with front matter, tags, and"
     }
   ]


### PR DESCRIPTION
## 概要

Qiita / Note 記事 Markdown の管理方針について、各 writer skill 配下の `references/` を正本として扱うことを README と skill 定義に明記しました。

## 変更内容

- README の方針と `references` 説明を更新し、Qiita / Note 記事 Markdown の正本配置を明確化
- Qiita 記事の正本を `skills/igapyon-qiita-writer/references/` として明記
- Note 記事の正本を `skills/igapyon-note-writer/references/` として明記
- `workplace/*/docs/articles/` などに旧配置や作業メモが残る場合でも、公開・更新対象は writer skill 配下の `references/` とする扱いを追加
- `igapyon-qiita-writer` と `igapyon-note-writer` の `SKILL.md` に、記事作成・更新時の正本参照ルールを追加
- 両 writer skill の `index.json` で、更新後の `SKILL.md` サイズ情報を反映