### PR TITLE
みくくスキルに Codex CLI ローカルトークン消費調査の参照を追加

### DIFF
--- a/skills/igapyon-mikuku-agent/SKILL.md
+++ b/skills/igapyon-mikuku-agent/SKILL.md
@@ -41,6 +41,12 @@ When creating graphic recording material, a graphic-recording text draft, or an 
 
 After this skill is already active, if the user mentions `グラレコ` or `graphic recording`, read and apply [references/graphic-recording.md](references/graphic-recording.md) before answering or starting related work. Do not rely on memory of that workflow; load the file in the current turn and follow its execution gate.
 
+## Codex Local Token Usage
+
+When this skill is active and the user asks about Codex token consumption, local usage history, weekly consumption, or related terms such as `トークン消費`, `消費状態`, `週間の消費量`, `週次消費`, `tokens_used`, `state_*.sqlite`, `Codex CLI usage`, or `ローカル履歴`, read and apply [references/codex-local-token-usage.md](references/codex-local-token-usage.md).
+
+This workflow is for Codex CLI and local Codex app state only. It is not a ChatGPT / Codex Web UI usage method, and results must be described as local history estimates rather than official account usage, billing usage, weekly quota, or remaining allowance.
+
 ## Visual Assets
 
 When the user asks for a `みくく` or `Mikuku` image, avatar, card image, visual reference, article portrait, or character visual, use image files from [assets/mikuku/](assets/mikuku/). Do not generate a new character image or choose an unrelated external image when an existing `assets/mikuku/` image fits the request.
@@ -63,4 +69,5 @@ Treat `index.json` as a generated discovery index. Do not rely on it as the sour
 - [references/mikuku-prompt.md](references/mikuku-prompt.md): full `みくく` character prompt and sample dialogue.
 - [references/article-writing.md](references/article-writing.md): article writing reference for `みくく` authored articles.
 - [references/graphic-recording.md](references/graphic-recording.md): graphic recording workflow entry for `みくく` article explainers.
+- [references/codex-local-token-usage.md](references/codex-local-token-usage.md): Codex CLI local token usage investigation prompt and caveats.
 - [references/examples/articles/](references/examples/articles/): example articles authored in the `みくく` style.

--- a/skills/igapyon-mikuku-agent/index.json
+++ b/skills/igapyon-mikuku-agent/index.json
@@ -5,6 +5,7 @@
  "files": [
   {"name":"mikuku-portrait-short-prompt.md","path":"assets/mikuku/mikuku-portrait-short-prompt.md","ext":"md","dir":"assets/mikuku","size":628,"summary":"Mikuku Portrait Short Prompt"},
   {"name":"article-writing.md","path":"references/article-writing.md","ext":"md","dir":"references","size":12742,"summary":"みくく担当記事の執筆参照"},
+  {"name":"codex-local-token-usage.md","path":"references/codex-local-token-usage.md","ext":"md","dir":"references","size":3748,"summary":"Codex CLI Local Token Usage Investigation"},
   {"name":"20260509-general-agent-skills-activation.md","path":"references/examples/articles/20260509-general-agent-skills-activation.md","ext":"md","dir":"references/examples/articles","size":14785,"summary":"Agent Skills の発火は、どのように起きているのか"},
   {"name":"20260509-general-agent-skills-docs.md","path":"references/examples/articles/20260509-general-agent-skills-docs.md","ext":"md","dir":"references/examples/articles","size":14543,"summary":"Agent Skills では、説明ページの役割が少し変わる"},
   {"name":"20260510-general-mcp-server-client-local.md","path":"references/examples/articles/20260510-general-mcp-server-client-local.md","ext":"md","dir":"references/examples/articles","size":19281,"summary":"MCP は、生成AIに道具を渡すための入口になる"},
@@ -25,6 +26,6 @@
   {"name":"mikuku-prompt.md","path":"references/mikuku-prompt.md","ext":"md","dir":"references","size":4292,"summary":"生成AI キャラクター `みくく` プロンプト (v20251229c改1)"},
   {"name":"article-footer-sections-template.md","path":"references/templates/article-footer-sections-template.md","ext":"md","dir":"references/templates","size":3416,"summary":"みくく担当記事の末尾セクションテンプレート"},
   {"name":"VERSION.md","path":"references/VERSION.md","ext":"md","dir":"references","size":934,"summary":"みくく Version"},
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":4641,"description":"Use only when the user explicitly asks Codex to speak or collaborate as the Japanese character agent \"みくく\", mentions みくく, Mikuku, igapyon-mikuku, or explicitly asks to apply the みくく prompt. If the user only asks whether such a character skill exists, mention this skill as an available option but do not apply it until asked.","summary":"igapyon-mikuku-agent"}
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":5462,"description":"Use only when the user explicitly asks Codex to speak or collaborate as the Japanese character agent \"みくく\", mentions みくく, Mikuku, igapyon-mikuku, or explicitly asks to apply the みくく prompt. If the user only asks whether such a character skill exists, mention this skill as an available option but do not apply it until asked.","summary":"igapyon-mikuku-agent"}
  ]
 }

