### PR TITLE
みくくグラレコ生成ワークフローを描画プロンプト埋め込み方式へ更新

### DIFF
--- a/skills/igapyon-mikuku-agent/SKILL.md
+++ b/skills/igapyon-mikuku-agent/SKILL.md
@@ -39,6 +39,8 @@ Use examples under [references/examples/articles/](references/examples/articles/
 
 When creating graphic recording material, a graphic-recording text draft, or an image-generation prompt for a `みくく` article explainer, read and apply [references/graphic-recording.md](references/graphic-recording.md).
 
+After this skill is already active, if the user mentions `グラレコ` or `graphic recording`, read and apply [references/graphic-recording.md](references/graphic-recording.md) before answering or starting related work. Do not rely on memory of that workflow; load the file in the current turn and follow its execution gate.
+
 ## Visual Assets
 
 When the user asks for a `みくく` or `Mikuku` image, avatar, card image, visual reference, article portrait, or character visual, use image files from [assets/mikuku/](assets/mikuku/). Do not generate a new character image or choose an unrelated external image when an existing `assets/mikuku/` image fits the request.

--- a/skills/igapyon-mikuku-agent/assets/mikuku/mikuku-portrait-short-prompt.md
+++ b/skills/igapyon-mikuku-agent/assets/mikuku/mikuku-portrait-short-prompt.md
@@ -1,0 +1,9 @@
+# Mikuku Portrait Short Prompt
+
+masterpiece, best quality, ultra-detailed anime portrait, head-and-shoulders 1girl, shy uneasy expression, slight 3/4 view, looking to her right and slightly upward.
+
+Warm chestnut-brown eyes with gold flecks, soft blush, worried upward-slanted brows, small downturned pout, fair warm skin, delicate V-U shaped chin.
+
+Soft caramel-chestnut very long twin-tails tied high with black ribbons and deep-red trim, silky wavy hair, asymmetrical curtain bangs, long side strands framing cheeks.
+
+Thin clean line art, soft cel shading, watercolor-like shading, subtle rim light, warm minimal background.

--- a/skills/igapyon-mikuku-agent/index.json
+++ b/skills/igapyon-mikuku-agent/index.json
@@ -3,6 +3,7 @@
  "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
  "basePath": ".",
  "files": [
+  {"name":"mikuku-portrait-short-prompt.md","path":"assets/mikuku/mikuku-portrait-short-prompt.md","ext":"md","dir":"assets/mikuku","size":628,"summary":"Mikuku Portrait Short Prompt"},
   {"name":"article-writing.md","path":"references/article-writing.md","ext":"md","dir":"references","size":12742,"summary":"みくく担当記事の執筆参照"},
   {"name":"20260509-general-agent-skills-activation.md","path":"references/examples/articles/20260509-general-agent-skills-activation.md","ext":"md","dir":"references/examples/articles","size":14785,"summary":"Agent Skills の発火は、どのように起きているのか"},
   {"name":"20260509-general-agent-skills-docs.md","path":"references/examples/articles/20260509-general-agent-skills-docs.md","ext":"md","dir":"references/examples/articles","size":14543,"summary":"Agent Skills では、説明ページの役割が少し変わる"},
@@ -15,15 +16,15 @@
   {"name":"20260516-general-markdown-gfm-introduction.md","path":"references/examples/articles/20260516-general-markdown-gfm-introduction.md","ext":"md","dir":"references/examples/articles","size":26990,"summary":"Markdown 入門は、まず GitHub 風 Markdown から始めたい"},
   {"name":"20260523-general-content-agent-skill-types.md","path":"references/examples/articles/20260523-general-content-agent-skill-types.md","ext":"md","dir":"references/examples/articles","size":32399,"title":"コンテンツ型 Agent Skill にはどんな種類があるか","summary":"はじめに"},
   {"name":"10-article-to-graphic-recording-text-prompt.md","path":"references/graphic-recording/10-article-to-graphic-recording-text-prompt.md","ext":"md","dir":"references/graphic-recording","size":4925,"summary":"グラレコテキスト生成プロンプト"},
-  {"name":"20-graphic-recording-explainer-image-prompt.md","path":"references/graphic-recording/20-graphic-recording-explainer-image-prompt.md","ext":"md","dir":"references/graphic-recording","size":5810,"summary":"グラレコ説明画像 生成AIプロンプト"},
-  {"name":"30-generate-graphic-recording-image-prompt.md","path":"references/graphic-recording/30-generate-graphic-recording-image-prompt.md","ext":"md","dir":"references/graphic-recording","size":4420,"summary":"グラレコ説明画像 生成実行プロンプト"},
-  {"name":"40-article-section-graphic-recording-batch-prompt.md","path":"references/graphic-recording/40-article-section-graphic-recording-batch-prompt.md","ext":"md","dir":"references/graphic-recording","size":10135,"summary":"見出し単位グラレコ画像 バッチ生成プロンプト"},
-  {"name":"50-generate-section-graphic-recording-images-prompt.md","path":"references/graphic-recording/50-generate-section-graphic-recording-images-prompt.md","ext":"md","dir":"references/graphic-recording","size":12817,"summary":"見出し単位グラレコ画像 生成実行プロンプト"},
-  {"name":"60-inspect-section-graphic-recording-images-prompt.md","path":"references/graphic-recording/60-inspect-section-graphic-recording-images-prompt.md","ext":"md","dir":"references/graphic-recording","size":3416,"summary":"見出し単位グラレコ画像 検品プロンプト"},
-  {"name":"graphic-recording.md","path":"references/graphic-recording.md","ext":"md","dir":"references","size":9692,"summary":"みくく担当グラレコ生成参照"},
+  {"name":"20-graphic-recording-explainer-image-prompt.md","path":"references/graphic-recording/20-graphic-recording-explainer-image-prompt.md","ext":"md","dir":"references/graphic-recording","size":6882,"summary":"グラレコ説明画像 生成AIプロンプト"},
+  {"name":"30-generate-graphic-recording-image-prompt.md","path":"references/graphic-recording/30-generate-graphic-recording-image-prompt.md","ext":"md","dir":"references/graphic-recording","size":6131,"summary":"グラレコ説明画像 生成実行プロンプト"},
+  {"name":"40-article-section-graphic-recording-batch-prompt.md","path":"references/graphic-recording/40-article-section-graphic-recording-batch-prompt.md","ext":"md","dir":"references/graphic-recording","size":10362,"summary":"見出し単位グラレコ画像 バッチ生成プロンプト"},
+  {"name":"50-generate-section-graphic-recording-images-prompt.md","path":"references/graphic-recording/50-generate-section-graphic-recording-images-prompt.md","ext":"md","dir":"references/graphic-recording","size":13139,"summary":"見出し単位グラレコ画像 生成実行プロンプト"},
+  {"name":"60-inspect-section-graphic-recording-images-prompt.md","path":"references/graphic-recording/60-inspect-section-graphic-recording-images-prompt.md","ext":"md","dir":"references/graphic-recording","size":3867,"summary":"見出し単位グラレコ画像 検品プロンプト"},
+  {"name":"graphic-recording.md","path":"references/graphic-recording.md","ext":"md","dir":"references","size":17462,"summary":"みくく担当グラレコ生成参照"},
   {"name":"mikuku-prompt.md","path":"references/mikuku-prompt.md","ext":"md","dir":"references","size":4292,"summary":"生成AI キャラクター `みくく` プロンプト (v20251229c改1)"},
   {"name":"article-footer-sections-template.md","path":"references/templates/article-footer-sections-template.md","ext":"md","dir":"references/templates","size":3416,"summary":"みくく担当記事の末尾セクションテンプレート"},
   {"name":"VERSION.md","path":"references/VERSION.md","ext":"md","dir":"references","size":934,"summary":"みくく Version"},
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":4314,"description":"Use only when the user explicitly asks Codex to speak or collaborate as the Japanese character agent \"みくく\", mentions みくく, Mikuku, igapyon-mikuku, or explicitly asks to apply the みくく prompt. If the user only asks whether such a character skill exists, mention this skill as an available option but do not apply it until asked.","summary":"igapyon-mikuku-agent"}
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":4641,"description":"Use only when the user explicitly asks Codex to speak or collaborate as the Japanese character agent \"みくく\", mentions みくく, Mikuku, igapyon-mikuku, or explicitly asks to apply the みくく prompt. If the user only asks whether such a character skill exists, mention this skill as an available option but do not apply it until asked.","summary":"igapyon-mikuku-agent"}
  ]
 }

