### PR TITLE
igapyon-ffmpeg-helper の YouTube 出力方針を強化

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260525.1</version>
+  <version>1.20260602.1</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>

--- a/skills/igapyon-ffmpeg-helper/SKILL.md
+++ b/skills/igapyon-ffmpeg-helper/SKILL.md
@@ -71,6 +71,9 @@ Use `index.json` as the discovery index when you need to confirm available
 reference files, but treat `SKILL.md` and files under `references/` as the
 source of truth.
 
+For the reasoning behind the current YouTube output defaults, see
+[references/decisions/youtube-output-policy.md](references/decisions/youtube-output-policy.md).
+
 ## Prerequisites
 
 Running generated commands requires the `ffmpeg` CLI to be available in the
@@ -97,7 +100,9 @@ Unless the user explicitly changes the first-cut workflow:
   the finish command.
 - Target peak is `-0.5 dBTP`.
 - Do not use compression.
-- Let the user choose hi-res or lo-res output for the finish command.
+- Let the user choose hi-res or lo-res output for the finish command; default
+  to hi-res when the user does not specify.
+- Tell the user that hi-res intermediate WAV files will be larger.
 - For multiple WAVs, trim and gain-adjust each selected WAV first, then
   concatenate.
 - End at a YouTube-uploadable video file.
@@ -118,8 +123,8 @@ When using this skill:
 - Preserve source files and avoid destructive commands.
 - Use quoted paths in generated shell commands.
 - Put generated working files under a per-job directory such as
-  `workplace/h4essential-260114_160901/` by default.
-- Keep a command log such as `workplace/h4essential-260114_160901/commands.log`
+  `workplace/ffmpeg-helper-260114_160901/` by default.
+- Keep a command log such as `workplace/ffmpeg-helper-260114_160901/commands.log`
   and record the exact commands that are executed or handed to the user.
 - It is acceptable and preferred to write auxiliary logs, measurement outputs,
   and troubleshooting files inside the per-job `workplace/` directory.

--- a/skills/igapyon-ffmpeg-helper/index.json
+++ b/skills/igapyon-ffmpeg-helper/index.json
@@ -3,14 +3,15 @@
  "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
  "basePath": ".",
  "files": [
-  {"name":"audio-concat.md","path":"references/process/audio-concat.md","ext":"md","dir":"references/process","size":1424,"summary":"Audio Concatenation"},
-  {"name":"audio-trim.md","path":"references/process/audio-trim.md","ext":"md","dir":"references/process","size":4379,"summary":"Audio Trim"},
+  {"name":"youtube-output-policy.md","path":"references/decisions/youtube-output-policy.md","ext":"md","dir":"references/decisions","size":5212,"summary":"YouTube Output Policy Decision"},
+  {"name":"audio-concat.md","path":"references/process/audio-concat.md","ext":"md","dir":"references/process","size":1676,"summary":"Audio Concatenation"},
+  {"name":"audio-trim.md","path":"references/process/audio-trim.md","ext":"md","dir":"references/process","size":5865,"summary":"Audio Trim"},
   {"name":"h4essential-input-discovery.md","path":"references/process/h4essential-input-discovery.md","ext":"md","dir":"references/process","size":2125,"summary":"H4essential Input Discovery"},
-  {"name":"peak-gain-normalize.md","path":"references/process/peak-gain-normalize.md","ext":"md","dir":"references/process","size":3448,"summary":"Peak-Based Simple Gain Adjustment"},
-  {"name":"still-image-youtube-video.md","path":"references/process/still-image-youtube-video.md","ext":"md","dir":"references/process","size":1504,"summary":"Still Image + Audio YouTube Video"},
-  {"name":"workspace-and-command-log.md","path":"references/process/workspace-and-command-log.md","ext":"md","dir":"references/process","size":2951,"summary":"Workspace and Command Log"},
-  {"name":"youtube-manual-upload.md","path":"references/process/youtube-manual-upload.md","ext":"md","dir":"references/process","size":705,"summary":"YouTube Manual Upload"},
-  {"name":"h4essential-orchestra-youtube.md","path":"references/workflows/h4essential-orchestra-youtube.md","ext":"md","dir":"references/workflows","size":5164,"summary":"H4essential Orchestra Recording to YouTube Workflow"},
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":5656,"description":"Use only on hard trigger: the user explicitly names igapyon-ffmpeg-helper, says to use/apply the FFmpeg helper skill, or uses a specific activation phrase such as igapyon FFmpeg helper, ffmpeg helper workflow, FFmpeg helper runbook, ffmpeg runbook igapyon, or igapyon ffmpeg runbook. This skill is for igapyon's personal FFmpeg runbooks, including the H4essential orchestra recording to YouTube workflow. Do not use for ordinary FFmpeg questions, H4essential mentions, YouTube/video/audio conversion questions, loudnorm/gain questions, or generic workflow discussion unless the user explicitly triggers this skill.","summary":"igapyon-ffmpeg-helper"}
+  {"name":"peak-gain-normalize.md","path":"references/process/peak-gain-normalize.md","ext":"md","dir":"references/process","size":4337,"summary":"Peak-Based Simple Gain Adjustment"},
+  {"name":"still-image-youtube-video.md","path":"references/process/still-image-youtube-video.md","ext":"md","dir":"references/process","size":7056,"summary":"Still Image + Audio YouTube Video"},
+  {"name":"workspace-and-command-log.md","path":"references/process/workspace-and-command-log.md","ext":"md","dir":"references/process","size":3050,"summary":"Workspace and Command Log"},
+  {"name":"youtube-manual-upload.md","path":"references/process/youtube-manual-upload.md","ext":"md","dir":"references/process","size":714,"summary":"YouTube Manual Upload"},
+  {"name":"h4essential-orchestra-youtube.md","path":"references/workflows/h4essential-orchestra-youtube.md","ext":"md","dir":"references/workflows","size":6329,"summary":"H4essential Orchestra Recording to YouTube Workflow"},
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":5942,"description":"Use only on hard trigger: the user explicitly names igapyon-ffmpeg-helper, says to use/apply the FFmpeg helper skill, or uses a specific activation phrase such as igapyon FFmpeg helper, ffmpeg helper workflow, FFmpeg helper runbook, ffmpeg runbook igapyon, or igapyon ffmpeg runbook. This skill is for igapyon's personal FFmpeg runbooks, including the H4essential orchestra recording to YouTube workflow. Do not use for ordinary FFmpeg questions, H4essential mentions, YouTube/video/audio conversion questions, loudnorm/gain questions, or generic workflow discussion unless the user explicitly triggers this skill.","summary":"igapyon-ffmpeg-helper"}
  ]
 }

