### PR TITLE
igapyon-ffmpeg-helper skill を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ Note / Qiita 記事 Markdown は、各 writer skill 配下の `references/` を�
 │  ├─ igapyon-github-writer/
 │  │  ├─ SKILL.md
 │  │  └─ references/
+│  ├─ igapyon-ffmpeg-helper/
+│  │  ├─ SKILL.md
+│  │  └─ references/
 │  ├─ igapyon-miku-soft-developer/
 │  │  ├─ SKILL.md
 │  │  └─ references/
@@ -213,6 +216,10 @@ Note / Qiita 記事 Markdown は、各 writer skill 配下の `references/` を�
 - `igapyon-github-writer`
 
   GitHub PR、GitHub Release、GitHub About に貼る文章の作成向け。明示的に指定した場合に利用する。
+
+- `igapyon-ffmpeg-helper`
+
+  H4essential のオーケストラ録音から、切り出し、単純ゲイン調整、必要なら結合、静止画付き YouTube 用動画作成までの個人用 FFmpeg ワークフロー向け。明示的に指定した場合に利用する。
 
 - `igapyon-miku-soft-developer`
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,88 @@
 - [ ] skill 配布先が必要になったら mirror 方針を決める
 - [ ] UI metadata が必要になったら skill 用の `agents/openai.yaml` を検討する
 
+## igapyon-ffmpeg-helper 作業メモ
+
+- [x] `skills/igapyon-ffmpeg-helper/` を新規 Agent Skill として作成した
+- [x] hard trigger 方針にした
+  - 発火する例: `igapyon-ffmpeg-helper`, `igapyon FFmpeg helper`, `ffmpeg helper`, `FFmpeg helper workflow`, `FFmpeg helper runbook`, `ffmpeg runbook igapyon`, `igapyon ffmpeg runbook`
+  - 通常の FFmpeg / H4essential / YouTube / loudnorm / gain / trim 相談では自動発火しない
+- [x] `SKILL.md` は入口とガードレールに絞り、詳細は `references/` に分離した
+- [x] first cut workflow を `references/workflows/h4essential-orchestra-youtube.md` に作成した
+  - H4essential オーケストラ録音フォルダ
+  - WAV トラック選択
+  - VLC で人間が切れ目確認
+  - cut memo を agent に戻す
+  - trim
+  - loudnorm JSON 測定
+  - `volume=...dB` の単純ゲイン仕上げ
+  - 必要なら結合
+  - 静止画 + 音声で YouTube 用 MP4 作成
+  - YouTube Studio で手動アップロード
+- [x] process runbook を `references/process/` に分割した
+  - `h4essential-input-discovery.md`
+  - `workspace-and-command-log.md`
+  - `audio-trim.md`
+  - `peak-gain-normalize.md`
+  - `audio-concat.md`
+  - `still-image-youtube-video.md`
+  - `youtube-manual-upload.md`
+- [x] H4essential 入力仕様を記録した
+  - 例: `/Volumes/ZOOM_H4E/260114_160901/260114_160901_TrMic.WAV`
+  - 実処理は録音フォルダをローカルに複数コピーしてから開始
+  - `TrMic`, `TrLR`, `Tr1`, `Tr2` を候補として扱う
+  - `TrMic` と `TrLR` が両方ある場合などは勝手に選ばず確認する
+- [x] trim 方針を記録した
+  - first cut では切れ目・ファイル境界は人間判断
+  - VLC 使用を強く推奨
+  - cut memo 形式を定義
+  - `01:23` は 1分23秒
+  - `00:01:23.500`, `83.5` のような小数秒指定も許容
+  - 前だけカット、後ろだけカット、両端カット、カットなしに対応
+- [x] 音量調整方針を記録した
+  - 参照元: `https://igapyon.github.io/local-html-tools/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html`
+  - 仕上げ処理としての loudnorm は使わない
+  - 測定フェーズでは `loudnorm=print_format=json` で `input_tp` を得る
+  - 仕上げフェーズでは `volume=...dB` のみ
+  - target true peak は `-0.5 dBTP`
+  - コンプなし、リミッターなし
+  - hi-res / lo-res を選択可能
+    - hi-res: `-ar 192000 -sample_fmt s32 -c:a pcm_s24le`
+    - lo-res: `-ar 44100 -sample_fmt s16 -c:a pcm_s16le`
+  - 仕上げ後に verification measurement を行う方針を追加した
+- [x] 作業フォルダ方針を記録した
+  - per-job directory: `workplace/h4essential-260114_160901/` など
+  - `commands.log` に実行/提示コマンドを残す
+  - 作業フォルダ内にログや測定出力を積極的に保存してよい
+  - 例: `ffmpeg-version.txt`, `01_gain-meta.json`, `01_gain-verify-meta.json`, `01_trim.log`, `01_gain.log`, `youtube-video.log`
+- [x] `ffmpeg -version` は必須にした
+  - conversion command 実行前に必ず実行
+  - `commands.log` に記録
+  - `ffmpeg-version.txt` に保存
+  - 失敗したら workflow を止める
+- [x] YouTube 動画作成方針を記録した
+  - 静止画 + 音声
+  - MP4 / H.264 / yuv420p / AAC 48kHz 320kbps
+  - 1920x1080, 画像全体を保持して padding
+  - `-movflags +faststart`
+  - YouTube API ではなく YouTube Studio から手動アップロード
+- [x] 自己レビューして改善した
+  - `ffmpeg -version` をログ化
+  - 測定コマンドを `tee` ではなく redirection へ寄せた
+  - `input_tp` が parse できない場合は次へ進まない
+  - 仕上げ後の再測定を追加
+  - no-trim 判定の文言を整理
+- [x] 検証済み
+  - `python3 /Users/igapyon/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/igapyon/Documents/git/igapyon-agent-skills/skills/igapyon-ffmpeg-helper`
+  - `mvn generate-resources`
+- [ ] 再開時の確認候補
+  - `commands.log` だけでなく各 ffmpeg 実行ログをどこまで標準化するか
+  - `ffmpeg -version` のコマンド自体も `commands.log` に記録する現方針で十分か
+  - hi-res / lo-res のデフォルトを決めるか、毎回聞くか
+  - verification measurement の許容誤差を明文化するか
+  - 無音検知を「VLC確認用の候補出し」として process 化するか
+  - `README.md` の skill 一覧説明をさらに詳しくするか
+
 ## Note 記事 TODO
 
 - [ ] 旧素材メモ `xxxxxxxx-general-content-agent-skills-token-context.md` から、3本の記事へ未展開だった補助論点を必要なら別記事または追補へ展開する