--- a/skills/igapyon-mikuku-agent/references/graphic-recording.md
+++ b/skills/igapyon-mikuku-agent/references/graphic-recording.md
@@ -10,13 +10,16 @@
 
 入力された記事パスをもとに、次の順序で処理します。
 
-1. 記事 Markdown を読む
-2. 実行単位の出力ディレクトリを作る
-3. グラレコ制作用整理テキストを作る
-4. みくく画像を選ぶ
-5. 画像生成AI用プロンプトを作る
-6. 画像生成AI用プロンプトとみくく画像を使って画像生成を実行する
-7. 生成物を Git 管理外の作業場所へ保存する
+1. このワークフロー文書を現在のターンで読む
+2. 記事 Markdown を読む
+3. 実行単位の出力ディレクトリを作る
+4. みくく描画プロンプトファイルを読み込む
+5. 画像生成ツールがテキストプロンプト生成に対応していることを確認する
+6. 実行状態ファイル `run-state.md` を作る
+7. グラレコ制作用整理テキストを作る
+8. 画像生成AI用プロンプトを作る
+9. みくく描画プロンプト本文を含む画像生成AI用プロンプトで画像生成を実行する、または未実行理由を記録する
+10. 生成物を Git 管理外の作業場所へ保存する
 
 ## 使用するプロンプト
 
@@ -69,33 +72,140 @@
 /Users/igapyon/Documents/git/igapyon-agent-skills/workplace/20260524095030-graphic-recording/
 ```
 
-主な生成物は次の 3 つです。
+主な生成物は次の 4 つです。
 
 - `graphic-recording-text.md`: グラレコ制作用整理テキスト
 - `image-prompt.md`: 画像生成AI用プロンプト
+- `copy-generated-image.md`: 生成画像を作業ディレクトリへコピーするための記録と手順
 - `graphic-recording.png`: グラレコ説明画像
 
 保存先は原則として同じ `{{RUN_OUTPUT_DIR}}` 配下に揃えます。`workplace/` を使う場合は、その場所が Git 管理外であることを確認できた場合だけ保存してください。
 
 Git 管理外の保存先を確認できない場合は、勝手にリポジトリ内へ保存せず、本文出力にフォールバックします。
 
-## みくく画像
+## 実行ゲート
 
-グラレコ説明画像の参照画像には、次の候補から 1 つを使います。
+グラレコ作業では、実際に読んだ入力と処理状態を固定してから次へ進んでください。
 
-- `/Users/igapyon/Documents/git/igapyon-agent-skills/skills/igapyon-mikuku-agent/assets/mikuku/mikuku01.png`
-- `/Users/igapyon/Documents/git/igapyon-agent-skills/skills/igapyon-mikuku-agent/assets/mikuku/mikuku02.png`
-- `/Users/igapyon/Documents/git/igapyon-agent-skills/skills/igapyon-mikuku-agent/assets/mikuku/mikuku03.png`
+次のどれかを満たしていない場合は、整理テキスト作成、画像プロンプト作成、画像生成へ進まないでください。
 
-通常は、候補からランダムに 1 つ選びます。
+- 現在のターンで、この `graphic-recording.md` を読んだ
+- 対象記事 Markdown を読んだ
+- 記事全体 1 枚か、`##` 見出しごとの複数枚かを決めた
+- 使用する個別プロンプトを読んだ
+- `{{RUN_OUTPUT_DIR}}` を決めた
+- `{{RUN_OUTPUT_DIR}}` が Git 管理外であることを確認した、または保存せず本文出力へフォールバックすると決めた
+- 使用する `{{MIKUKU_PROMPT_PATH}}` を決め、実在を確認し、本文を読んだ
+- 画像生成ツールがテキストプロンプト生成に対応していることを確認した
 
-選んだ画像パスを、[graphic-recording/20-graphic-recording-explainer-image-prompt.md](graphic-recording/20-graphic-recording-explainer-image-prompt.md) の `{{MIKUKU_IMAGE_PATH}}` として扱います。
+`{{RUN_OUTPUT_DIR}}` と `{{MIKUKU_PROMPT_PATH}}` を決め、みくく描画プロンプト本文を読み、画像生成ツール仕様を確認したら、整理テキスト作成へ進む前に次の状態ファイルを作成してください。
 
-ランダム選択の実行が難しい環境では、候補一覧の中から任意に 1 つ選んでください。
+```text
+{{RUN_OUTPUT_DIR}}/run-state.md
+```
 
-`assets/mikuku/mikuku-mini01.png` は、このグラレコ説明画像の既定候補には含めません。
+`run-state.md` には、少なくとも次を記録してください。
+
+```markdown
+# Graphic Recording Run State
+
+- workflow-read: yes
+- article-read: yes
+- mode: whole-article | sections
+- run-output-dir:
+- workplace-gitignored: yes | no
+- prompts-read:
+  - 10-article-to-graphic-recording-text-prompt.md
+  - 20-graphic-recording-explainer-image-prompt.md
+  - 30-generate-graphic-recording-image-prompt.md
+- article-path:
+- mikuku-prompt:
+- mikuku-prompt-exists: yes | no
+- mikuku-prompt-read: yes | no
+- image-tool:
+- text-prompt-generation: available | unavailable
+- character-prompt-embedded: yes | no
+- copy-instruction-created: yes | no
+- generated-source-path:
+- workspace-output-path:
+- current-status:
+```
+
+以降の各段階が終わるたびに、`current-status` と関連項目を更新してください。
+
+状態ファイルを保存できない場合は、同等の内容を本文で短く示してから処理を続けてください。
+
+## みくく描画プロンプト
+
+グラレコ説明画像のキャラクター描画には、次のテキストプロンプトを使います。
+
+- `/Users/igapyon/Documents/git/igapyon-agent-skills/skills/igapyon-mikuku-agent/assets/mikuku/mikuku-portrait-short-prompt.md`
+
+このファイルを `{{MIKUKU_PROMPT_PATH}}` として扱います。
+
+画像生成AI用プロンプトを作るときは、このファイルの本文を読み、最終プロンプトへそのまま、または意味を保ったまま埋め込んでください。パスだけを書いて済ませないでください。
+
+## みくく同一性の維持
+
+グラレコ画像では、`{{MIKUKU_PROMPT_PATH}}` の本文を、同一キャラクター `Mikuku` / `みくく` の正本描画プロンプトとして扱ってください。
+
+新しい画像を生成するときも、キャラクターを再設計しないでください。変更してよいのは、場面、ポーズ、表情、構図、持ち物、説明している内容だけです。
+
+グラレコ描画では、記事内容や説明対象の配置に合わせて、生成前に顔の向きや視線方向を変更してよいです。たとえば、右側に配置したみくくが左側の図解を見る、中央の見出しを見上げる、吹き出し側へ視線を向ける、などは許容します。ただし、顔の輪郭、目の描き方、髪型、髪色、ツインテール、髪留めの印象は維持してください。
+
+維持する要素:
+
+- 顔の輪郭
+- 髪型
+- 髪色
+- ツインテールと髪留めの印象
+- 目の描き方
+- 全体の性格印象
+- 日本のアニメ調技術解説イラストの雰囲気
+- やわらかく明るい光
+- Note.com や技術記事に合う清潔なビジュアルブランド
+
+画像生成AI用プロンプトには、`{{MIKUKU_PROMPT_PATH}}` の本文に加えて、`same character`, `do not redesign`, `preserve character identity`, `canonical character prompt` に相当する指示を含めてください。
+
+髪留め、髪型、顔つきなどの細部が変わった場合は、同一性が崩れた生成として扱い、正式なグラレコ成果物ではなく再生成候補または下書きとして扱ってください。
+
+## 描画プロンプト本文の扱い
+
+画像生成時は、`{{MIKUKU_PROMPT_PATH}}` のパスだけでなく、そのファイル本文を画像生成AI用プロンプトへ埋め込んでください。
+
+次の場合は、描画プロンプト本文を使えていると扱えます。
+
+- `{{MIKUKU_PROMPT_PATH}}` の本文を読んだ
+- 画像生成AI用プロンプトに、みくく描画プロンプト本文または意味を保った短縮本文を含めた
+- 画像生成ツールへ、その統合済みテキストプロンプトを渡せる
+
+次の場合は、描画プロンプト本文を使えていると扱わないでください。
+
+- `{{MIKUKU_PROMPT_PATH}}` のパスだけを書いた
+- 以前の会話や別実行で使った描画プロンプトが暗黙に引き継がれることを期待した
+- みくく描画プロンプト本文を読まず、一般的な「アニメ少女」説明だけで生成した
+
+みくく描画プロンプト本文を読めない場合は、通常の画像生成を実行せず、画像生成AI用プロンプトのパス、みくく描画プロンプトのパス、推奨する画像出力パス、未実行理由を報告してください。
 
 ## 実施手順