--- a/skills/igapyon-ffmpeg-helper/references/decisions/youtube-output-policy.md
+++ b/skills/igapyon-ffmpeg-helper/references/decisions/youtube-output-policy.md
@@ -1,0 +1,166 @@
+# YouTube Output Policy Decision
+
+This note records the reasoning behind the current YouTube output defaults for
+`igapyon-ffmpeg-helper`.
+
+## Context
+
+This skill started from the FFmpeg tools under:
+
+```text
+/Users/igapyon/Documents/git/local-html-tools/docs/ffmpeg
+```
+
+The source tool `ffmpeg-youtube-mkv-gen` used two routes:
+
+- YouTube preset: `.mkv`
+- General video preset: `.mp4`
+
+That local tool is still useful context, especially because the MKV route can
+preserve prepared WAV audio with `-c:a copy`.
+
+However, this skill is a runbook for producing a file that is likely to upload
+cleanly through YouTube Studio. For that purpose, YouTube's current official
+recommendations carry more weight than the historical local default.
+
+## Decision
+
+Use MP4/H.264/AAC-LC as the default YouTube upload route.
+
+Keep MKV as an explicit source-preserving option only when the user asks to
+avoid audio re-encoding or specifically wants the local-html-tools-style MKV
+route.
+
+## Rationale
+
+YouTube's recommended upload settings currently name:
+
+- Container: MP4
+- Video codec: H.264
+- Progressive scan
+- High Profile
+- 2 B-frames
+- Closed GOP, with GOP length half the frame rate
+- Chroma subsampling: 4:2:0
+- Audio codec: AAC-LC, Opus, or Eclipsa Audio
+- Audio sample rate: 48 kHz
+- Stereo audio bitrate: 384 kbps
+- SDR color space: BT.709
+
+YouTube's supported file format list includes MP4 but does not list MKV. This
+does not prove that every MKV upload will fail, but it makes MP4 the safer
+default for routine manual uploads.
+
+## Current Default Command Shape
+
+The default still-image video command therefore uses:
+
+```text
+MP4 container
+H.264 / libx264
+High Profile
+30 fps
+closed GOP with -g 15
+2 B-frames
+yuv420p
+BT.709 tags via x264 parameters
+AAC-LC audio
+48 kHz audio sample rate
+384 kbps stereo audio bitrate
+faststart moov atom
+```
+
+## Frame Rate Philosophy
+
+The default frame rate is 30 fps even for a static-image video.
+
+A lower frame rate such as 2 fps can work technically because the picture does
+not move. It may also reduce video data. However, the purpose of this skill is
+not to minimize every byte; it is to generate a predictable YouTube upload file
+with conservative compatibility.
+
+For that reason, 30 fps is the default:
+
+- It matches YouTube's common upload frame-rate examples.
+- It keeps the still-image video close to ordinary YouTube video expectations.
+- It makes the GOP rule simple: with 30 fps, half-frame-rate GOP is `-g 15`.
+- It avoids making a special low-fps file unless the user explicitly wants that
+  tradeoff.
+
+If a lower frame rate is used, adjust GOP length to half the chosen frame rate
+where practical, and explain that 30 fps remains the safer YouTube compatibility
+default.
+
+## Duration Philosophy
+
+Static-image videos use `-loop 1`, which makes the image input effectively
+endless. `-shortest` is useful, but it should not be the only duration control
+when an exact YouTube upload duration matters.
+
+The observed failure mode is:
+
+```text
+audio duration: 10:35
+MP4/container duration: 11:04.50
+```
+
+This can happen because the video stream is synthesized from an endless still
+image input, and FFmpeg/libx264 has frame timestamps, encoder lookahead, B-frame
+reordering, and frame-rate rounding to resolve at the end of the file. Low frame
+rates such as 2 fps make each video timestamp coarser, which can make this kind
+of mismatch more visible.
+
+The robust rule is:
+
+- Measure the prepared audio duration with `ffprobe`.
+- Add `-t AUDIO_DURATION` to the still-image video command.
+- Keep `-shortest` as an extra guard.
+- Verify the final MP4 duration with `ffprobe`.
+
+With the current 30 fps default, this problem is less likely than with 2 fps,
+but explicit `-t` is still the cleaner rule when the audio duration is known.
+
+## Audio Philosophy
+
+The audio workflow preserves natural orchestra recording dynamics by using
+simple peak-based gain:
+
+- measure with `loudnorm=print_format=json`
+- compute gain from `input_tp`
+- finish with `volume=...dB`
+- target true peak: `-0.5 dBTP`
+- no compression
+- no loudness normalization in the finishing pass
+
+When the user does not choose output resolution for the intermediate WAV, use
+hi-res by default:
+
+```text
+192 kHz / 24-bit WAV
+```
+
+Tell the user that hi-res intermediate WAV files will be larger. The final
+default YouTube MP4 still converts the prepared WAV audio to AAC-LC.
+
+## Image Philosophy
+
+For the in-video still image, use 16:9 at 1920x1080 by default. This matches the
+default 1080p video command.
+
+For custom thumbnails, tell the user the current official recommendation is
+3840x2160 at 16:9. A lighter 1280x720 16:9 thumbnail remains a practical
+fallback when the user wants a smaller image.
+
+Keep important text and faces away from the edges because YouTube UI overlays
+and cropping can hide edge content.
+
+## Operational Rule
+
+When answering the user, be direct:
+
+```text
+YouTube 公式推奨に寄せるなら MP4/H.264/AAC が無難です。MKV は WAV 音声を再エンコードせずに入れやすい利点がありますが、アップロード互換性の安全側では MP4 を既定にします。
+```
+
+Do not turn this into a generic FFmpeg policy unless the user asks to expand the
+skill.