--- a/skills/igapyon-ffmpeg-helper/SKILL.md
+++ b/skills/igapyon-ffmpeg-helper/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: igapyon-ffmpeg-helper
+description: "Use only on hard trigger: the user explicitly names igapyon-ffmpeg-helper, says to use/apply the FFmpeg helper skill, or uses a specific activation phrase such as igapyon FFmpeg helper, ffmpeg helper workflow, FFmpeg helper runbook, ffmpeg runbook igapyon, or igapyon ffmpeg runbook. This skill is for igapyon's personal FFmpeg runbooks, including the H4essential orchestra recording to YouTube workflow. Do not use for ordinary FFmpeg questions, H4essential mentions, YouTube/video/audio conversion questions, loudnorm/gain questions, or generic workflow discussion unless the user explicitly triggers this skill."
+---
+
+# igapyon-ffmpeg-helper
+
+This skill guides igapyon's personal FFmpeg workflows. Use it as a
+conversational command generator and runbook navigator.
+
+Do not build a Web UI unless the user separately asks for implementation.
+
+## Activation
+
+Use this skill only on a hard trigger. Valid triggers include:
+
+- `igapyon-ffmpeg-helper`
+- `igapyon FFmpeg helper`
+- `ffmpeg helper`
+- `FFmpeg helper workflow`
+- `FFmpeg helper runbook`
+- `ffmpeg runbook igapyon`
+- `igapyon ffmpeg runbook`
+- `igapyon's FFmpeg helper workflow`
+- an explicit request to use or apply this Agent Skill
+
+Do not activate this skill for:
+
+- ordinary FFmpeg questions
+- ordinary H4essential questions
+- ordinary YouTube/video/audio conversion questions
+- mentions of `loudnorm`, gain adjustment, trimming, concatenation, or still
+  image video creation
+- vague descriptions of a similar workflow
+
+If the user only asks whether such a skill exists, mention this skill as an
+available option, but do not apply it until the user asks to use it.
+
+## Workflow Selection
+
+The first-cut workflow is:
+
+- [references/workflows/h4essential-orchestra-youtube.md](references/workflows/h4essential-orchestra-youtube.md)
+
+When more workflows are added, choose the closest workflow from
+`references/workflows/`. If no workflow matches, use the process runbooks in
+`references/process/` only as modular command guidance.
+
+For the first-cut workflow, confirm the route once at the start:
+
+```text
+H4essentialのオーケストラ録音から、切り出し、loudnorm JSON測定、-0.5 dBTPピーク基準の単純ゲイン仕上げ、必要なら結合、静止画付きYouTube用動画作成まで進めますか？
+```
+
+After the route is confirmed, keep moving and ask only for the missing input
+needed for the next concrete command.
+
+## Process Runbooks
+
+Use these process files as reusable command building blocks:
+
+- [references/process/h4essential-input-discovery.md](references/process/h4essential-input-discovery.md)
+- [references/process/workspace-and-command-log.md](references/process/workspace-and-command-log.md)
+- [references/process/audio-trim.md](references/process/audio-trim.md)
+- [references/process/peak-gain-normalize.md](references/process/peak-gain-normalize.md)
+- [references/process/audio-concat.md](references/process/audio-concat.md)
+- [references/process/still-image-youtube-video.md](references/process/still-image-youtube-video.md)
+- [references/process/youtube-manual-upload.md](references/process/youtube-manual-upload.md)
+
+Use `index.json` as the discovery index when you need to confirm available
+reference files, but treat `SKILL.md` and files under `references/` as the
+source of truth.
+
+## Prerequisites
+
+Running generated commands requires the `ffmpeg` CLI to be available in the
+user's shell. `ffmpeg -version` is mandatory before executing any workflow
+command on the user's machine:
+
+```sh
+ffmpeg -version
+```
+
+If `ffmpeg -version` fails or `ffmpeg` is unavailable, stop command execution
+and ask the user to install or expose `ffmpeg` in `PATH`.
+
+## First-Cut Guardrails
+
+Unless the user explicitly changes the first-cut workflow:
+
+- Use copied ZOOM H4essential recording folders as the source.
+- Assume orchestra or ensemble rehearsal recording.
+- Treat trimming as expected and usually required.
+- Use a two-phase simple-gain route: measurement first, finishing second.
+- Use `loudnorm=print_format=json` only for measurement JSON.
+- Use `volume=...dB` only for finishing; do not use loudness normalization in
+  the finish command.
+- Target peak is `-0.5 dBTP`.
+- Do not use compression.
+- Let the user choose hi-res or lo-res output for the finish command.
+- For multiple WAVs, trim and gain-adjust each selected WAV first, then
+  concatenate.
+- End at a YouTube-uploadable video file.
+- Upload manually through the YouTube Studio Web UI.
+- Do not introduce YouTube API upload, OAuth, scheduled publishing, or metadata
+  automation unless the user explicitly asks to expand the skill.
+
+## Response Style
+
+When using this skill:
+
+- Prefer Japanese explanations for this user's workflow unless the user switches
+  language.
+- Show concrete commands in execution order.
+- Clearly label the two FFmpeg runs: measurement phase and finishing phase.
+- Ask the user to paste the loudnorm JSON measurement output back when you
+  cannot run the measurement command yourself.
+- Preserve source files and avoid destructive commands.
+- Use quoted paths in generated shell commands.
+- Put generated working files under a per-job directory such as
+  `workplace/h4essential-260114_160901/` by default.
+- Keep a command log such as `workplace/h4essential-260114_160901/commands.log`
+  and record the exact commands that are executed or handed to the user.
+- It is acceptable and preferred to write auxiliary logs, measurement outputs,
+  and troubleshooting files inside the per-job `workplace/` directory.
+- Do not silently choose between plausible H4essential tracks when the recording
+  source is ambiguous.