+
+### 0. ワークフローを読む
+
+この作業を開始するたびに、まずこの `graphic-recording.md` を現在のターンで読み込んでください。
+
+過去の会話で読んだ記憶だけで処理を始めないでください。
+
+記事全体 1 枚で作る場合は、少なくとも次を読む必要があります。
+
+- [graphic-recording/10-article-to-graphic-recording-text-prompt.md](graphic-recording/10-article-to-graphic-recording-text-prompt.md)
+- [graphic-recording/20-graphic-recording-explainer-image-prompt.md](graphic-recording/20-graphic-recording-explainer-image-prompt.md)
+- [graphic-recording/30-generate-graphic-recording-image-prompt.md](graphic-recording/30-generate-graphic-recording-image-prompt.md)
+
+`##` 見出しごとの複数枚で作る場合は、少なくとも次を読む必要があります。
+
+- [graphic-recording/40-article-section-graphic-recording-batch-prompt.md](graphic-recording/40-article-section-graphic-recording-batch-prompt.md)
+- [graphic-recording/50-generate-section-graphic-recording-images-prompt.md](graphic-recording/50-generate-section-graphic-recording-images-prompt.md)
+- [graphic-recording/60-inspect-section-graphic-recording-images-prompt.md](graphic-recording/60-inspect-section-graphic-recording-images-prompt.md)
 
 ### 1. 記事を読む
 
@@ -121,7 +231,37 @@ workplace/<YYYYMMDDHHmmss>-graphic-recording/
 
 以降の生成物は、原則としてこのディレクトリに保存してください。
 
-### 3. グラレコ制作用テキストを作る
+`{{RUN_OUTPUT_DIR}}` を作成したら、次にみくく描画プロンプトファイルを読み、画像生成ツール仕様を確認してください。その後、上記の「実行ゲート」に従って `run-state.md` を作成してください。
+
+### 3. みくく描画プロンプトを読む
+
+上記の「みくく描画プロンプト」のパスを `{{MIKUKU_PROMPT_PATH}}` として扱ってください。
+
+`{{MIKUKU_PROMPT_PATH}}` が実在することを確認し、本文を読み込んでください。
+
+### 4. 画像生成ツール仕様を確認する
+
+画像生成ツールが、統合済みのテキストプロンプトを受け取れるか確認してください。
+
+確認結果は `run-state.md` の `image-tool` と `text-prompt-generation` に記録します。
+
+みくく描画プロンプト本文を読めない場合でも、グラレコ制作用整理テキストは作成してよいです。ただし、画像生成AI用プロンプトと画像生成へは進まず、未実行理由を記録してください。
+
+### 5. 実行状態を確認する
+
+整理テキストを作る前に、`run-state.md` または本文の状態メモで次を確認してください。
+
+- `workflow-read: yes`
+- `article-read: yes`
+- `mode` が決まっている
+- 使用する個別プロンプトを読んでいる
+- `mikuku-prompt-exists: yes`
+- `mikuku-prompt-read: yes`
+- `text-prompt-generation` が `available` または `unavailable` として記録されている
+
+未確認の項目がある場合は、処理を進めず、該当ファイルを読んで状態を更新してください。
+
+### 6. グラレコ制作用テキストを作る
 
 まず、[graphic-recording/10-article-to-graphic-recording-text-prompt.md](graphic-recording/10-article-to-graphic-recording-text-prompt.md) の方針に従って、記事本文をグラレコ制作用の整理テキストへ変換してください。
 
@@ -147,15 +287,9 @@ workplace/<YYYYMMDDHHmmss>-graphic-recording/
 
 保存したファイルのパスを、次の手順の `{{GRAPHIC_RECORDING_TEXT_PATH}}` として扱ってください。
 
-### 4. みくく画像を選ぶ
+### 7. 画像生成用プロンプトを作る
 
-上記の「みくく画像」の候補から、今回使うみくく画像をランダムに 1 つ選んでください。
-
-選んだ画像パスを、次の手順の `{{MIKUKU_IMAGE_PATH}}` として扱ってください。
-
-### 5. 画像生成用プロンプトを作る
-
-次に、手順 3 で保存したグラレコ制作用テキストのファイルパスと、手順 4 で選んだみくく画像のファイルパスを入力として、[graphic-recording/20-graphic-recording-explainer-image-prompt.md](graphic-recording/20-graphic-recording-explainer-image-prompt.md) の方針に従い、画像生成AIへ渡すための最終プロンプトを作成してください。
+次に、手順 6 で保存したグラレコ制作用テキストのファイルパスと、手順 3 で選んだみくく描画プロンプトのファイルパスを入力として、[graphic-recording/20-graphic-recording-explainer-image-prompt.md](graphic-recording/20-graphic-recording-explainer-image-prompt.md) の方針に従い、画像生成AIへ渡すための最終プロンプトを作成してください。
 
 作成した画像生成AI用プロンプトは、次のパスへ Markdown ファイルとして保存してください。
 
@@ -168,7 +302,7 @@ workplace/<YYYYMMDDHHmmss>-graphic-recording/
 最終プロンプトには、以下を含めてください。
 
 - みくくが説明している構図
-- 参照画像として使うみくく画像のパス
+- みくく描画プロンプト本文
 - 横長ポスター構図
 - 手描きグラレコ風
 - ホワイトボード解説風
@@ -178,11 +312,11 @@ workplace/<YYYYMMDDHHmmss>-graphic-recording/
 - 対比や循環構造
 - 避けたい表現
 