--- a/skills/igapyon-ffmpeg-helper/references/process/audio-concat.md
+++ b/skills/igapyon-ffmpeg-helper/references/process/audio-concat.md
@@ -6,7 +6,7 @@ file.
 ## Policy
 
 For the first-cut H4essential workflow, concatenate only after each selected WAV
-has already been trimmed and gain-adjusted.
+or selected part has already been trimmed and gain-adjusted.
 
 Use the same output resolution choice for all files before concatenation. Do not
 mix hi-res and lo-res adjusted files in one concat list.
@@ -21,18 +21,26 @@ file '02_gain-lores-tp0p5-plain.wav'
 file '03_gain-lores-tp0p5-plain.wav'
 ```
 
+For multiple parts cut from one source WAV, prefer names that preserve the
+recording id and part number:
+
+```text
+file '260503_113659-part1_gain-hires-tp0p5-plain.wav'
+file '260503_113659-part2_gain-hires-tp0p5-plain.wav'
+```
+
 ## Command
 
 Try stream copy first when the files have matching formats:
 
 ```sh
-ffmpeg -f concat -safe 0 -i "workplace/h4essential-260114_160901/concat_list.txt" -c copy "workplace/h4essential-260114_160901/merged_gain-lores-tp0p5-plain.wav"
+ffmpeg -f concat -safe 0 -i "workplace/ffmpeg-helper-260114_160901/concat_list.txt" -c copy "workplace/ffmpeg-helper-260114_160901/merged_gain-lores-tp0p5-plain.wav"
 ```
 
 If `-c copy` fails because formats differ, fall back to re-encoding:
 
 ```sh
-ffmpeg -f concat -safe 0 -i "workplace/h4essential-260114_160901/concat_list.txt" -ar 44100 -sample_fmt s16 -c:a pcm_s16le "workplace/h4essential-260114_160901/merged_gain-lores-tp0p5-plain.wav"
+ffmpeg -f concat -safe 0 -i "workplace/ffmpeg-helper-260114_160901/concat_list.txt" -ar 44100 -sample_fmt s16 -c:a pcm_s16le "workplace/ffmpeg-helper-260114_160901/merged_gain-lores-tp0p5-plain.wav"
 ```
 
 ## Notes

--- a/skills/igapyon-ffmpeg-helper/references/process/audio-trim.md
+++ b/skills/igapyon-ffmpeg-helper/references/process/audio-trim.md
@@ -16,7 +16,8 @@ Ask for these if missing:
 - end time, optional
 - output WAV path
 
-Use one trim command per selected WAV in multiple-file workflows.
+Use one trim command per selected WAV in multiple-file workflows. Also use one
+trim command per cut when a single source WAV is split into multiple parts.
 
 If trim times are missing, ask the user to listen in VLC and provide the start
 and/or end times when trimming is needed. Do not infer musical cut points
@@ -62,6 +63,59 @@ cut memo:
   note: second section
 ```
 
+For a single source WAV split into multiple parts, keep the same input path and
+ask for one item per part:
+
+```text
+cut memo:
+1.
+  input: 260503_113659_TrMic.WAV
+  start: 00:07:06
+  end: 00:17:41
+  output: 260503_113659-part1_trim.wav
+  note: first piece
+2.
+  input: 260503_113659_TrMic.WAV
+  start: 00:19:10
+  end: 00:28:42
+  output: 260503_113659-part2_trim.wav
+  note: second piece
+```
+
+## Part Naming
+
+When a single source WAV is split into multiple musical items or sections, use
+`part1`, `part2`, and so on. Keep the original H4essential recording id at the
+front of every generated filename.
+
+Recommended pattern:
+
+```text
+<recording-id>-partN_trim.wav
+<recording-id>-partN_gain-meta.json
+<recording-id>-partN_gain-hires-tp0p5-plain.wav
+<recording-id>-partN_gain-verify-meta.json
+<recording-id>-partN-youtube.mp4
+```
+
+Example:
+
+```text
+260503_113659-part1_trim.wav
+260503_113659-part1_gain-hires-tp0p5-plain.wav
+260503_113659-part1-youtube.mp4
+```
+
+For a concatenated final output made from several parts of the same source, use:
+
+```text
+260503_113659-parts-merged-youtube.mp4
+```
+
+Avoid generic stage names like `01_trim.wav` when the source is being split into
+multiple deliverables. Numbered names are acceptable for internal scratch files,
+but final and logged artifacts should preserve the recording id and part number.
+
 Accept these time formats:
 
 - `HH:MM:SS`