--- a/skills/igapyon-ffmpeg-helper/agents/openai.yaml
+++ b/skills/igapyon-ffmpeg-helper/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "igapyon FFmpeg Helper"
+  short_description: "Guide igapyon-specific FFmpeg recording workflows."
+  default_prompt: "Use igapyon-ffmpeg-helper to guide my H4essential orchestra recording workflow."

--- a/skills/igapyon-ffmpeg-helper/index.json
+++ b/skills/igapyon-ffmpeg-helper/index.json
@@ -1,0 +1,16 @@
+{
+ "generator": "miku-indexgen",
+ "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
+ "basePath": ".",
+ "files": [
+  {"name":"audio-concat.md","path":"references/process/audio-concat.md","ext":"md","dir":"references/process","size":1424,"summary":"Audio Concatenation"},
+  {"name":"audio-trim.md","path":"references/process/audio-trim.md","ext":"md","dir":"references/process","size":4379,"summary":"Audio Trim"},
+  {"name":"h4essential-input-discovery.md","path":"references/process/h4essential-input-discovery.md","ext":"md","dir":"references/process","size":2125,"summary":"H4essential Input Discovery"},
+  {"name":"peak-gain-normalize.md","path":"references/process/peak-gain-normalize.md","ext":"md","dir":"references/process","size":3448,"summary":"Peak-Based Simple Gain Adjustment"},
+  {"name":"still-image-youtube-video.md","path":"references/process/still-image-youtube-video.md","ext":"md","dir":"references/process","size":1504,"summary":"Still Image + Audio YouTube Video"},
+  {"name":"workspace-and-command-log.md","path":"references/process/workspace-and-command-log.md","ext":"md","dir":"references/process","size":2951,"summary":"Workspace and Command Log"},
+  {"name":"youtube-manual-upload.md","path":"references/process/youtube-manual-upload.md","ext":"md","dir":"references/process","size":705,"summary":"YouTube Manual Upload"},
+  {"name":"h4essential-orchestra-youtube.md","path":"references/workflows/h4essential-orchestra-youtube.md","ext":"md","dir":"references/workflows","size":5164,"summary":"H4essential Orchestra Recording to YouTube Workflow"},
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":5656,"description":"Use only on hard trigger: the user explicitly names igapyon-ffmpeg-helper, says to use/apply the FFmpeg helper skill, or uses a specific activation phrase such as igapyon FFmpeg helper, ffmpeg helper workflow, FFmpeg helper runbook, ffmpeg runbook igapyon, or igapyon ffmpeg runbook. This skill is for igapyon's personal FFmpeg runbooks, including the H4essential orchestra recording to YouTube workflow. Do not use for ordinary FFmpeg questions, H4essential mentions, YouTube/video/audio conversion questions, loudnorm/gain questions, or generic workflow discussion unless the user explicitly triggers this skill.","summary":"igapyon-ffmpeg-helper"}
+ ]
+}