-### 6. 画像生成を実行する
+### 8. 画像生成を実行する
 
-次に、手順 5 で保存した画像生成AI用プロンプトのファイルパスと、手順 4 で選んだみくく画像のファイルパスを入力として、[graphic-recording/30-generate-graphic-recording-image-prompt.md](graphic-recording/30-generate-graphic-recording-image-prompt.md) の方針に従い、グラレコ説明画像を生成してください。
+次に、手順 7 で保存した画像生成AI用プロンプトのファイルパスと、手順 3 で選んだみくく描画プロンプトのファイルパスを入力として、[graphic-recording/30-generate-graphic-recording-image-prompt.md](graphic-recording/30-generate-graphic-recording-image-prompt.md) の方針に従い、グラレコ説明画像を生成してください。
 
-画像生成ツールが利用可能な環境では、画像生成AI用プロンプト本文と `{{MIKUKU_IMAGE_PATH}}` の参照画像を渡して画像生成まで実行します。
+画像生成ツールが利用可能で、かつ統合済みのテキストプロンプトを渡せる環境では、画像生成AI用プロンプト本文を渡して画像生成まで実行します。
 
 生成した画像は、次のパスへ画像ファイルとして保存してください。
 
@@ -190,14 +324,14 @@ workplace/<YYYYMMDDHHmmss>-graphic-recording/
 {{RUN_OUTPUT_DIR}}/graphic-recording.png
 ```
 
-画像生成ツールが使えない環境では、画像生成は実行せず、画像生成AI用プロンプトのパス、みくく画像のパス、推奨する画像出力パスを報告してください。
+画像生成ツールが使えない環境、または画像生成ツールがテキストプロンプトを受け取れない環境では、画像生成は実行せず、画像生成AI用プロンプトのパス、みくく描画プロンプトのパス、推奨する画像出力パス、未実行理由を報告してください。
 
 ## 最終報告
 
 処理後、保存したファイルのパスを短く報告してください。
 
 - グラレコ制作用整理テキスト
-- 選択したみくく画像
+- 選択したみくく描画プロンプト
 - 画像生成AI用プロンプト
 - グラレコ説明画像、または画像生成ツールへ渡すための入力情報
 - 実行単位の出力ディレクトリ
@@ -209,5 +343,5 @@ Git 管理外の保存先を確認できない場合は、ファイル保存せ�
 - グラレコ生成は、記事執筆そのものとは別の後工程として扱います。
 - 記事の文体調整が必要な場合は、先に [article-writing.md](article-writing.md) を参照します。
 - グラレコ向け整理では、要約だけでなく、構造、対比、役割分担、流れ、循環を抽出します。
-- 画像生成AI用プロンプトでは、みくく画像パスを参照画像として明示します。
+- 画像生成AI用プロンプトでは、みくく描画プロンプトパスを描画プロンプトとして明示します。
 - `index.json` は生成物です。更新が必要な場合は手編集せず、`miku-indexgen` で再生成します。

--- a/skills/igapyon-mikuku-agent/references/graphic-recording/20-graphic-recording-explainer-image-prompt.md
+++ b/skills/igapyon-mikuku-agent/references/graphic-recording/20-graphic-recording-explainer-image-prompt.md
@@ -1,7 +1,7 @@
 # グラレコ説明画像 生成AIプロンプト
 
 次の入力パスで指定されたグラレコ制作用テキストを読み、
-指定された「みくく」画像のパスを参照画像として使い、技術記事の内容をグラフィックレコーディング（グラレコ）風にまとめた大きな説明ポスター画像の生成AIプロンプトを作成してください。
+指定された「みくく」描画プロンプトファイルを読み、技術記事の内容をグラフィックレコーディング（グラレコ）風にまとめた大きな説明ポスター画像の生成AIプロンプトを作成してください。
 
 作成した画像生成AI用プロンプトは、指定された出力パスへ Markdown ファイルとして保存してください。
 
@@ -15,13 +15,14 @@
 {{GRAPHIC_RECORDING_TEXT_PATH}}
 ```
 
-みくく画像のパス:
+みくく描画プロンプトのパス:
 
 ```text
-{{MIKUKU_IMAGE_PATH}}
+{{MIKUKU_PROMPT_PATH}}
 ```
 
-`{{MIKUKU_IMAGE_PATH}}` の画像を、キャラクター外観の参照画像として扱ってください。
+`{{MIKUKU_PROMPT_PATH}}` の Markdown 本文を読み、キャラクター外観の正本描画プロンプトとして扱ってください。
+画像生成AI用プロンプトには、このパスだけでなく、描画プロンプト本文そのものを含めてください。
 
 ---
 
@@ -99,7 +100,16 @@ git check-ignore -q workplace/<YYYYMMDDHHmmss>-graphic-recording/image-prompt.md
 
 ## キャラクター
 
-* `{{MIKUKU_IMAGE_PATH}}` のみくく画像をベースにする
+* `{{MIKUKU_PROMPT_PATH}}` の本文をベースにする
+* 画像生成AI用プロンプト内に `{{MIKUKU_PROMPT_PATH}}` の本文を含める
+* パスだけを書いて済ませない
+* 同じキャラクター `Mikuku` / `みくく` として扱う
+* キャラクターを再設計しない
+* 顔の輪郭、髪型、髪色、目の描き方、ツインテール、髪留め、全体の性格印象を維持する
+* 変更してよいのは、場面、ポーズ、表情、構図、持ち物、説明している内容だけ
+* 顔の向きと視線方向は、記事内容やグラレコ内の説明対象に合わせて生成前に変更してよい
+* 例: 右側のみくくが左側の図解を見る、中央の見出しを見上げる、吹き出し側へ視線を向ける
+* `same character`, `do not redesign`, `preserve character identity`, `canonical character reference` の意図を明確に含める
 * ツインテール
 * やわらかい茶髪
 * 少し困り顔
@@ -208,8 +218,8 @@ git check-ignore -q workplace/<YYYYMMDDHHmmss>-graphic-recording/image-prompt.md
 # 実施手順
 
 1. `{{GRAPHIC_RECORDING_TEXT_PATH}}` の Markdown ファイルを読む
-2. `{{MIKUKU_IMAGE_PATH}}` の画像をキャラクター参照画像として扱う
-3. その内容をもとに、画像生成AIへ渡せる最終プロンプトを作成する
+2. `{{MIKUKU_PROMPT_PATH}}` の Markdown ファイルを読む
+3. グラレコ制作用テキストとみくく描画プロンプト本文をもとに、画像生成AIへ渡せる最終プロンプトを作成する
 4. `{{OUTPUT_PATH}}` が指定されている場合はそこへ保存する
 5. `{{OUTPUT_PATH}}` が未指定で `{{RUN_OUTPUT_DIR}}` が指定されている場合は、`{{RUN_OUTPUT_DIR}}/image-prompt.md` へ保存する
 6. どちらも未指定の場合は、Git 管理外であることを確認できた `workplace/<YYYYMMDDHHmmss>-graphic-recording/` 配下へ保存する

--- a/skills/igapyon-mikuku-agent/references/graphic-recording/30-generate-graphic-recording-image-prompt.md
+++ b/skills/igapyon-mikuku-agent/references/graphic-recording/30-generate-graphic-recording-image-prompt.md
@@ -1,6 +1,8 @@
 # グラレコ説明画像 生成実行プロンプト
 