@@ -92,7 +146,8 @@ When the user returns a cut memo:
 
 1. Parse the input, start, end, output, and note fields.
 2. Preserve the listed order for multiple files.
-3. Generate one trim or staging command per memo item.
+3. Generate one trim or staging command per memo item, including multiple parts
+   from the same input WAV.
 4. Write outputs under the current job directory, even if the memo only gives a
    short output file name.
 5. Log each generated trim command to `commands.log`.
@@ -103,32 +158,32 @@ When the user returns a cut memo:
 For leading and trailing margin cuts, prefer:
 
 ```sh
-ffmpeg -i "input.WAV" -ss 00:01:23 -to 00:12:34 -c:a pcm_f32le "workplace/h4essential-260114_160901/01_trim.wav"
+ffmpeg -i "input.WAV" -ss 00:01:23 -to 00:12:34 -c:a pcm_f32le "workplace/ffmpeg-helper-260114_160901/01_trim.wav"
 ```
 
 For leading-margin-only cuts, omit `-to`:
 
 ```sh
-ffmpeg -i "input.WAV" -ss 00:01:23 -c:a pcm_f32le "workplace/h4essential-260114_160901/01_trim.wav"
+ffmpeg -i "input.WAV" -ss 00:01:23 -c:a pcm_f32le "workplace/ffmpeg-helper-260114_160901/01_trim.wav"
 ```
 
 For trailing-margin-only cuts, omit `-ss`:
 
 ```sh
-ffmpeg -i "input.WAV" -to 00:12:34 -c:a pcm_f32le "workplace/h4essential-260114_160901/01_trim.wav"
+ffmpeg -i "input.WAV" -to 00:12:34 -c:a pcm_f32le "workplace/ffmpeg-helper-260114_160901/01_trim.wav"
 ```
 
 For no-trim staging, use a clear staged output name:
 
 ```sh
-ffmpeg -i "input.WAV" -c:a pcm_f32le "workplace/h4essential-260114_160901/01_trim.wav"
+ffmpeg -i "input.WAV" -c:a pcm_f32le "workplace/ffmpeg-helper-260114_160901/01_trim.wav"
 ```
 
 If the source is not 32-bit float WAV or the user wants a simpler command, omit
 the explicit codec and let FFmpeg choose an appropriate WAV format:
 
 ```sh
-ffmpeg -i "input.WAV" -ss 00:01:23 -to 00:12:34 "workplace/h4essential-260114_160901/01_trim.wav"
+ffmpeg -i "input.WAV" -ss 00:01:23 -to 00:12:34 "workplace/ffmpeg-helper-260114_160901/01_trim.wav"
 ```
 
 ## Notes

--- a/skills/igapyon-ffmpeg-helper/references/process/peak-gain-normalize.md
+++ b/skills/igapyon-ffmpeg-helper/references/process/peak-gain-normalize.md
@@ -14,7 +14,9 @@ but only the volume-only route is used for finishing.
 - Do not use limiting.
 - Do not use loudness normalization in the finishing command.
 - If `input_tp` is already above `-0.5 dBTP`, apply negative gain.
-- Let the user choose hi-res or lo-res output for the finishing command.
+- Let the user choose hi-res or lo-res output for the finishing command; default
+  to hi-res when the user does not specify.
+- Tell the user that hi-res intermediate WAV files will be larger.
 
 ## Output Resolution Choice
 
@@ -32,8 +34,11 @@ lo-res:
   -c:a pcm_s16le
 ```
 
-If the user does not choose, ask once. For YouTube upload video creation, the
-later video step still converts audio to AAC 48 kHz.
+If the user does not choose, use hi-res and mention that the intermediate WAV
+file will be larger. For the default YouTube MP4 video creation step, the
+prepared WAV audio is converted to AAC. If the user explicitly asks for the
+source-preserving MKV route, the prepared WAV audio can be copied with
+`-c:a copy`.
 
 ## Phase 1: Measurement
 
@@ -41,7 +46,7 @@ Generate a measurement command that writes the loudnorm JSON output to a file.
 Prefer redirection over `tee` so command failure is easier to detect.
 
 ```sh
-ffmpeg -hide_banner -i "workplace/h4essential-260114_160901/01_trim.wav" -af loudnorm=print_format=json -f null - > "workplace/h4essential-260114_160901/01_gain-meta.json" 2>&1
+ffmpeg -hide_banner -i "workplace/ffmpeg-helper-260114_160901/01_trim.wav" -af loudnorm=print_format=json -f null - > "workplace/ffmpeg-helper-260114_160901/01_gain-meta.json" 2>&1
 ```
 
 Ask the user to paste the JSON measurement output when you cannot run the
@@ -51,6 +56,18 @@ Before generating a finishing command, verify that the measurement output
 contains a parseable JSON object and a numeric `input_tp`. If `input_tp` is
 missing or not numeric, stop and inspect the measurement output instead of
 guessing a gain value.
+
+## User-Facing Note for Low Peaks
+
+When the user asks why an H4essential recording's measured peak is low, explain
+briefly in Japanese:
+
+```text
+H4essential の 32-bit float 録音では、ピークが低めに見えることは十分あります。32-bit float は後から大きく持ち上げる前提にしやすく、クリップ回避のためのヘッドルームを広く取れるので、小さくても不自然な値ではありません。
+```
+
+Use this as supportive context only. It does not change the peak-based gain
+calculation or the `-0.5 dBTP` target.
 
 ## Calculate Gain
 
@@ -77,13 +94,13 @@ normalization.
 Lo-res output:
 
 ```sh