--- a/skills/igapyon-ffmpeg-helper/references/process/audio-concat.md
+++ b/skills/igapyon-ffmpeg-helper/references/process/audio-concat.md
@@ -1,0 +1,44 @@
+# Audio Concatenation
+
+Use this process when multiple gain-adjusted WAV files should become one audio
+file.
+
+## Policy
+
+For the first-cut H4essential workflow, concatenate only after each selected WAV
+has already been trimmed and gain-adjusted.
+
+Use the same output resolution choice for all files before concatenation. Do not
+mix hi-res and lo-res adjusted files in one concat list.
+
+## File List
+
+Create `concat_list.txt` in the job directory:
+
+```text
+file '01_gain-lores-tp0p5-plain.wav'
+file '02_gain-lores-tp0p5-plain.wav'
+file '03_gain-lores-tp0p5-plain.wav'
+```
+
+## Command
+
+Try stream copy first when the files have matching formats:
+
+```sh
+ffmpeg -f concat -safe 0 -i "workplace/h4essential-260114_160901/concat_list.txt" -c copy "workplace/h4essential-260114_160901/merged_gain-lores-tp0p5-plain.wav"
+```
+
+If `-c copy` fails because formats differ, fall back to re-encoding:
+
+```sh
+ffmpeg -f concat -safe 0 -i "workplace/h4essential-260114_160901/concat_list.txt" -ar 44100 -sample_fmt s16 -c:a pcm_s16le "workplace/h4essential-260114_160901/merged_gain-lores-tp0p5-plain.wav"
+```
+
+## Notes
+
+- Keep the adjusted per-source WAV files.
+- Use the merged file as input for YouTube video creation.
+- Log the concat command to the job directory's `commands.log`.
+- For hi-res workflows, use the corresponding `*-hires-tp0p5-plain.wav` names
+  and `-ar 192000 -sample_fmt s32 -c:a pcm_s24le` for the re-encode fallback.

--- a/skills/igapyon-ffmpeg-helper/references/process/audio-trim.md
+++ b/skills/igapyon-ffmpeg-helper/references/process/audio-trim.md
@@ -1,0 +1,141 @@
+# Audio Trim
+
+Use this process to remove unnecessary beginning and ending portions from a
+selected recording.
+
+In the first cut, trim points and file boundaries are human judgment. Strongly
+recommend checking the source recording in VLC before deciding start/end times
+or where multiple files should join.
+
+## Inputs
+
+Ask for these if missing:
+
+- input WAV path
+- start time, optional
+- end time, optional
+- output WAV path
+
+Use one trim command per selected WAV in multiple-file workflows.
+
+If trim times are missing, ask the user to listen in VLC and provide the start
+and/or end times when trimming is needed. Do not infer musical cut points
+automatically from silence or waveform assumptions in the first cut.
+
+Trimming supports four cases:
+
+- both start and end are specified: cut leading and trailing margins
+- start only: cut leading margin and keep through the source end
+- end only: keep from the source beginning and cut trailing margin
+- no start and no end: do not trim; either skip this process or copy/re-encode
+  into the job directory only if a normalized workflow needs a staged file
+
+## VLC Cut Memo Hand-off
+
+When the user needs to inspect recordings manually, give them a compact memo
+format to fill in and return. Prefer this format for a single file:
+
+```text
+cut memo:
+- input: 260114_160901_TrMic.WAV
+- start: 00:01:23
+- end: 00:12:34
+- output: 01_trim.wav
+- note: first movement only
+```
+
+For multiple files, ask for one item per source file, in final playback order:
+
+```text
+cut memo:
+1.
+  input: 260114_160901_TrMic.WAV
+  start: 00:01:23
+  end: 00:12:34
+  output: 01_trim.wav
+  note: first section
+2.
+  input: 260114_162430_TrMic.WAV
+  start: 00:00:08
+  end: 00:09:56
+  output: 02_trim.wav
+  note: second section
+```
+
+Accept these time formats:
+
+- `HH:MM:SS`
+- `MM:SS`
+- `HH:MM:SS.xxx` or `MM:SS.xxx` for fractional seconds
+- seconds, such as `83.5`
+
+Interpret `01:23` as 1 minute 23 seconds. For millisecond-level precision,
+prefer `00:01:23.500` or `83.5`.
+
+If the user wants the file to continue to the end, accept `end: end` or an empty
+end value and generate a command without `-to`.
+
+If the user wants the file to start from the beginning, accept `start: start`,
+`start: 0`, or an empty start value and generate a command without `-ss`.
+
+Treat the item as no-trim when the effective start is the source beginning and
+the effective end is the source end. For example, `start` empty, `start: start`,
+or `start: 0` combined with `end` empty or `end: end`. Ask whether to skip trim
+or stage the file into the job directory if that is not clear.
+
+If the cut memo contains ambiguous or missing fields, ask only for the missing
+fields. Do not ask the user to restate confirmed entries.
+
+## Agent Handling of Returned Memos
+
+When the user returns a cut memo:
+
+1. Parse the input, start, end, output, and note fields.
+2. Preserve the listed order for multiple files.
+3. Generate one trim or staging command per memo item.
+4. Write outputs under the current job directory, even if the memo only gives a
+   short output file name.
+5. Log each generated trim command to `commands.log`.
+6. Continue to the measurement phase after trim command generation.
+
+## Command
+
+For leading and trailing margin cuts, prefer:
+
+```sh
+ffmpeg -i "input.WAV" -ss 00:01:23 -to 00:12:34 -c:a pcm_f32le "workplace/h4essential-260114_160901/01_trim.wav"
+```
+
+For leading-margin-only cuts, omit `-to`:
+
+```sh
+ffmpeg -i "input.WAV" -ss 00:01:23 -c:a pcm_f32le "workplace/h4essential-260114_160901/01_trim.wav"
+```
+
+For trailing-margin-only cuts, omit `-ss`:
+
+```sh
+ffmpeg -i "input.WAV" -to 00:12:34 -c:a pcm_f32le "workplace/h4essential-260114_160901/01_trim.wav"
+```
+
+For no-trim staging, use a clear staged output name:
+
+```sh
+ffmpeg -i "input.WAV" -c:a pcm_f32le "workplace/h4essential-260114_160901/01_trim.wav"
+```
+
+If the source is not 32-bit float WAV or the user wants a simpler command, omit
+the explicit codec and let FFmpeg choose an appropriate WAV format:
+
+```sh
+ffmpeg -i "input.WAV" -ss 00:01:23 -to 00:12:34 "workplace/h4essential-260114_160901/01_trim.wav"
+```
+
+## Notes
+
+- Do not overwrite source recordings.
+- Strongly recommend VLC for confirming the cut points before generating final
+  trim commands.
+- Quote file paths.
+- Log the exact trim command to the job directory's `commands.log`.
+- Preserve each trimmed file separately in multiple-file workflows.