-次の画像生成AI用プロンプトと、みくく参照画像を使って、グラフィックレコーディング（グラレコ）風の説明画像を生成してください。
+次の画像生成AI用プロンプトを使って、グラフィックレコーディング（グラレコ）風の説明画像を生成してください。
+
+画像生成AI用プロンプトには、すでにみくく描画プロンプト本文が含まれている前提です。
 
 ---
 
@@ -12,10 +14,10 @@
 {{IMAGE_PROMPT_PATH}}
 ```
 
-みくく画像のパス:
+みくく描画プロンプトのパス:
 
 ```text
-{{MIKUKU_IMAGE_PATH}}
+{{MIKUKU_PROMPT_PATH}}
 ```
 
 ---
@@ -38,6 +40,12 @@
 
 ```text
 {{RUN_OUTPUT_DIR}}/graphic-recording.png
+```
+
+コピー手順記録パス:
+
+```text
+{{RUN_OUTPUT_DIR}}/copy-generated-image.md
 ```
 
 `{{IMAGE_OUTPUT_PATH}}` と `{{RUN_OUTPUT_DIR}}` がどちらも未指定の場合は、次の順序で保存先を決めてください。
@@ -77,42 +85,106 @@ git check-ignore -q workplace/<YYYYMMDDHHmmss>-graphic-recording/graphic-recordi
 # 実施内容
 
 1. `{{IMAGE_PROMPT_PATH}}` の Markdown ファイルを読む
-2. `{{MIKUKU_IMAGE_PATH}}` の画像が存在することを確認する
-3. `{{MIKUKU_IMAGE_PATH}}` の画像を、この生成実行用の参照画像としてロード、添付、または指定する
-4. 画像生成AI用プロンプト本文を画像生成ツールへ渡す
-5. 参照画像として `{{MIKUKU_IMAGE_PATH}}` を添付または指定する
+2. `{{MIKUKU_PROMPT_PATH}}` の Markdown ファイルが存在することを確認する
+3. `{{IMAGE_PROMPT_PATH}}` の本文に、みくく描画プロンプト本文または意味を保った短縮本文が含まれていることを確認する
+4. 画像生成ツールがテキストプロンプトを受け取れることを確認する
+5. 画像生成AI用プロンプト本文を画像生成ツールへ渡す
 6. 横長ポスター構図のグラレコ説明画像を生成する
-7. 生成画像を `{{IMAGE_OUTPUT_PATH}}`、`{{RUN_OUTPUT_DIR}}/graphic-recording.png`、または Git 管理外であることを確認できた `workplace/<YYYYMMDDHHmmss>-graphic-recording/graphic-recording.png` へコピーまたは保存する
-8. `image-generation-report.md` に元画像パス、みくく参照画像パス、ワークスペース側の保存先を記録する
-9. 最後に、生成画像の保存先を短く報告する
+7. 生成画像の元ファイルパスを特定する
+8. `copy-generated-image.md` を作成し、元画像パス、コピー先、実行するコピーコマンド、確認コマンドを記録する
+9. 生成画像を `{{IMAGE_OUTPUT_PATH}}`、`{{RUN_OUTPUT_DIR}}/graphic-recording.png`、または Git 管理外であることを確認できた `workplace/<YYYYMMDDHHmmss>-graphic-recording/graphic-recording.png` へコピーまたは保存する
+10. コピー先の存在、ファイルサイズ、画像形式を確認し、`copy-generated-image.md` を結果付きで更新する
+11. `image-generation-report.md` に元画像パス、みくく描画プロンプトパス、コピー手順記録パス、ワークスペース側の保存先、または未実行理由を記録する
+12. 最後に、生成画像の保存先、または未生成の理由を短く報告する
 
-`{{MIKUKU_IMAGE_PATH}}` はパス文字列としてプロンプト内に書くだけでなく、画像生成ツールが対応している場合は実際の参照画像入力として渡してください。
-別の生成実行でロード済みの参照画像が今回の生成へ引き継がれるとは扱わないでください。
+`{{MIKUKU_PROMPT_PATH}}` はパス文字列としてプロンプト内に書くだけでなく、事前に本文を `{{IMAGE_PROMPT_PATH}}` へ埋め込んでください。
+別の生成実行で使った描画プロンプトが今回の生成へ暗黙に引き継がれるとは扱わないでください。
 
-組み込み `imagegen` を使う場合、生成画像は通常 `$CODEX_HOME/generated_images/...` 配下へ保存されます。プロジェクトで使う画像は、生成後に上記の出力先へコピーしてください。元画像は削除しないでください。
+組み込み `imagegen` が `prompt` しか受け取れない環境でも、`{{IMAGE_PROMPT_PATH}}` にみくく描画プロンプト本文が含まれていれば生成を実行できます。
+
+組み込み `imagegen` の生成画像は通常 `$CODEX_HOME/generated_images/...` 配下へ保存されます。プロジェクトで使う画像は、生成後に上記の出力先へコピーしてください。元画像は削除しないでください。
+
+## コピー手順記録
+
+画像生成後は、コピーを実行する前に `{{RUN_OUTPUT_DIR}}/copy-generated-image.md` を作成してください。
+
+`copy-generated-image.md` には、少なくとも次を記録してください。
+
+````markdown
+# Copy Generated Image
+
+- status: pending | copied | failed | skipped
+- generated-source-path:
+- workspace-output-path:
+- source-exists: yes | no
+- workspace-output-exists: yes | no
+- workspace-output-size:
+- workspace-output-file-type:
+
+## Copy Command
+
+```bash
+cp "<generated-source-path>" "<workspace-output-path>"
+```
+
+## Verify Commands
+
+```bash
+ls -lh "<workspace-output-path>"
+file "<workspace-output-path>"
+```
+
+## Notes
+````
+
+コピー後は `status: copied`、`workspace-output-exists: yes`、ファイルサイズ、画像形式を更新してください。
+
+生成画像の元パスを特定できない場合は、コピーを実行せず、`status: failed` または `status: skipped` として理由を `Notes` に記録してください。この場合、`graphic-recording.png` を生成済みとして報告しないでください。
+
+---
+
+# 描画プロンプト本文の判定
+
+画像生成を始める前に、現在使える画像生成ツールの入力仕様を確認してください。
+
+描画プロンプト本文を使えている例:
+
+- `{{MIKUKU_PROMPT_PATH}}` の本文を読んでいる
+- `{{IMAGE_PROMPT_PATH}}` の本文に、みくく描画プロンプト本文または意味を保った短縮本文が含まれている
+- 画像生成ツールへ `{{IMAGE_PROMPT_PATH}}` の本文を渡せる
+
+描画プロンプト本文を使えていない例:
+
+- `{{MIKUKU_PROMPT_PATH}}` のパスだけを書いている
+- みくく描画プロンプト本文を読んでいない
+- 以前の会話や別実行で使ったキャラクター指定が暗黙に引き継がれることを期待している
+
+描画プロンプト本文が `{{IMAGE_PROMPT_PATH}}` に含まれていない場合は、通常の画像生成を実行しないでください。`image-generation-report.md` に `character-prompt-embedded: no` と記録し、`graphic-recording.png` は生成済みとして報告しないでください。
 
 ---
 
 # 画像生成ツールが使える場合
 
-利用可能な画像生成ツールがある場合は、このプロンプトで画像生成まで実行してください。
+利用可能な画像生成ツールがあり、かつ `{{IMAGE_PROMPT_PATH}}` にみくく描画プロンプト本文が含まれている場合は、このプロンプトで画像生成まで実行してください。
 
 生成時は、必ず次を入力として使います。
 
-- 画像生成AI用プロンプト本文
-- みくく参照画像 `{{MIKUKU_IMAGE_PATH}}`
+- みくく描画プロンプト本文を含む画像生成AI用プロンプト本文
 
 出力先を直接指定できない画像生成ツールでも、生成後に画像ファイルを出力先へコピーできる場合は生成済みとして扱ってよいです。
+
+ただし、最終的な成功条件は、ワークスペース側の `graphic-recording.png` が存在し、0 バイトではなく、`copy-generated-image.md` と `image-generation-report.md` に元画像パスとコピー先が記録されていることです。
 
 ---
 
 # 画像生成ツールが使えない場合
 
-現在の実行環境で画像生成ツールを使えない場合は、画像生成は実行せず、次を短く報告してください。
+現在の実行環境で画像生成ツールを使えない場合、または `{{IMAGE_PROMPT_PATH}}` にみくく描画プロンプト本文が含まれていない場合は、画像生成は実行せず、次を短く報告してください。
 
 - 画像生成AI用プロンプトのパス
-- みくく参照画像のパス
+- みくく描画プロンプトのパス
 - 手動で画像生成AIへ渡す必要があること
 - 推奨する画像出力パス
+- 未実行の理由
 
 この場合も、画像が生成済みであるかのように報告しないでください。

--- a/skills/igapyon-mikuku-agent/references/graphic-recording/40-article-section-graphic-recording-batch-prompt.md
+++ b/skills/igapyon-mikuku-agent/references/graphic-recording/40-article-section-graphic-recording-batch-prompt.md
@@ -14,17 +14,17 @@
 {{ARTICLE_PATH}}
 ```
 