-ffmpeg -i "workplace/h4essential-260114_160901/01_trim.wav" -af "volume=+6.8dB" -ar 44100 -sample_fmt s16 -c:a pcm_s16le "workplace/h4essential-260114_160901/01_gain-lores-tp0p5-plain.wav"
+ffmpeg -i "workplace/ffmpeg-helper-260114_160901/01_trim.wav" -af "volume=+6.8dB" -ar 44100 -sample_fmt s16 -c:a pcm_s16le "workplace/ffmpeg-helper-260114_160901/01_gain-lores-tp0p5-plain.wav"
 ```
 
 Hi-res output:
 
 ```sh
-ffmpeg -i "workplace/h4essential-260114_160901/01_trim.wav" -af "volume=+6.8dB" -ar 192000 -sample_fmt s32 -c:a pcm_s24le "workplace/h4essential-260114_160901/01_gain-hires-tp0p5-plain.wav"
+ffmpeg -i "workplace/ffmpeg-helper-260114_160901/01_trim.wav" -af "volume=+6.8dB" -ar 192000 -sample_fmt s32 -c:a pcm_s24le "workplace/ffmpeg-helper-260114_160901/01_gain-hires-tp0p5-plain.wav"
 ```
 
 For multiple WAVs, repeat both phases separately for each trimmed WAV before
@@ -100,7 +117,7 @@ This is not another processing pass; it only confirms the resulting peak.
 Lo-res example:
 
 ```sh
-ffmpeg -hide_banner -i "workplace/h4essential-260114_160901/01_gain-lores-tp0p5-plain.wav" -af loudnorm=print_format=json -f null - > "workplace/h4essential-260114_160901/01_gain-verify-meta.json" 2>&1
+ffmpeg -hide_banner -i "workplace/ffmpeg-helper-260114_160901/01_gain-lores-tp0p5-plain.wav" -af loudnorm=print_format=json -f null - > "workplace/ffmpeg-helper-260114_160901/01_gain-verify-meta.json" 2>&1
 ```
 
 Check that the verification output contains a numeric `input_tp` close to the

--- a/skills/igapyon-ffmpeg-helper/references/process/still-image-youtube-video.md
+++ b/skills/igapyon-ffmpeg-helper/references/process/still-image-youtube-video.md
@@ -14,35 +14,167 @@ Ask for these if missing:
 The still image may be a jacket, cover, title card, or other manually prepared
 image.
 
+## Output File Naming
+
+Do not use a generic final name such as `youtube_upload.mp4` unless the user
+explicitly asks for it. Name the upload file so the original H4essential
+recording identifier is visible from the filename.
+
+Prefer one of these patterns:
+
+```text
+<recording-id>-youtube.mp4
+<recording-id>-<short-piece-or-project>-youtube.mp4
+<first-recording-id>-merged-youtube.mp4
+```
+
+Examples:
+
+```text
+workplace/ffmpeg-helper-260503_113659/260503_113659-youtube.mp4
+workplace/ffmpeg-helper-260503_113659/260503_113659-dvorak-youtube.mp4
+workplace/ffmpeg-helper-260503_113659/260503_113659-merged-youtube.mp4
+```
+
+Derive the recording id from the source recording folder or source WAV stem,
+for example `260503_113659` from `260503_113659_TrMic.WAV`. If the user provides
+a title or piece name, append a short lowercase ASCII slug after the recording
+id. If multiple recording ids are involved, use the first recording id plus
+`merged`, unless the user gives a better short project name.
+
+## When No Still Image Exists
+
+If the user has no still image, support one of these routes:
+
+- Use an existing photo, poster, flyer, score image, or venue image provided by
+  the user.
+- Create a simple title-card image for the job.
+- Generate a new bitmap image when the user explicitly wants generated artwork.
+
+For a simple title card, ask only for the missing fields needed to make a usable
+1920x1080 image:
+
+- title
+- subtitle, optional
+- date or venue, optional
+- preferred mood or colors, optional
+
+Save created or generated still images inside the current job directory, for
+example:
+
+```text
+workplace/ffmpeg-helper-260114_160901/cover.png
+```
+
+Tell the user that YouTube thumbnails and the in-video still image can be
+separate files if they want a different upload thumbnail later.
+
+## YouTube Image Size Guidance
+
+When helping with a still image or title card, give practical size guidance:
+
+- In-video still image: use 16:9 at 1920x1080 by default, matching the video
+  command in this runbook.
+- YouTube custom thumbnail: 3840x2160 is the current official recommended
+  target, with 16:9 aspect ratio. 1280x720 is an acceptable practical fallback
+  when a lighter image is preferred.
+- Keep important text and faces away from the edges so YouTube UI overlays and
+  cropping do not hide them.
+- It is acceptable to create one 1920x1080 title card for the video and export
+  a separate 3840x2160 or 1280x720 thumbnail later if needed.
+
+Do not over-explain this unless the user asks. A short note is enough:
+
+```text
+静止画は動画内では 1920x1080 の 16:9 を基本にします。YouTube のサムネイル用は公式推奨なら 3840x2160、軽めに作るなら 1280x720 の 16:9 が目安です。端の文字は切れたり UI に重なったりしやすいので、少し内側に置くのが無難です。
+```
+
+## Format Choice
+
+The original local-html-tools YouTube generator used an MKV route for its
+YouTube preset and an MP4 route for its general video preset. For this skill,
+prefer the MP4 route by default because YouTube's current recommended upload
+encoding settings name MP4 as the recommended container.
+
+Use these routes:
+
+- Default YouTube upload route: MP4 (`.mp4`) with H.264 video and AAC audio.
+- Source-preserving route: MKV (`.mkv`) with H.264 video and copied WAV audio,
+  only when the user explicitly wants to avoid audio re-encoding or asks for
+  the local-html-tools MKV-style route.
+
+Tell the user the tradeoff briefly when choosing:
+
+```text
+YouTube 公式推奨に寄せるなら MP4/H.264/AAC が無難です。MKV は WAV 音声を再エンコードせずに入れやすい利点がありますが、アップロード互換性の安全側では MP4 を既定にします。
+```
+
 ## First-Cut Defaults
 
 - Container: MP4.
 - Video codec: H.264 via `libx264`.
+- Video profile: High.
+- Preset: `medium`.
+- Quality: `-crf 18`.
+- Frame rate: 30 fps for still-image videos by default. A lower frame rate can
+  work for a static-image video, but 30 fps is the compatibility-oriented
+  default for YouTube upload.
+- GOP: closed GOP; use a GOP length of half the frame rate. With the default
+  30 fps command, use `-g 15`.
+- B-frames: 2.
 - Pixel format: `yuv420p`.
+- SDR color space: BT.709.
 - Tune: `stillimage`.
 - Resolution: 1920x1080 unless the user requests otherwise.
 - Image fit: preserve the entire image and pad to 16:9.
-- Audio codec: AAC.
+- Audio codec: AAC-LC.
 - Audio sample rate: 48 kHz.
-- Audio bitrate: 320 kbps.
+- Audio bitrate: 384 kbps for stereo.
 - MP4 fast start: include `-movflags +faststart`.
+- Duration: when the audio duration is known, add `-t AUDIO_DURATION` to make
+  the MP4 container duration match the audio reliably. Keep `-shortest` as an
+  additional guard.
 
 ## Command
 
-For multiple-file workflows, use the merged gain-adjusted WAV:
+For default YouTube upload workflows, use MP4. First measure the prepared audio
+duration:
 
 ```sh