--- a/skills/igapyon-ffmpeg-helper/references/process/h4essential-input-discovery.md
+++ b/skills/igapyon-ffmpeg-helper/references/process/h4essential-input-discovery.md
@@ -1,0 +1,71 @@
+# H4essential Input Discovery
+
+Use this process when the user provides a copied H4essential recording folder,
+multiple recording folders, or a parent directory containing copied recording
+folders.
+
+## Expected Structure
+
+The H4essential source structure commonly looks like this:
+
+```text
+/Volumes/ZOOM_H4E/260114_160901/
+  260114_160901_TrMic.WAV
+```
+
+In real use, processing starts after one or more recording folders such as
+`260114_160901` have been copied locally.
+
+## Discovery Steps
+
+1. Inspect the directory before generating final commands.
+2. Recursively find `.WAV` and `.wav` files.
+3. Group candidates by recording folder when possible.
+4. Prefer H4essential track-name awareness over treating every WAV as equal.
+5. Show the detected candidates and ask the user to confirm the track choice and
+   order before proceeding when multiple plausible files exist.
+
+Useful discovery command:
+
+```sh
+find "<input-dir>" -type f \( -iname '*.WAV' -o -iname '*.wav' \)
+```
+
+## Track Names
+
+Use these H4essential track-name meanings:
+
+- `TrMic`: built-in XY microphone.
+- `Tr1`: input track 1.
+- `Tr2`: input track 2.
+- `TrLR`: stereo mix of tracks.
+
+Default candidate ordering:
+
+1. `*_TrMic.WAV` / `*_TrMic.wav` for built-in mic workflows.
+2. `*_TrLR.WAV` / `*_TrLR.wav` when the user used external inputs or wants the
+   stereo mix.
+3. `*_Tr1.WAV`, `*_Tr2.WAV`, and other tracks when explicitly relevant.
+4. Other `.WAV` / `.wav` files only as fallback candidates.
+
+When candidates include both `TrMic` and `TrLR`, do not silently choose between
+them unless the user has already stated the recording source. For external mic
+or line-input work, expect that `TrMic` may not be the desired file.
+
+## Candidate Presentation
+
+Present candidates grouped by recording folder:
+
+```text
+260114_160901
+  - 260114_160901_TrMic.WAV  built-in XY microphone
+  - 260114_160901_TrLR.WAV   stereo mix
+  - 260114_160901_Tr1.WAV    input track 1
+  - 260114_160901_Tr2.WAV    input track 2
+```
+
+Ask the user to confirm:
+
+- which track to use for each folder
+- whether the file order is correct
+- whether any detected file should be skipped