--- a/skills/igapyon-mikuku-agent/references/codex-local-token-usage.md
+++ b/skills/igapyon-mikuku-agent/references/codex-local-token-usage.md
@@ -1,0 +1,65 @@
+# Codex CLI Local Token Usage Investigation
+
+This reference describes how to reproduce a local Codex token-usage investigation from the Codex state SQLite database.
+
+## Scope
+
+This method is for Codex CLI and local Codex app environments that write state under `CODEX_HOME`, usually `~/.codex`.
+
+It is not a Web UI usage investigation method. The ChatGPT / Codex Web UI does not expose the local filesystem path `~/.codex/state_*.sqlite` to the assistant, so this method cannot inspect Web UI-only usage. Treat all results as local history estimates, not official account usage, billing usage, weekly quota, or remaining allowance.
+
+## When to Use
+
+Use this reference when the user asks about local Codex token consumption and mentions words such as:
+
+- `トークン消費`
+- `消費状態`
+- `週間の消費量`
+- `週次消費`
+- `tokens_used`
+- `state_*.sqlite`
+- `Codex CLI usage`
+- `ローカル履歴`
+
+## Investigation Prompt
+
+Use or adapt the following prompt to reproduce the investigation in a later session:
+
+```text
+Codex CLI のローカル状態DBから、トークン消費状況を調べてください。
+
+重要:
+- この方法は Codex CLI / ローカル Codex アプリ環境専用です。
+- ChatGPT / Codex Web UI だけの利用量調査には使えません。
+- 公式な週次上限・残量・課金利用量ではなく、このマシンのローカル Codex 履歴に記録された tokens_used の集計です。
+
+目的:
+- ~/.codex/state_*.sqlite の threads テーブルを確認し、tokens_used / created_at / updated_at を使って利用量を集計してください。
+- SQLite が WAL モードの場合があるので、DB本体だけでなく .sqlite-wal の更新時刻も確認してください。
+
+やってほしいこと:
+1. codex doctor --json などで CODEX_HOME と state DB の場所を確認する。
+2. state DB のスキーマを sqlite3 .schema で確認する。
+3. threads テーブルに tokens_used, created_at, updated_at があるか確認する。
+4. 最新スレッド上位を表示する。
+5. JST基準で「今週」「先週」「直近7日」「その前の7日」の tokens_used 合計を出す。
+6. DBファイル本体、-wal、-shm の更新時刻を確認する。
+7. 結果には「これはローカル履歴ベースであり、公式のアカウント利用量や上限対比ではない」と明記する。
+
+使うコマンド例:
+- codex doctor --json
+- sqlite3 ~/.codex/state_5.sqlite .schema
+- sqlite3 -header -column ~/.codex/state_5.sqlite "select datetime(updated_at,'unixepoch','localtime') as updated, datetime(created_at,'unixepoch','localtime') as created, tokens_used, id, title from threads order by updated_at desc limit 10;"
+- sqlite3 -header -column ~/.codex/state_5.sqlite "select date(updated_at,'unixepoch','localtime') as day, count(*) as threads, sum(tokens_used) as tokens from threads where updated_at >= strftime('%s','now','-14 days') group by day order by day desc;"
+- ls -l ~/.codex/state_5.sqlite*
+- stat ~/.codex/state_5.sqlite*
+```
+
+## Notes for the Assistant
+
+- Prefer discovering the actual state DB path from `codex doctor --json` instead of assuming `state_5.sqlite`.
+- If `codex doctor --json` is unavailable or too noisy, inspect `~/.codex/state_*.sqlite` candidates.
+- On macOS, `stat -f '%Sm %m %N' FILE` gives readable and epoch mtimes. On Linux, use `stat FILE` or `stat -c '%y %Y %n' FILE`.
+- SQLite may return data newer than the main DB file mtime because committed changes can still be in the `-wal` file.
+- Use absolute dates when explaining week boundaries, especially when the user asks about `今週`, `先週`, `今日`, or `昨日`.
+- Do not present the result as official OpenAI, ChatGPT, billing, or quota usage.


### PR DESCRIPTION
## 概要

`igapyon-mikuku-agent` に、Codex CLI のローカル状態DBを使ったトークン消費状況調査の参照ワークフローを追加します。

## 変更内容

- `SKILL.md` に `Codex Local Token Usage` セクションを追加
- トークン消費、週次消費、`tokens_used`、`state_*.sqlite` などの問い合わせ時に参照するファイルを明示
- 調査結果は公式なアカウント利用量、課金利用量、週次上限、残量ではなく、ローカル履歴ベースの推定として扱う注意書きを追加
- `references/codex-local-token-usage.md` を新規追加
- Codex CLI のローカル状態DB、`threads` テーブル、`tokens_used`、WAL ファイルを確認するための調査手順とコマンド例を追加
- `index.json` に新規参照ファイルを反映