-ffmpeg -loop 1 -framerate 2 -i "cover.png" -i "workplace/h4essential-260114_160901/merged_gain-lores-tp0p5-plain.wav" \
-  -vf "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2" \
-  -c:v libx264 -tune stillimage -pix_fmt yuv420p \
-  -c:a aac -b:a 320k -ar 48000 \
+ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "workplace/ffmpeg-helper-260114_160901/merged_gain-lores-tp0p5-plain.wav"
+```
+
+Then pass that duration with `-t`. For example, if the measured duration is
+`635.000000`:
+
+```sh
+ffmpeg -loop 1 -framerate 30 -i "cover.png" -i "workplace/ffmpeg-helper-260114_160901/merged_gain-lores-tp0p5-plain.wav" \
+  -t 635.000000 \
+  -vf "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2,format=yuv420p" \
+  -c:v libx264 -profile:v high -preset medium -tune stillimage -crf 18 -g 15 -bf 2 \
+  -x264-params colorprim=bt709:transfer=bt709:colormatrix=bt709:open-gop=0 \
+  -c:a aac -profile:a aac_low -b:a 384k -ar 48000 \
   -movflags +faststart \
-  -shortest "workplace/h4essential-260114_160901/youtube_upload.mp4"
+  -shortest "workplace/ffmpeg-helper-260114_160901/260114_160901-merged-youtube.mp4"
 ```
 
 For a single-file workflow, use
-`workplace/h4essential-260114_160901/01_gain-lores-tp0p5-plain.wav` instead of
-`workplace/h4essential-260114_160901/merged_gain-lores-tp0p5-plain.wav`. For
+`workplace/ffmpeg-helper-260114_160901/01_gain-lores-tp0p5-plain.wav` instead of
+`workplace/ffmpeg-helper-260114_160901/merged_gain-lores-tp0p5-plain.wav`. For
 hi-res workflows, use the corresponding `*-hires-tp0p5-plain.wav` file.
+
+If the user explicitly prefers a lighter static-image video, a lower frame rate
+such as 2 fps is acceptable. In that case, adjust the GOP length to half the
+chosen frame rate where practical, and explain that 30 fps remains the safer
+YouTube compatibility default.
+
+For a looping still-image input, do not rely on `-shortest` alone when exact
+duration matters. `-loop 1` creates an effectively endless video input, and
+encoder lookahead, B-frames, frame timestamps, and low frame rates can leave the
+video stream or container duration slightly longer than the audio. Using `-t`
+with the measured audio duration prevents the common "audio is 10:35 but MP4
+shows 11:04.50" style mismatch.
+
+For the source-preserving MKV route, use `-c:a copy` and output `.mkv`.
 
 Log the video creation command to the job directory's `commands.log`.

--- a/skills/igapyon-ffmpeg-helper/references/process/workspace-and-command-log.md
+++ b/skills/igapyon-ffmpeg-helper/references/process/workspace-and-command-log.md
@@ -4,20 +4,20 @@ Use this process before generating conversion commands.
 
 ## Workspace Directory
 
-Create a per-job directory under `workplace/`. Prefer a name derived from the
-recording folder or project:
+Create a per-job directory under `workplace/`. Prefer a name with the
+`ffmpeg-helper-` prefix followed by the recording timestamp or job timestamp:
 
 ```text