--- a/skills/igapyon-ffmpeg-helper/references/process/peak-gain-normalize.md
+++ b/skills/igapyon-ffmpeg-helper/references/process/peak-gain-normalize.md
@@ -1,0 +1,108 @@
+# Peak-Based Simple Gain Adjustment
+
+Use this process for the first-cut audio normalization policy. It is modeled on
+the simple-gain route of the local-html-tools FFmpeg Loudnorm command generator,
+but only the volume-only route is used for finishing.
+
+## Policy
+
+- Run FFmpeg twice: measurement phase, then finishing phase.
+- Measurement phase: use `loudnorm=print_format=json` to obtain `input_tp`.
+- Finishing phase: use `volume=...dB` only.
+- Target true peak: `-0.5 dBTP`.
+- Do not use compression.
+- Do not use limiting.
+- Do not use loudness normalization in the finishing command.
+- If `input_tp` is already above `-0.5 dBTP`, apply negative gain.
+- Let the user choose hi-res or lo-res output for the finishing command.
+
+## Output Resolution Choice
+
+Use these output settings:
+
+```text
+hi-res:
+  -ar 192000
+  -sample_fmt s32
+  -c:a pcm_s24le
+
+lo-res:
+  -ar 44100
+  -sample_fmt s16
+  -c:a pcm_s16le
+```
+
+If the user does not choose, ask once. For YouTube upload video creation, the
+later video step still converts audio to AAC 48 kHz.
+
+## Phase 1: Measurement
+
+Generate a measurement command that writes the loudnorm JSON output to a file.
+Prefer redirection over `tee` so command failure is easier to detect.
+
+```sh
+ffmpeg -hide_banner -i "workplace/h4essential-260114_160901/01_trim.wav" -af loudnorm=print_format=json -f null - > "workplace/h4essential-260114_160901/01_gain-meta.json" 2>&1
+```
+
+Ask the user to paste the JSON measurement output when you cannot run the
+command yourself. The required value is `input_tp`.
+
+Before generating a finishing command, verify that the measurement output
+contains a parseable JSON object and a numeric `input_tp`. If `input_tp` is
+missing or not numeric, stop and inspect the measurement output instead of
+guessing a gain value.
+
+## Calculate Gain
+
+Compute gain as:
+
+```text
+gain_db = -0.5 - input_tp
+```
+
+Round to one decimal place for the generated command, matching the existing
+local-html-tools behavior.
+
+Examples:
+
+- `input_tp: -7.3` -> `gain_db = +6.8`
+- `input_tp: -1.2` -> `gain_db = +0.7`
+- `input_tp: 0.0` -> `gain_db = -0.5`
+
+## Phase 2: Finishing
+
+Generate a `volume=XdB` command. Do not add compression, limiting, or loudnorm
+normalization.
+
+Lo-res output:
+
+```sh
+ffmpeg -i "workplace/h4essential-260114_160901/01_trim.wav" -af "volume=+6.8dB" -ar 44100 -sample_fmt s16 -c:a pcm_s16le "workplace/h4essential-260114_160901/01_gain-lores-tp0p5-plain.wav"
+```
+
+Hi-res output:
+
+```sh
+ffmpeg -i "workplace/h4essential-260114_160901/01_trim.wav" -af "volume=+6.8dB" -ar 192000 -sample_fmt s32 -c:a pcm_s24le "workplace/h4essential-260114_160901/01_gain-hires-tp0p5-plain.wav"
+```
+
+For multiple WAVs, repeat both phases separately for each trimmed WAV before
+concatenation.
+
+Log both the measurement command and the finishing command to the job
+directory's `commands.log`.
+
+## Phase 3: Verification Measurement
+
+After finishing, run a verification measurement on the gain-adjusted output.
+This is not another processing pass; it only confirms the resulting peak.
+
+Lo-res example:
+
+```sh
+ffmpeg -hide_banner -i "workplace/h4essential-260114_160901/01_gain-lores-tp0p5-plain.wav" -af loudnorm=print_format=json -f null - > "workplace/h4essential-260114_160901/01_gain-verify-meta.json" 2>&1
+```
+
+Check that the verification output contains a numeric `input_tp` close to the
+target. If the value is materially different from `-0.5 dBTP`, report it and
+ask before applying another gain pass.

--- a/skills/igapyon-ffmpeg-helper/references/process/still-image-youtube-video.md
+++ b/skills/igapyon-ffmpeg-helper/references/process/still-image-youtube-video.md
@@ -1,0 +1,48 @@
+# Still Image + Audio YouTube Video
+
+Use this process to create a YouTube-uploadable video from one still image and
+one audio file.
+
+## Inputs
+
+Ask for these if missing:
+
+- still image path
+- normalized audio path
+- output video path
+
+The still image may be a jacket, cover, title card, or other manually prepared
+image.
+
+## First-Cut Defaults
+
+- Container: MP4.
+- Video codec: H.264 via `libx264`.
+- Pixel format: `yuv420p`.
+- Tune: `stillimage`.
+- Resolution: 1920x1080 unless the user requests otherwise.
+- Image fit: preserve the entire image and pad to 16:9.
+- Audio codec: AAC.
+- Audio sample rate: 48 kHz.
+- Audio bitrate: 320 kbps.
+- MP4 fast start: include `-movflags +faststart`.
+
+## Command
+
+For multiple-file workflows, use the merged gain-adjusted WAV:
+
+```sh
+ffmpeg -loop 1 -framerate 2 -i "cover.png" -i "workplace/h4essential-260114_160901/merged_gain-lores-tp0p5-plain.wav" \
+  -vf "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2" \
+  -c:v libx264 -tune stillimage -pix_fmt yuv420p \
+  -c:a aac -b:a 320k -ar 48000 \
+  -movflags +faststart \
+  -shortest "workplace/h4essential-260114_160901/youtube_upload.mp4"
+```
+
+For a single-file workflow, use
+`workplace/h4essential-260114_160901/01_gain-lores-tp0p5-plain.wav` instead of
+`workplace/h4essential-260114_160901/merged_gain-lores-tp0p5-plain.wav`. For
+hi-res workflows, use the corresponding `*-hires-tp0p5-plain.wav` file.
+
+Log the video creation command to the job directory's `commands.log`.

