### PR TITLE
Node main app の release asset workflow 方針を v20260507 に更新

### DIFF
--- a/skills/igapyon-miku-soft-developer/assets/node-main-app/.github/workflows/release-cli-bundle.yml
+++ b/skills/igapyon-miku-soft-developer/assets/node-main-app/.github/workflows/release-cli-bundle.yml
@@ -1,0 +1,60 @@
+name: Release CLI bundle
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release-cli-bundle:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Smoke test
+        run: npm run smoke:bundle
+
+      - name: Prepare release assets
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG_NAME#v}"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          case "${VERSION}" in
+            "${PACKAGE_VERSION}"|"${PACKAGE_VERSION}".*) ;;
+            *)
+              echo "Release tag version (${VERSION}) must match package.json version (${PACKAGE_VERSION}) or add a dot suffix such as ${PACKAGE_VERSION}.2." >&2
+              exit 1
+              ;;
+          esac
+
+          mkdir -p release-assets
+          cp bundle/__PRODUCT_NAME__.mjs "release-assets/__PRODUCT_NAME__-${VERSION}.mjs"
+          cp bundle/__PRODUCT_NAME__-sources.tgz "release-assets/__PRODUCT_NAME__-sources-${VERSION}.tgz"
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: release-assets/*
+          overwrite_files: true
+          draft: false
+          prerelease: false

--- a/skills/igapyon-miku-soft-developer/index.json
+++ b/skills/igapyon-miku-soft-developer/index.json
@@ -38,7 +38,7 @@
       "path": "references/10-node-app-workflow.md",
       "ext": "md",
       "dir": "references",
-      "size": 12203,
+      "size": 12754,
       "summary": "Node App Workflow"
     },
     {
@@ -106,12 +106,12 @@
       "summary": "Miku Software Overview Design v20260427"
     },
     {
-      "name": "miku-soft-10-mainapp-design-v20260506.md",
-      "path": "references/miku-soft-basic/miku-soft-10-mainapp-design-v20260506.md",
+      "name": "miku-soft-10-mainapp-design-v20260507.md",
+      "path": "references/miku-soft-basic/miku-soft-10-mainapp-design-v20260507.md",
       "ext": "md",
       "dir": "references/miku-soft-basic",
-      "size": 65008,
-      "summary": "Miku Software Main Application Design v20260506"
+      "size": 65868,
+      "summary": "Miku Software Main Application Design v20260507"
     },
     {
       "name": "miku-soft-20-javaapp-design-v20260506.md",
@@ -198,7 +198,7 @@
       "path": "references/review/release-automation.md",
       "ext": "md",
       "dir": "references/review",
-      "size": 7256,
+      "size": 7908,
       "summary": "Release Automation Review"
     },
     {

--- a/skills/igapyon-miku-soft-developer/references/10-node-app-workflow.md
+++ b/skills/igapyon-miku-soft-developer/references/10-node-app-workflow.md
@@ -2,7 +2,7 @@
 
 Use this workflow for creating or maintaining a miku-soft Node.js / TypeScript main application.
 
-Detailed design guidance lives in [miku-soft-basic/miku-soft-10-mainapp-design-v20260506.md](miku-soft-basic/miku-soft-10-mainapp-design-v20260506.md). Keep this file as the execution checklist.
+Detailed design guidance lives in [miku-soft-basic/miku-soft-10-mainapp-design-v20260507.md](miku-soft-basic/miku-soft-10-mainapp-design-v20260507.md). Keep this file as the execution checklist.
 
 ## Required Initial Input
 
@@ -56,9 +56,10 @@ Categories:
 
 - CI baseline:
   - pull request / push verification
+  - separate quality gate category, not part of the standard release asset workflow
 
 - Release asset workflow:
-  - `v*` tag or GitHub Release publication
+  - `v*` tag push
   - attach generated files to a GitHub Release
   - check tag version against `package.json` version
   - build from the release tag
@@ -69,7 +70,7 @@ Categories:
   - package registry publication
   - token and registry policy
 
-If the user says `v* tag`, `release`, `attach files`, `release asset`, or `GitHub Release`, do not add or modify CI baseline as the primary action. Use the Release Bundle Workflow section first.
+If the user says `v* tag`, `release`, `attach files`, `release asset`, or `GitHub Release`, do not add or modify CI baseline as the primary action. Use the Release Bundle Workflow section first. Do not create a pull-request or normal-push CI baseline workflow unless the user explicitly asks for CI baseline work.
 
 If the repository does not yet have a bundle artifact script, do not assume the asset type silently. Report the available artifact candidates, such as:
 
@@ -88,14 +89,17 @@ When a Node CLI main app publishes a single-file runtime artifact through GitHub
 
 Check these points:
 
-- The workflow is triggered by GitHub Release publication and, when useful, `workflow_dispatch` with an explicit `tag_name`.
-- The workflow only attaches release assets for version tags, normally `v*`.
-- The checkout ref uses the release tag or manually supplied tag, not an unrelated branch tip.
-- The workflow runs dependency install, build, asset preparation, and `smoke:bundle` before upload.
+- The standard workflow is triggered by `push` tags matching `v*`.
+- Do not use GitHub Release `published` as the standard trigger. Use it only when the repository has a documented repository-specific reason.
+- Use `workflow_dispatch` with an explicit `tag_name` only when the repository needs a manual rerun path for recreating or attaching release assets.
+- If `workflow_dispatch` is used, guard the job so only `v*` tags proceed.
+- The checkout ref uses the pushed release tag or explicit manual tag, not an unrelated branch tip.
+- The workflow runs dependency install, build, smoke, release asset staging, and upload in that order.
+- Build and smoke are delegated to local `npm scripts`; release tag validation and asset staging may be in the workflow template when they only adapt local build outputs into GitHub Release asset names.
 - The `smoke:bundle` command verifies that the generated single-file runtime starts and responds to both `--version` and `--help`.
 - The release tag version is checked against `package.json` `version`; if patch suffix tags are allowed, the accepted suffix rule is explicit.
-- Runtime and source assets are copied from `bundle/` into a release staging directory with product and version in the filename.
-- Upload uses the GitHub Release tag and only the prepared miku-soft CLI assets, normally `<product>-<version>.mjs` and `<product>-sources-<version>.tgz`.
+- Runtime and source assets are staged into `release-assets/`, with product and version in the filename.
+- Upload uses the GitHub Release tag and only files already prepared under `release-assets/*`.
 - Do not implement a Release CLI bundle workflow by running `npm pack` and uploading `release-assets/*.tgz` unless the user explicitly asked for the npm package tarball as the release asset.
 - Do not add a broad repository source ZIP or generic source archive as a custom uploaded release asset.
 - Actions runtime compatibility settings, such as Node.js version or JavaScript action runtime flags, are kept only when the reference project or current repository needs them.
@@ -111,21 +115,15 @@ If the current repository only has `npm pack` and does not yet generate `bundle/
 
 The bundle smoke path should include metadata checks for the generated runtime artifact. At minimum, run the bundled CLI with `--version` and `--help` without requiring normal input files or stdin payloads. Product-specific smoke checks may add a small real operation after those metadata checks.
 
-When the repository has a documented bundle build and smoke script, the expected local workflow file is normally `.github/workflows/release-cli-bundle.yml` with this shape, adapted to the product name and artifact paths:
+When the repository has a documented bundle build and smoke script, the expected local workflow file is normally `.github/workflows/release-cli-bundle.yml` with this shape, adapted to the product name, package scripts, and artifact paths:
 
 ```yaml
 name: Release CLI bundle
 
 on:
-  release:
-    types:
-      - published
-  workflow_dispatch:
-    inputs:
-      tag_name:
-        description: "GitHub Release tag to attach the CLI bundle to"
-        required: true
-        type: string
+  push:
+    tags:
+      - "v*"
 
 permissions:
   contents: write
@@ -136,13 +134,10 @@ env:
 jobs:
   release-cli-bundle:
     runs-on: ubuntu-latest
-    if: startsWith(github.event.release.tag_name || github.event.inputs.tag_name, 'v')
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.tag_name || github.event.release.tag_name || github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -156,9 +151,12 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Smoke test
+        run: npm run smoke:bundle
+
       - name: Prepare release assets
         env:
-          TAG_NAME: ${{ github.event.inputs.tag_name || github.event.release.tag_name || github.ref_name }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           VERSION="${TAG_NAME#v}"
@@ -175,21 +173,23 @@ jobs:
           cp bundle/<product>.mjs "release-assets/<product>-${VERSION}.mjs"
           cp bundle/<product>-sources.tgz "release-assets/<product>-sources-${VERSION}.tgz"
 
-      - name: Verify CLI bundle asset
-        run: npm run smoke:bundle
-
       - name: Upload CLI bundle to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.inputs.tag_name || github.event.release.tag_name || github.ref_name }}
+          tag_name: ${{ github.ref_name }}
           files: release-assets/*
+          overwrite_files: true
           draft: false
           prerelease: false
 ```
 
-If the repository does not require an Actions runtime compatibility environment variable, omit `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`. If the bundle files or smoke script use different names, adapt only those paths and commands while preserving the release-triggered asset upload contract.
+If a repository needs a manual rerun path, add `workflow_dispatch` with a required `tag_name`, check out that explicit tag, and use it for release asset upload; keep a `v*` guard on the job. Do not add manual dispatch by default.
+
+If the repository does not require an Actions runtime compatibility environment variable, omit `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`. If the bundle files or smoke script use different names, adapt only those paths and commands while preserving the tag-push asset upload contract.
 
 Do not treat Release asset upload as a substitute for local bundle verification. The local build and smoke contract should remain valid without GitHub Actions.
+
+For new Node main application scaffolding that needs a release asset workflow, use the starter template at `assets/node-main-app/.github/workflows/release-cli-bundle.yml` and adapt its product name, bundle paths, and script names to the target repository.
 
 ## Checklist
 

--- a/skills/igapyon-miku-soft-developer/references/architecture-rules.md
+++ b/skills/igapyon-miku-soft-developer/references/architecture-rules.md
@@ -11,7 +11,7 @@ Do not create or rely on a synchronization script for these documents. When a ta
 Read only the document needed for the current task:
 
 - [miku-soft-basic/miku-soft-00-overview-design-v20260427.md](miku-soft-basic/miku-soft-00-overview-design-v20260427.md): overall miku-soft stance and product-type overview
-- [miku-soft-basic/miku-soft-10-mainapp-design-v20260506.md](miku-soft-basic/miku-soft-10-mainapp-design-v20260506.md): main application, Web UI, CLI, local-first behavior, diagnostics, and shared conventions
+- [miku-soft-basic/miku-soft-10-mainapp-design-v20260507.md](miku-soft-basic/miku-soft-10-mainapp-design-v20260507.md): main application, Web UI, CLI, local-first behavior, diagnostics, and shared conventions
 - [miku-soft-basic/miku-soft-20-javaapp-design-v20260506.md](miku-soft-basic/miku-soft-20-javaapp-design-v20260506.md): Java CLI, Maven, Java runtime boundary, packaging, and Java-side maintenance
 - [miku-soft-basic/miku-soft-30-straight-conversion-v20260506.md](miku-soft-basic/miku-soft-30-straight-conversion-v20260506.md): Node.js / TypeScript to Java straight conversion
 - [miku-soft-basic/miku-soft-40-agentskills-design-v20260506.md](miku-soft-basic/miku-soft-40-agentskills-design-v20260506.md): Agent Skills versions and agent-facing local workflow packages

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-10-mainapp-design-v20260507.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-10-mainapp-design-v20260507.md
@@ -1,4 +1,4 @@
-# Miku Software Main Application Design v20260506
+# Miku Software Main Application Design v20260507
 
 This memo organizes design characteristics commonly seen across the software series whose names start with `miku`.
 
@@ -369,14 +369,19 @@ This release path is a distribution layer over the local build contract. It shou
 
 Recommended release asset behavior is as follows.
 
-- Trigger release-asset attachment from published GitHub Releases and, when useful, manual dispatch with an explicit tag.
-- Restrict release bundle upload to version tags such as `v*`.
+- Trigger release-asset attachment from `push` tags matching `v*`.
+- Treat CI baseline workflows for pull requests or ordinary pushes as a separate category. Do not include them in the standard release asset workflow unless the user explicitly asks for CI baseline work.
+- Do not use GitHub Release `published` as the standard trigger. Use it only when the repository has a documented repository-specific reason.
+- Use `workflow_dispatch` with an explicit `tag_name` only when the repository needs a manual rerun path for recreating or attaching release assets.
+- If `workflow_dispatch` is used, guard the workflow so only `v*` tags proceed.
 - Check that the release tag version matches `package.json` `version`, or document any accepted dot-suffix rule.
 - Build from the release tag, not from an unrelated branch state.
-- Stage release assets with product and version in their filenames, such as `<product>-<version>.mjs` and `<product>-sources-<version>.tgz`.
-- Upload only those prepared miku-soft CLI assets as custom release assets; do not add broad repository source archives as extra uploaded assets.
-- Run the bundle smoke test before uploading release assets.
+- Keep build and smoke reproducible through local `npm scripts` or `scripts/*.mjs`; release asset staging may be in the workflow template when it only copies local build outputs into versioned GitHub Release asset names.
+- Run build, smoke, release asset staging, and upload in that order.
+- Stage release assets into `release-assets/` with product and version in their filenames, such as `<product>-<version>.mjs` and `<product>-sources-<version>.tgz`.
+- Upload only `release-assets/*` as custom release assets; do not add broad repository source archives as extra uploaded assets.
 - Keep GitHub Actions runtime compatibility settings local to the workflow and do not let them change the product runtime contract.
+- Keep GitHub repository creation, tag push, release publication, secret configuration, and registry publication as human-owned operations unless separately requested.
 
 ### `workplace/` Directory Principles
 

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-40-agentskills-design-v20260506.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-40-agentskills-design-v20260506.md
@@ -29,7 +29,7 @@ This document is not a detailed specification for one skill repository. Reposito
 
 Use the shared design documents together as follows.
 
-- `docs/miku-soft-10-mainapp-design-v20260506.md`
+- `docs/miku-soft-10-mainapp-design-v20260507.md`
   - describes the upstream product design and semantic center
 - `docs/miku-soft-20-javaapp-design-v20260506.md`
   - describes Java runtime versions when they exist

--- a/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-50-mcp-design-v20260506.md
+++ b/skills/igapyon-miku-soft-developer/references/miku-soft-basic/miku-soft-50-mcp-design-v20260506.md
@@ -39,7 +39,7 @@ This document is not a detailed specification for one MCP repository. Repository
 
 Use the shared design documents together as follows.
 
-- `docs/miku-soft-10-mainapp-design-v20260506.md`
+- `docs/miku-soft-10-mainapp-design-v20260507.md`
   - describes the upstream product design and semantic center
 - `docs/miku-soft-40-agentskills-design-v20260506.md`
   - describes how Agent Skills versions expose miku workflows to AI agents

--- a/skills/igapyon-miku-soft-developer/references/review/release-automation.md
+++ b/skills/igapyon-miku-soft-developer/references/review/release-automation.md
@@ -61,9 +61,15 @@ Check these points:
 
 Check these points:
 
-- release asset workflows trigger on GitHub Release publication or an explicit
-  `workflow_dispatch` tag input when that is the intended operation
+- Node.js / TypeScript main application release asset workflows normally
+  trigger on `push` tags matching `v*`
+- GitHub Release `published` is not the standard trigger for Node main app
+  release assets; require a repository-specific reason when it is used
+- `workflow_dispatch` is optional for Node main app release assets; when used,
+  it requires an explicit `tag_name` input and only proceeds for `v*` tags
 - CI baseline workflows are not confused with release asset workflows
+- pull-request and ordinary-push CI baseline workflows are not created as part
+  of release asset automation unless explicitly requested
 - publish workflows, such as `npm publish`, are separate from release asset
   attachment unless the repository intentionally combines them
 - workflow permissions are scoped to the needed operation
@@ -77,6 +83,10 @@ Check these points:
 
 - release workflow runs the repository's documented build command
 - tests or focused smoke checks run before assets are staged
+- Node main app release workflows delegate build and smoke to local `npm scripts`
+  or `scripts/*.mjs`; version checks and release asset staging may stay in the
+  workflow when they only adapt local build outputs into versioned release asset
+  names
 - CLI runtime assets are smoke-tested with at least `--version` and `--help`
 - Java runtime assets are smoke-tested with equivalent metadata commands when
   available
@@ -152,7 +162,7 @@ When this review applies, include a short classification before findings:
 Release Automation Review
 
 Release shape: GitHub Release asset / npm package / Java distribution / skill bundle / MCP package
-Trigger: release published / workflow_dispatch / tag push / manual local
+Trigger: tag push / release published / workflow_dispatch / manual local
 Version source: package.json / pom.xml / skill metadata / tag
 Artifacts: Web App / CLI runtime / jar / source archive / skill zip / docs
 Smoke checks: present / missing / partial


### PR DESCRIPTION
## 概要

`igapyon-miku-soft-developer` の Node.js / TypeScript main application 向け release asset workflow 方針を更新し、main application design document を `v20260507` として改版しました。

## 変更内容

- Node main app 用の starter workflow template を追加
  - `push` tags `v*` で起動
  - `npm ci`、`npm run build`、`npm run smoke:bundle` を実行
  - `package.json` version と release tag version を照合
  - `release-assets/*` に CLI bundle と source archive を配置して GitHub Release に upload
- `10-node-app-workflow.md` の release asset workflow 方針を更新
  - CI baseline と release asset workflow を分離
  - Node main app の標準 release trigger を `v*` tag push として整理
  - `workflow_dispatch` は必要な場合のみの optional manual rerun path として明記
  - GitHub Release `published` trigger は標準外として整理
- main application design document を `miku-soft-10-mainapp-design-v20260507.md` に改版
- `architecture-rules.md`、Agent Skills / MCP design document 内の main app design 参照を `v20260507` に更新
- release automation review note に Node main app release workflow の review 観点を追加
- `index.json` を更新し、改版後の design document と参照サイズを反映