-workplace/h4essential-260114_160901/
-workplace/h4essential-260114_160901-youtube/
+workplace/ffmpeg-helper-260114_160901/
+workplace/ffmpeg-helper-260114_160901-youtube/
 workplace/orchestra-20260114-youtube/
 ```
 
-If multiple recording folders are involved, use the first folder name or a short
-project name:
+If multiple recording folders are involved, use the first recording timestamp,
+the job timestamp, or a short project name:
 
 ```text
-workplace/h4essential-260114_160901-merged/
+workplace/ffmpeg-helper-260114_160901-merged/
 ```
 
 Do not write generated audio/video files next to source recordings unless the
@@ -31,8 +31,8 @@ also acceptable and preferred to keep auxiliary logs and diagnostic output files
 there.
 
 ```sh
-mkdir -p "workplace/h4essential-260114_160901"
-printf '# igapyon-ffmpeg-helper command log\n# Created: %s\n\n' "$(date '+%Y-%m-%d %H:%M:%S %z')" > "workplace/h4essential-260114_160901/commands.log"
+mkdir -p "workplace/ffmpeg-helper-260114_160901"
+printf '# igapyon-ffmpeg-helper command log\n# Created: %s\n\n' "$(date '+%Y-%m-%d %H:%M:%S %z')" > "workplace/ffmpeg-helper-260114_160901/commands.log"
 ```
 
 ## Mandatory FFmpeg Version Check
@@ -41,8 +41,8 @@ Run `ffmpeg -version` before any conversion command and record the exact command
 in `commands.log`. Also save the version output for later troubleshooting.
 
 ```sh
-printf '%s\n' 'ffmpeg -version > "workplace/h4essential-260114_160901/ffmpeg-version.txt"' >> "workplace/h4essential-260114_160901/commands.log"
-ffmpeg -version > "workplace/h4essential-260114_160901/ffmpeg-version.txt"
+printf '%s\n' 'ffmpeg -version > "workplace/ffmpeg-helper-260114_160901/ffmpeg-version.txt"' >> "workplace/ffmpeg-helper-260114_160901/commands.log"
+ffmpeg -version > "workplace/ffmpeg-helper-260114_160901/ffmpeg-version.txt"
 ```
 
 If this fails, stop the workflow before generating or running conversion
@@ -53,7 +53,7 @@ commands.
 Before running or presenting a command, append it to `commands.log`.
 
 ```sh
-printf '%s\n' 'ffmpeg -i "input.WAV" -ss 00:01:23 -to 00:12:34 -c:a pcm_f32le "workplace/h4essential-260114_160901/01_trim.wav"' >> "workplace/h4essential-260114_160901/commands.log"
+printf '%s\n' 'ffmpeg -i "input.WAV" -ss 00:01:23 -to 00:12:34 -c:a pcm_f32le "workplace/ffmpeg-helper-260114_160901/01_trim.wav"' >> "workplace/ffmpeg-helper-260114_160901/commands.log"
 ```
 
 When commands are multi-line for readability, log the exact one-line form that
@@ -66,8 +66,8 @@ For measurement commands, keep both the command log and the measurement output.
 Example:
 
 ```sh
-printf '%s\n' 'ffmpeg -hide_banner -i "workplace/h4essential-260114_160901/01_trim.wav" -af loudnorm=print_format=json -f null - > "workplace/h4essential-260114_160901/01_gain-meta.json" 2>&1' >> "workplace/h4essential-260114_160901/commands.log"
-ffmpeg -hide_banner -i "workplace/h4essential-260114_160901/01_trim.wav" -af loudnorm=print_format=json -f null - > "workplace/h4essential-260114_160901/01_gain-meta.json" 2>&1
+printf '%s\n' 'ffmpeg -hide_banner -i "workplace/ffmpeg-helper-260114_160901/01_trim.wav" -af loudnorm=print_format=json -f null - > "workplace/ffmpeg-helper-260114_160901/01_gain-meta.json" 2>&1' >> "workplace/ffmpeg-helper-260114_160901/commands.log"
+ffmpeg -hide_banner -i "workplace/ffmpeg-helper-260114_160901/01_trim.wav" -af loudnorm=print_format=json -f null - > "workplace/ffmpeg-helper-260114_160901/01_gain-meta.json" 2>&1
 ```
 
 Do not treat `commands.log` as a full terminal transcript. It is a concise

--- a/skills/igapyon-ffmpeg-helper/references/process/youtube-manual-upload.md
+++ b/skills/igapyon-ffmpeg-helper/references/process/youtube-manual-upload.md
@@ -22,5 +22,5 @@ the skill:
 End the workflow by pointing to the generated upload file:
 
 ```text
-生成された `workplace/h4essential-260114_160901/youtube_upload.mp4` を YouTube Studio から手動アップロードしてください。
+生成された `workplace/ffmpeg-helper-260114_160901/260114_160901-youtube.mp4` を YouTube Studio から手動アップロードしてください。
 ```

--- a/skills/igapyon-ffmpeg-helper/references/workflows/h4essential-orchestra-youtube.md
+++ b/skills/igapyon-ffmpeg-helper/references/workflows/h4essential-orchestra-youtube.md
@@ -28,6 +28,9 @@ This workflow is intentionally personal and narrow:
 Do not turn this into a generic FFmpeg workflow unless the user asks to expand
 the skill.
 
+For the reasoning behind the YouTube output defaults, see
+[../decisions/youtube-output-policy.md](../decisions/youtube-output-policy.md).
+
 ## Prerequisites
 
 This workflow requires the `ffmpeg` CLI to be available in the shell. Running
@@ -36,7 +39,7 @@ the command in `commands.log` and save the output as `ffmpeg-version.txt` in the
 job directory:
 
 ```sh