--- a/skills/igapyon-ffmpeg-helper/references/process/workspace-and-command-log.md
+++ b/skills/igapyon-ffmpeg-helper/references/process/workspace-and-command-log.md
@@ -1,0 +1,87 @@
+# Workspace and Command Log
+
+Use this process before generating conversion commands.
+
+## Workspace Directory
+
+Create a per-job directory under `workplace/`. Prefer a name derived from the
+recording folder or project:
+
+```text
+workplace/h4essential-260114_160901/
+workplace/h4essential-260114_160901-youtube/
+workplace/orchestra-20260114-youtube/
+```
+
+If multiple recording folders are involved, use the first folder name or a short
+project name:
+
+```text
+workplace/h4essential-260114_160901-merged/
+```
+
+Do not write generated audio/video files next to source recordings unless the
+user explicitly asks.
+
+## Initialize Log
+
+Create `commands.log` in the job directory. It records the exact commands that
+were executed or handed to the user. Because this is a working directory, it is
+also acceptable and preferred to keep auxiliary logs and diagnostic output files
+there.
+
+```sh
+mkdir -p "workplace/h4essential-260114_160901"
+printf '# igapyon-ffmpeg-helper command log\n# Created: %s\n\n' "$(date '+%Y-%m-%d %H:%M:%S %z')" > "workplace/h4essential-260114_160901/commands.log"
+```
+
+## Mandatory FFmpeg Version Check
+
+Run `ffmpeg -version` before any conversion command and record the exact command
+in `commands.log`. Also save the version output for later troubleshooting.
+
+```sh
+printf '%s\n' 'ffmpeg -version > "workplace/h4essential-260114_160901/ffmpeg-version.txt"' >> "workplace/h4essential-260114_160901/commands.log"
+ffmpeg -version > "workplace/h4essential-260114_160901/ffmpeg-version.txt"
+```
+
+If this fails, stop the workflow before generating or running conversion
+commands.
+
+## Log a Command
+
+Before running or presenting a command, append it to `commands.log`.
+
+```sh
+printf '%s\n' 'ffmpeg -i "input.WAV" -ss 00:01:23 -to 00:12:34 -c:a pcm_f32le "workplace/h4essential-260114_160901/01_trim.wav"' >> "workplace/h4essential-260114_160901/commands.log"
+```
+
+When commands are multi-line for readability, log the exact one-line form that
+can be copied and executed.
+
+## Capture Command Output When Useful
+
+For measurement commands, keep both the command log and the measurement output.
+
+Example:
+
+```sh
+printf '%s\n' 'ffmpeg -hide_banner -i "workplace/h4essential-260114_160901/01_trim.wav" -af loudnorm=print_format=json -f null - > "workplace/h4essential-260114_160901/01_gain-meta.json" 2>&1' >> "workplace/h4essential-260114_160901/commands.log"
+ffmpeg -hide_banner -i "workplace/h4essential-260114_160901/01_trim.wav" -af loudnorm=print_format=json -f null - > "workplace/h4essential-260114_160901/01_gain-meta.json" 2>&1
+```
+
+Do not treat `commands.log` as a full terminal transcript. It is a concise
+record of commands. Store measurement JSON, FFmpeg stderr/stdout captures,
+version output, verification output, and other troubleshooting data as separate
+files in the same job directory.
+
+Suggested auxiliary files:
+
+```text
+ffmpeg-version.txt
+01_gain-meta.json
+01_gain-verify-meta.json
+01_trim.log
+01_gain.log
+youtube-video.log
+```

--- a/skills/igapyon-ffmpeg-helper/references/process/youtube-manual-upload.md
+++ b/skills/igapyon-ffmpeg-helper/references/process/youtube-manual-upload.md
@@ -1,0 +1,26 @@
+# YouTube Manual Upload
+
+Use this process as the final step of the first-cut workflow.
+
+## Policy
+
+The first-cut workflow ends with a YouTube-uploadable video file. Upload is
+manual through the YouTube Studio Web UI.
+
+Do not introduce any of the following unless the user explicitly asks to expand
+the skill:
+
+- YouTube API upload
+- OAuth setup
+- scheduled publishing
+- title or description automation
+- thumbnail API registration
+- public/private visibility automation
+
+## Final Message
+
+End the workflow by pointing to the generated upload file:
+
+```text
+生成された `workplace/h4essential-260114_160901/youtube_upload.mp4` を YouTube Studio から手動アップロードしてください。
+```