-みくく画像のパス:
+みくく描画プロンプトのパス:
 
 ```text
-{{MIKUKU_IMAGE_PATH}}
+{{MIKUKU_PROMPT_PATH}}
 ```
 
-`{{MIKUKU_IMAGE_PATH}}` が未指定の場合は、次の候補から 1 つ選び、全セクションで同じ参照画像として使ってください。
+`{{MIKUKU_PROMPT_PATH}}` が未指定の場合は、次を使い、全セクションで同じ描画プロンプトとして使ってください。
 
-- `skills/igapyon-mikuku-agent/assets/mikuku/mikuku01.png`
-- `skills/igapyon-mikuku-agent/assets/mikuku/mikuku02.png`
-- `skills/igapyon-mikuku-agent/assets/mikuku/mikuku03.png`
+```text
+/Users/igapyon/Documents/git/igapyon-agent-skills/skills/igapyon-mikuku-agent/assets/mikuku/mikuku-portrait-short-prompt.md
+```
 
 ---
 
@@ -111,7 +111,7 @@ front matter や公開管理用メタデータは、`TODO.md` の画像生成対
 # 見出し単位グラレコ画像 TODO
 
 記事: {{ARTICLE_PATH}}
-みくく画像: {{MIKUKU_IMAGE_PATH}}
+みくく描画プロンプト: {{MIKUKU_PROMPT_PATH}}
 
 ## 進行状況
 
@@ -191,7 +191,7 @@ front matter や公開管理用メタデータは、`TODO.md` の画像生成対
 
 ## 3. セクション専用の画像生成プロンプトを作る
 
-`section-text.md` と `{{MIKUKU_IMAGE_PATH}}` を入力として、セクション専用の画像生成AI用プロンプトを作成します。
+`section-text.md` と `{{MIKUKU_PROMPT_PATH}}` の本文を入力として、セクション専用の画像生成AI用プロンプトを作成します。
 
 保存先:
 
@@ -203,19 +203,21 @@ front matter や公開管理用メタデータは、`TODO.md` の画像生成対
 
 - みくくがその `##` セクションを説明している構図
 - セクション見出しを主題にした横長ポスター構図
+- 記事内容や説明対象の配置に合わせて、みくくの顔の向きや視線方向を調整してよいという指示
 - 手描きグラレコ風
 - ホワイトボード解説風
 - 図解、矢印、囲み、アイコン
 - セクション本文に基づく重要語
 - みくくの吹き出し
-- 参照画像として使う `{{MIKUKU_IMAGE_PATH}}`
-- 画像生成時に、各セクションごとに `{{MIKUKU_IMAGE_PATH}}` を参照画像として読み込み直す指示
+- 描画プロンプトとして使う `{{MIKUKU_PROMPT_PATH}}` の本文
+- 画像生成時に、各セクションごとに `{{MIKUKU_PROMPT_PATH}}` の本文を画像生成AI用プロンプトに埋め込む指示
+- パスだけを書いて済ませない、という注意
 - 画像内テキストとして使う短い正確表記
 - 画像内に長文を入れすぎない方針
 
-`TODO.md` の `みくく画像:` 行は、参照画像パスの記録です。
-画像生成ツールへ参照画像が自動で引き継がれることは前提にしないでください。
-各 `image-prompt.md` には、タイトルごとの画像生成時に `{{MIKUKU_IMAGE_PATH}}` を添付、指定、またはロードしてから生成することを明記してください。
+`TODO.md` の `みくく描画プロンプト:` 行は、描画プロンプトパスの記録です。
+画像生成ツールへ描画プロンプトが自動で引き継がれることは前提にしないでください。
+各 `image-prompt.md` には、タイトルごとの画像生成時に `{{MIKUKU_PROMPT_PATH}}` の本文を含めて生成することを明記してください。
 
 画像内テキストは、本文の長い見出しや文章をそのまま入れず、短いラベルへ整理してください。
 

--- a/skills/igapyon-mikuku-agent/references/graphic-recording/50-generate-section-graphic-recording-images-prompt.md
+++ b/skills/igapyon-mikuku-agent/references/graphic-recording/50-generate-section-graphic-recording-images-prompt.md
@@ -1,6 +1,6 @@
 # 見出し単位グラレコ画像 生成実行プロンプト
 
-`40-article-section-graphic-recording-batch-prompt.md` が作成した実行ディレクトリを読み、各 `##` セクション用の `image-prompt.md` とみくく参照画像を使って、セクションごとのグラフィックレコーディング（グラレコ）画像を生成してください。
+`40-article-section-graphic-recording-batch-prompt.md` が作成した実行ディレクトリを読み、各 `##` セクション用の `image-prompt.md` とみくく描画プロンプトを使って、セクションごとのグラフィックレコーディング（グラレコ）画像を生成してください。
 
 このプロンプトは、画像生成だけを担当します。記事分割、セクション本文作成、画像生成AI用プロンプト作成は `40-article-section-graphic-recording-batch-prompt.md` の担当です。
 
@@ -20,10 +20,10 @@ TODO ファイル:
 {{TODO_PATH}}
 ```
 
-みくく画像のパス:
+みくく描画プロンプトのパス:
 
 ```text
-{{MIKUKU_IMAGE_PATH}}
+{{MIKUKU_PROMPT_PATH}}
 ```
 
 処理件数:
@@ -38,26 +38,26 @@ TODO ファイル:
 {{RUN_OUTPUT_DIR}}/TODO.md
 ```
 
-`{{MIKUKU_IMAGE_PATH}}` が未指定の場合は、`TODO.md` の `みくく画像:` 行を読んでください。
+`{{MIKUKU_PROMPT_PATH}}` が未指定の場合は、`TODO.md` の `みくく描画プロンプト:` 行を読んでください。
 
 `{{LIMIT}}` が未指定の場合は、まず 1 セクションだけ処理してください。初回から全件を処理しないでください。ユーザーが全件処理を明示した場合のみ、未生成セクションを複数処理してください。
 
 ---
 
-# みくく参照画像の扱い
+# みくく描画プロンプトの扱い
 