-ffmpeg -version > "workplace/h4essential-260114_160901/ffmpeg-version.txt"
+ffmpeg -version > "workplace/ffmpeg-helper-260114_160901/ffmpeg-version.txt"
 ```
 
 If `ffmpeg -version` fails or `ffmpeg` is unavailable, stop and ask the user to
@@ -66,6 +69,9 @@ source of truth for trim command generation.
 Classify the request into one mode:
 
 - Single WAV: one selected recording track becomes one final YouTube video.
+- Single WAV, multiple parts: one selected recording track is split into
+  several separately named parts such as `260503_113659-part1_trim.wav` and
+  `260503_113659-part2_trim.wav`.
 - Multiple WAVs: several selected recording tracks are processed individually
   and then concatenated.
 - Already trimmed: skip trim and start from the measurement phase.
@@ -74,7 +80,14 @@ Classify the request into one mode:
 - Already adjusted: skip gain adjustment and start from concat or video
   creation.
 - Still-image-only missing: help create or locate the still image if the user
-  asks, otherwise request the still image path.
+  asks, otherwise request the still image path. Prefer a user-provided image,
+  a simple title card, or generated artwork when explicitly requested.
+  Mention practical YouTube image-size guidance when useful: 1920x1080 for the
+  in-video still image, 3840x2160 for the current official custom thumbnail
+  recommendation, and 1280x720 as a lighter practical fallback.
+- YouTube upload format: prefer MP4/H.264/AAC by default for official
+  recommendation alignment. Offer the local-html-tools-style MKV route only
+  when the user explicitly wants to preserve WAV audio with `-c:a copy`.
 
 ## Process Order
 
@@ -96,7 +109,7 @@ the other igapyon Agent Skills. If the user does not give names, propose names
 like these:
 
 ```text
-workplace/h4essential-260114_160901/
+workplace/ffmpeg-helper-260114_160901/
   commands.log
   01_trim.wav
   01_gain-meta.json
@@ -106,22 +119,24 @@ workplace/h4essential-260114_160901/
   02_gain-lores-tp0p5-plain.wav
   concat_list.txt
   merged_gain-lores-tp0p5-plain.wav
-  youtube_upload.mp4
+  260114_160901-merged-youtube.mp4
 ```
 
 For a single file, use:
 
 ```text
-workplace/h4essential-260114_160901/
+workplace/ffmpeg-helper-260114_160901/
   commands.log
   01_trim.wav
   01_gain-meta.json
   01_gain-lores-tp0p5-plain.wav
-  youtube_upload.mp4
+  260114_160901-youtube.mp4
 ```
 
 Do not overwrite source recordings. Generated commands should write to
-the per-job `workplace/` directory or clearly named output files.
+the per-job `workplace/` directory or clearly named output files. Do not use a
+generic final upload filename such as `youtube_upload.mp4`; include the
+original H4essential recording id, such as `260503_113659`, in the MP4 filename.
 
 ## First-Cut Audio Policy
 
@@ -135,9 +150,11 @@ For this workflow:
 - Target peak: `-0.5 dBTP`.
 - Do not use compression.
 - Do not use loudness normalization for finishing.
-- Let the user choose hi-res or lo-res output:
+- Let the user choose hi-res or lo-res output. If the user does not specify,
+  use hi-res:
   - hi-res: 192 kHz / 24-bit WAV.
   - lo-res: 44.1 kHz / 16-bit WAV.
+- Tell the user that hi-res intermediate WAV files will be larger.
 - For multiple WAV files, normalize each trimmed file before concatenation.
 
 This is a practical workflow choice to preserve the natural sound of the

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260525a
+Version: 20260602a
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

`igapyon-ffmpeg-helper` の H4essential 録音から YouTube 用動画を作成する runbook を強化しました。

YouTube 向け出力の既定方針を MP4/H.264/AAC に整理し、音声時間に合わせた動画長制御、出力ファイル命名、hi-res 中間 WAV の既定化、単一 WAV の複数パート切り出しなどを追加しています。

## 変更内容

- YouTube 出力方針の判断メモ `youtube-output-policy.md` を追加
- `SKILL.md` から YouTube 出力方針メモを参照するよう更新
- 作業ディレクトリ例を `workplace/ffmpeg-helper-.../` 形式へ整理
- hi-res / lo-res 選択で、未指定時は hi-res を既定にする方針を追加
- 単一 WAV を複数パートに分割する cut memo と命名規則を追加
- 最終動画ファイル名に H4essential 録音 ID を含める方針を追加
- 静止画付き YouTube 動画作成手順を更新
  - MP4/H.264/AAC を既定化
  - 30 fps、High Profile、BT.709、AAC-LC 384kbps などの設定を追加
  - `ffprobe` で音声長を測定し、`-t` と `-shortest` を併用する方針を追加
  - 明示要求時のみ MKV + WAV copy ルートを扱う方針を追加
- concat、trim、gain、manual upload、workflow の各 runbook を新方針に合わせて更新
- `index.json` を再生成
- ルート `pom.xml` と `みくく` バージョンを `20260602` 系へ更新