--- a/skills/igapyon-ffmpeg-helper/references/workflows/h4essential-orchestra-youtube.md
+++ b/skills/igapyon-ffmpeg-helper/references/workflows/h4essential-orchestra-youtube.md
@@ -1,0 +1,144 @@
+# H4essential Orchestra Recording to YouTube Workflow
+
+Use this workflow for the first-cut `igapyon-ffmpeg-helper` route:
+
+```text
+H4essential orchestra recording folders
+  -> select WAV tracks
+  -> trim unnecessary portions
+  -> measurement phase with loudnorm JSON
+  -> finishing phase with volume-only gain to target peak -0.5 dBTP
+  -> optionally concatenate adjusted files
+  -> combine still image + audio into a YouTube-uploadable video
+  -> manual upload in YouTube Studio
+```
+
+## Scope
+
+This workflow is intentionally personal and narrow:
+
+- Source: ZOOM H4essential recording folders copied to local storage.
+- Main use case: orchestra or ensemble rehearsal recording.
+- Final target: YouTube-uploadable video file.
+- Upload method: manual upload through YouTube Studio.
+- Cut points and file boundaries: human judgment in the first cut. Strongly
+  recommend checking the recording in VLC before deciding start/end times or
+  where multiple files should join.
+
+Do not turn this into a generic FFmpeg workflow unless the user asks to expand
+the skill.
+
+## Prerequisites
+
+This workflow requires the `ffmpeg` CLI to be available in the shell. Running
+`ffmpeg -version` is mandatory before any workflow command is executed. Record
+the command in `commands.log` and save the output as `ffmpeg-version.txt` in the
+job directory:
+
+```sh
+ffmpeg -version > "workplace/h4essential-260114_160901/ffmpeg-version.txt"
+```
+
+If `ffmpeg -version` fails or `ffmpeg` is unavailable, stop and ask the user to
+install or expose it in `PATH`.
+
+## Initial Confirmation
+
+Confirm the route once at the beginning:
+
+```text
+H4essentialのオーケストラ録音から、切り出し、loudnorm JSON測定、-0.5 dBTPピーク基準の単純ゲイン仕上げ、必要なら結合、静止画付きYouTube用動画作成まで進めますか？
+```
+
+After confirmation, ask only for missing inputs needed for the next command.
+
+For trim points and file boundaries, do not pretend to infer musical cut points
+automatically. Ask the user to confirm times after listening in VLC.
+Trimming may cut both margins, only the beginning, only the end, or nothing.
+
+When trim points are unknown, ask the user to inspect the recording in VLC and
+return a cut memo using the format in
+[../process/audio-trim.md](../process/audio-trim.md). Treat that memo as the
+source of truth for trim command generation.
+
+## Modes
+
+Classify the request into one mode:
+
+- Single WAV: one selected recording track becomes one final YouTube video.
+- Multiple WAVs: several selected recording tracks are processed individually
+  and then concatenated.
+- Already trimmed: skip trim and start from the measurement phase.
+- No trim needed: skip trim, or stage the source into the job directory if a
+  staged file is useful for consistent later commands.
+- Already adjusted: skip gain adjustment and start from concat or video
+  creation.
+- Still-image-only missing: help create or locate the still image if the user
+  asks, otherwise request the still image path.
+
+## Process Order
+
+Use these process runbooks in order:
+
+1. [../process/h4essential-input-discovery.md](../process/h4essential-input-discovery.md)
+2. [../process/workspace-and-command-log.md](../process/workspace-and-command-log.md)
+3. [../process/audio-trim.md](../process/audio-trim.md)
+4. [../process/peak-gain-normalize.md](../process/peak-gain-normalize.md)
+5. [../process/audio-concat.md](../process/audio-concat.md), only when multiple
+   adjusted WAV files must be joined
+6. [../process/still-image-youtube-video.md](../process/still-image-youtube-video.md)
+7. [../process/youtube-manual-upload.md](../process/youtube-manual-upload.md)
+
+## Output Naming
+
+Prefer a per-job directory under `workplace/`, following the convention used by
+the other igapyon Agent Skills. If the user does not give names, propose names
+like these:
+
+```text
+workplace/h4essential-260114_160901/
+  commands.log
+  01_trim.wav
+  01_gain-meta.json
+  01_gain-lores-tp0p5-plain.wav
+  02_trim.wav
+  02_gain-meta.json
+  02_gain-lores-tp0p5-plain.wav
+  concat_list.txt
+  merged_gain-lores-tp0p5-plain.wav
+  youtube_upload.mp4
+```
+
+For a single file, use:
+
+```text
+workplace/h4essential-260114_160901/
+  commands.log
+  01_trim.wav
+  01_gain-meta.json
+  01_gain-lores-tp0p5-plain.wav
+  youtube_upload.mp4
+```
+
+Do not overwrite source recordings. Generated commands should write to
+the per-job `workplace/` directory or clearly named output files.
+
+## First-Cut Audio Policy
+
+For this workflow:
+
+- Use simple peak-based gain adjustment.
+- Run FFmpeg twice for audio adjustment: measurement phase, then finishing
+  phase.
+- Measurement phase: use `loudnorm=print_format=json` to obtain `input_tp`.
+- Finishing phase: use `volume=...dB` only.
+- Target peak: `-0.5 dBTP`.
+- Do not use compression.
+- Do not use loudness normalization for finishing.
+- Let the user choose hi-res or lo-res output:
+  - hi-res: 192 kHz / 24-bit WAV.
+  - lo-res: 44.1 kHz / 16-bit WAV.
+- For multiple WAV files, normalize each trimmed file before concatenation.
+
+This is a practical workflow choice to preserve the natural sound of the
+orchestra recording. Future workflows may use different policies.


### PR DESCRIPTION
## 概要

H4essential のオーケストラ録音を FFmpeg で処理するための個人用 Agent Skill `igapyon-ffmpeg-helper` を追加しました。

録音トラックの確認、切り出し、loudnorm JSON による測定、単純ゲイン調整、必要に応じた結合、静止画付き YouTube 用動画作成、YouTube Studio での手動アップロードまでを扱う runbook 構成になっています。

## 変更内容

- `skills/igapyon-ffmpeg-helper/` を新規 Agent Skill として追加
- hard trigger 前提の発火条件と、通常の FFmpeg 相談では自動適用しないガードレールを定義
- H4essential オーケストラ録音から YouTube 用動画を作成する workflow runbook を追加
- 以下の process runbook を追加
  - H4essential 入力ファイル探索
  - 作業ディレクトリと `commands.log` 管理
  - 音声トリミング
  - loudnorm JSON 測定と `volume=...dB` によるピーク基準ゲイン調整
  - 音声結合
  - 静止画 + 音声の YouTube 用 MP4 作成
  - YouTube Studio 手動アップロード
- `agents/openai.yaml` と `index.json` を追加
- `README.md` の skill 一覧に `igapyon-ffmpeg-helper` を追加
- `TODO.md` に作成内容、処理方針、確認済み項目、今後の確認候補を追記