-`TODO.md` の `みくく画像:` 行は、参照画像パスの記録にすぎません。
-画像生成ツールへ参照画像が自動で引き継がれることは前提にしないでください。
+`TODO.md` の `みくく描画プロンプト:` 行は、描画プロンプトパスの記録にすぎません。
+画像生成ツールへ描画プロンプトが自動で引き継がれることは前提にしないでください。
 
 タイトルごとの画像生成では、各セクションを処理するたびに、次を実施してください。
 
-1. `{{MIKUKU_IMAGE_PATH}}` の実在を確認する
-2. 画像生成ツールが参照画像入力に対応している場合は、毎回 `{{MIKUKU_IMAGE_PATH}}` を添付、指定、またはロードする
-3. 参照画像を渡せない画像生成ツールの場合は、その制約を `image-generation-report.md` に記録する
-4. 参照画像なしではみくくの外観一貫性が保てないと判断した場合は、生成せず `image-pending: image-tool-unavailable` のまま残す
+1. `{{MIKUKU_PROMPT_PATH}}` の実在を確認する
+2. `{{MIKUKU_PROMPT_PATH}}` の本文を読む
+3. 対象セクションの `image-prompt.md` に、みくく描画プロンプト本文または意味を保った短縮本文が含まれていることを確認する
+4. 含まれていない場合は画像生成せず、`image-pending: character-prompt-not-embedded` として残す
 
-複数セクションを連続処理する場合でも、前セクションでロード済みの参照画像が次セクションへ引き継がれるとは考えないでください。
-各 `imagegen` 実行、または各外部画像生成AIへの投入ごとに、みくく参照画像を明示してください。
+複数セクションを連続処理する場合でも、前セクションで使った描画プロンプトが次セクションへ暗黙に引き継がれるとは考えないでください。
+各 `imagegen` 実行、または各外部画像生成AIへの投入ごとに、みくく描画プロンプト本文を含む `image-prompt.md` を使ってください。
 
 ---
 
@@ -106,13 +106,13 @@ TODO ファイル:
 - `image-generated-unsaved`
 - `image-skipped`
 - `image-skipped: front-matter`
-- `image-pending: mikuku-image-missing`
+- `image-pending: mikuku-prompt-missing`
 - `graphic-recording.png` が既に存在し、ユーザーが再生成を明示していない行
 - 対応する `image-prompt.md` が存在しない行
 
 既存画像を上書きしないでください。再生成が必要な場合は、ユーザーが明示したときだけ実行してください。
 
-`image-pending: mikuku-image-missing` は、みくく画像パスを修正してから再実行してください。
+`image-pending: mikuku-prompt-missing` は、みくく描画プロンプトパスを修正してから再実行してください。
 
 ---
 
@@ -123,17 +123,23 @@ TODO ファイル:
 1. `image-prompt.md` の本文を画像生成AIへ渡せる
 2. 生成画像を最終的に対象セクションのディレクトリへ保存または移動できる
 
-みくく参照画像 `{{MIKUKU_IMAGE_PATH}}` を画像生成AIへ添付または指定できる場合は、セクションごとの生成実行ごとに必ず使ってください。
-
-ローカル参照画像を使えない環境では、`image-prompt.md` の本文だけで生成可能か判断してください。本文だけで生成するとキャラクター外観の一貫性が落ちる場合は、無理に生成せず `image-pending: image-tool-unavailable` として残してください。
+みくく描画プロンプト本文が `image-prompt.md` に含まれている場合は、セクションごとの生成実行ごとにその `image-prompt.md` 本文を使ってください。
 
 組み込み `imagegen` が利用可能な場合は、出力先を直接指定できないことだけを理由に保留しないでください。まず `imagegen` で 1 セクション分を生成し、生成された画像をワークスペース内の対象セクションディレクトリへ保存または移動してください。
 
 組み込み `imagegen` は、通常 `$CODEX_HOME/generated_images/...` 配下へ画像を保存します。対象セクションで使う画像は、生成後にその保存先からコピーしてください。元画像は削除しないでください。
 
+生成画像をコピーする前に、対象セクションごとに次のファイルを作成してください。
+
+```text
+{{RUN_OUTPUT_DIR}}/sections/<NNN>-<slug>/copy-generated-image.md
+```
+
+この Markdown には、生成画像の元パス、コピー先、コピーコマンド、検証コマンド、コピー結果を記録します。
+
 生成画像を対象セクションのディレクトリへ保存または移動できない場合は、生成済みにしないでください。この場合は `image-generated-unsaved` として記録し、実際の画像の所在を分かる範囲で `TODO.md` またはレポートへ残してください。
 
-画像生成ツールそのものが利用できない場合は、必要に応じて画像生成ツールへ渡すための一覧を `{{RUN_OUTPUT_DIR}}/image-generation-queue.md` として作成し、`TODO.md` は `image-pending: image-tool-unavailable` のまま残してください。
+画像生成ツールそのものが利用できない場合、または描画プロンプト本文が `image-prompt.md` に含まれていない場合は、必要に応じて画像生成ツールへ渡すための一覧を `{{RUN_OUTPUT_DIR}}/image-generation-queue.md` として作成し、`TODO.md` は `image-pending: image-tool-unavailable` または `image-pending: character-prompt-not-embedded` のまま残してください。
 
 この状態は「画像生成の失敗」ではなく「現在の環境では未実行」です。`image-generation-failed` は、画像生成ツールを実行したがエラーになった、または出力画像が不正だった場合だけ使ってください。
 
@@ -150,7 +156,7 @@ TODO ファイル:
 必須入力:
 
 - `image-prompt.md`
-- `{{MIKUKU_IMAGE_PATH}}`
+- `{{MIKUKU_PROMPT_PATH}}`
 
 任意参照:
 
@@ -159,7 +165,7 @@ TODO ファイル:
 
 `image-prompt.md` がない場合、そのセクションは画像生成せず、`TODO.md` に `image-prompt-missing` と記録してください。
 
-`{{MIKUKU_IMAGE_PATH}}` が存在しない場合、そのセクションは画像生成せず、`TODO.md` に `image-pending: mikuku-image-missing` と記録してください。
+`{{MIKUKU_PROMPT_PATH}}` が存在しない場合、そのセクションは画像生成せず、`TODO.md` に `image-pending: mikuku-prompt-missing` と記録してください。
 
 ## 2. 画像生成AI用プロンプトを読む
 
@@ -168,10 +174,10 @@ TODO ファイル:
 画像生成に渡す入力:
 
 - `image-prompt.md` の本文
-- みくく参照画像 `{{MIKUKU_IMAGE_PATH}}`
+- みくく描画プロンプト本文を含む `image-prompt.md`
 
-この時点で、当該セクション用にみくく参照画像を改めてロード、添付、または指定してください。
-前セクションの生成時に使った参照画像が現在の生成へ引き継がれるとは扱わないでください。
+この時点で、当該セクション用の `image-prompt.md` にみくく描画プロンプト本文が含まれていることを確認してください。
+前セクションの生成時に使った描画プロンプトが現在の生成へ引き継がれるとは扱わないでください。
 
 `image-prompt.md` 内に推奨出力先が書かれている場合は、それを尊重してください。書かれていない場合は、次のパスを使ってください。
 
@@ -181,9 +187,9 @@ TODO ファイル:
 
 ## 3. 画像を生成する
 
-画像生成ツールが利用可能な環境では、`image-prompt.md` の本文と、当該セクション用にロードした `{{MIKUKU_IMAGE_PATH}}` を使って画像生成を実行してください。
+画像生成ツールが利用可能で、かつ `image-prompt.md` にみくく描画プロンプト本文が含まれている場合は、`image-prompt.md` の本文を使って画像生成を実行してください。
 
-組み込み `imagegen` を使う場合は、1 セクションずつ実行してください。各実行前に、参照画像として使うみくく画像パスを生成プロンプト内にも明示してください。生成後、選択した生成画像を対象セクションのディレクトリに `graphic-recording.png` として保存または移動してください。
+組み込み `imagegen` を使う場合は、1 セクションずつ実行してください。各実行前に、`image-prompt.md` 本文にみくく描画プロンプト本文が含まれていることを確認してください。生成後、選択した生成画像を対象セクションのディレクトリに `graphic-recording.png` として保存または移動してください。
 
 ```text
 {{RUN_OUTPUT_DIR}}/sections/<NNN>-<slug>/graphic-recording.png
@@ -192,9 +198,11 @@ TODO ファイル:
 組み込み `imagegen` の生成物が `$CODEX_HOME/generated_images/...` に保存された場合は、次の方針で扱ってください。
 
 1. 今回の生成で作成された画像ファイルを特定する
-2. 対象セクションの出力先へコピーする
-3. コピー先のファイルサイズが 0 バイトではないことを確認する
-4. 元の `$CODEX_HOME/generated_images/...` 側の画像は残す
+2. 対象セクションの `copy-generated-image.md` を `status: pending` で作成する
+3. 対象セクションの出力先へコピーする
+4. コピー先のファイルサイズが 0 バイトではないことを確認する
+5. `copy-generated-image.md` を `status: copied` として更新する
+6. 元の `$CODEX_HOME/generated_images/...` 側の画像は残す
 
 コピー先:
 
@@ -202,10 +210,43 @@ TODO ファイル:
 {{RUN_OUTPUT_DIR}}/sections/<NNN>-<slug>/graphic-recording.png
 ```
 
+`copy-generated-image.md` には、少なくとも次を記録してください。
+
+````markdown
+# Copy Generated Image
+
+- status: pending | copied | failed | skipped
+- section:
+- generated-source-path:
+- workspace-output-path:
+- source-exists: yes | no
+- workspace-output-exists: yes | no
+- workspace-output-size:
+- workspace-output-file-type:
+
+## Copy Command
+
+```bash
+cp "<generated-source-path>" "<workspace-output-path>"
+```
+
+## Verify Commands
+
+```bash
+ls -lh "<workspace-output-path>"
+file "<workspace-output-path>"
+```
+
+## Notes
+````
+
+生成画像の元パスを特定できない場合は、コピーを実行せず、`status: failed` または `status: skipped` として理由を `Notes` に記録してください。この場合、対象セクションを `image-generated` として扱わないでください。
+
 生成時の基本方針:
 
 - 横長ポスター構図
 - みくくが説明する構図
+- 記事内容や説明対象の配置に合わせて顔の向きや視線方向を調整してよい
 - 手描きグラレコ風
 - ホワイトボード解説風
 - セクション本文だけを主題にする
@@ -219,6 +260,8 @@ TODO ファイル:
 - `graphic-recording.png` が保存されている
 - ファイルサイズが 0 バイトではない
 - 対象セクションのディレクトリに保存されている
+- `copy-generated-image.md` が保存されている
+- `copy-generated-image.md` に元画像パス、コピー先、コピー結果が記録されている
 - `image-generation-report.md` に元画像パスとコピー先を記録している
 
 可能であれば、画像を開いて明らかな失敗がないか確認してください。
@@ -240,10 +283,11 @@ TODO ファイル:
 
 - status: image-generated
 - prompt: sections/001-text-file/image-prompt.md
-- mikuku-image: skills/igapyon-mikuku-agent/assets/mikuku/mikuku01.png
-- mikuku-image-loaded: yes
+- mikuku-prompt: skills/igapyon-mikuku-agent/assets/mikuku/mikuku-portrait-short-prompt.md
+- character-prompt-embedded: yes
 - generated-source: <imagegen が保存した元画像パス>
 - workspace-output: sections/001-text-file/graphic-recording.png
+- copy-instruction: sections/001-text-file/copy-generated-image.md
 ```
 
 画像生成ができなかった場合は、理由を短く残してください。
@@ -252,13 +296,14 @@ TODO ファイル:
 
 ```markdown
 - [ ] 001: テキストファイルとは - image-pending: image-tool-unavailable
-- [ ] 001: テキストファイルとは - image-pending: mikuku-image-missing
+- [ ] 001: テキストファイルとは - image-pending: character-prompt-not-embedded
+- [ ] 001: テキストファイルとは - image-pending: mikuku-prompt-missing
 - [ ] 001: テキストファイルとは - image-generated-unsaved
 - [ ] 001: テキストファイルとは - image-generation-failed: 画像生成エラー
 - [ ] 002: 文字エンコーディングは UTF-8 で - image-prompt-missing
 ```
 
-画像生成ツールが使えない環境では、すべてを生成済み扱いにしないでください。`image-pending: image-tool-unavailable` として残してください。
+画像生成ツールが使えない環境、または描画プロンプト本文が `image-prompt.md` に含まれていない環境では、すべてを生成済み扱いにしないでください。`image-pending: image-tool-unavailable` または `image-pending: character-prompt-not-embedded` として残してください。
 
 ---
 

--- a/skills/igapyon-mikuku-agent/references/graphic-recording/60-inspect-section-graphic-recording-images-prompt.md
+++ b/skills/igapyon-mikuku-agent/references/graphic-recording/60-inspect-section-graphic-recording-images-prompt.md
@@ -39,7 +39,8 @@ TODO ファイル:
 
 - `image-pending`
 - `image-pending: image-tool-unavailable`
-- `image-pending: mikuku-image-missing`
+- `image-pending: character-prompt-not-embedded`
+- `image-pending: mikuku-prompt-missing`
 - `image-generated-unsaved`
 - `image-generation-failed`
 - `image-prompt-missing`
@@ -61,6 +62,9 @@ TODO ファイル:
 - 対象セクションの主題と明らかに一致している
 - 別セクションの内容が主題になっていない
 - みくくが説明する構図になっている
+- 顔の輪郭、髪型、髪色、目の描き方、ツインテール、髪留めが `mikuku-portrait-short-prompt.md` の内容から大きく変わっていない
+- 顔の向きや視線方向の変更は、記事内容や説明対象の配置に合っていれば問題として扱わない
+- キャラクターが別人に見える場合は、内容が良くても再生成候補として扱う
 - 横長ポスター構図として成立している
 - 手描きグラレコ風、ホワイトボード解説風になっている
 - 文字量が多すぎない


### PR DESCRIPTION
## 概要

`igapyon-mikuku-agent` のグラレコ生成手順を、みくく参照画像ベースから、みくく描画プロンプト本文を画像生成プロンプトへ埋め込む方式へ更新しました。

## 変更内容

- グラレコ関連ワークフローで `MIKUKU_IMAGE_PATH` ではなく `MIKUKU_PROMPT_PATH` を扱うように整理
- `mikuku-portrait-short-prompt.md` を追加し、みくくの短縮描画プロンプトを定義
- グラレコ生成前に描画プロンプト本文を読み、画像生成AI用プロンプトへ含める実行ゲートを追加
- 画像生成結果のコピー手順を `copy-generated-image.md` に記録する運用を追加
- セクション別グラレコ生成で、描画プロンプト未埋め込み時の状態 `character-prompt-not-embedded` を扱うように更新
- 検品手順に、みくくのキャラクター同一性確認項目を追加
- `index.json` を追加・更新された skill ファイル構成に合わせて更新