### PR TITLE
リリースアーカイブ作成と GitHub Release 添付を追加

### DIFF
--- a/.github/workflows/release-archive.yml
+++ b/.github/workflows/release-archive.yml
@@ -1,0 +1,32 @@
+name: Release archive
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release-archive:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Build release archive
+        run: mvn clean package
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: target/*.zip

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,37 @@
+# Install
+
+This archive contains igapyon's Agent Skills.
+
+## Contents
+
+- `skills/`: Agent Skill directories
+- `README.md`: repository overview and operating rules
+- `LICENSE`: license information
+- `pom.xml`: build metadata used to regenerate indexes and release archives
+
+## Install To Codex
+
+Copy the skill directories into your Codex skills directory.
+
+```sh
+mkdir -p "$HOME/.codex/skills"
+cp -R skills/* "$HOME/.codex/skills/"
+```
+
+Reload the Codex host application after copying the files.
+
+## Update Existing Install
+
+To update an existing local install, copy the same `skills/*` directories again.
+
+```sh
+cp -R skills/* "$HOME/.codex/skills/"
+```
+
+## Verify
+
+After installation, confirm that the expected skill directories exist.
+
+```sh
+ls "$HOME/.codex/skills"
+```

--- a/README.md
+++ b/README.md
@@ -248,3 +248,22 @@ mvn clean package
 ```
 
 生成された `index.json` は、skill と一緒にコミットします。
+
+## Release archive
+
+GitHub Release に添付する利用者向け archive は、次のコマンドで作成します。
+
+```sh
+mvn clean package
+```
+
+生成物は `target/igapyon-agent-skills-<version>.zip` です。
+
+archive には `README.md`、`INSTALL.md`、`LICENSE`、`pom.xml`、`.mvn/`、`lib/`、`skills/` を含めます。
+利用者は archive を展開し、`INSTALL.md` の手順で `skills/*` を自分の Codex skills directory へコピーします。
+
+release archive には、この repo の `skills/` に加えて、外部管理の `igapyon-miku-indexgen` skill も同梱します。
+外部 skill は `mvn package` の `prepare-package` フェーズで `target/release-staging/skills/` に取得し、archive 化します。
+取得元は `pom.xml` の `external.miku-indexgen-skills.*` properties で固定します。
+
+GitHub では `v*` tag が push されたときに GitHub Actions で `mvn clean package` を実行し、生成された zip を GitHub Release asset として添付します。

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,12 @@
 
   <name>igapyon-agent-skills</name>
 
+  <properties>
+    <external.miku-indexgen-skills.repo>https://github.com/igapyon/miku-indexgen-skills.git</external.miku-indexgen-skills.repo>
+    <external.miku-indexgen-skills.ref>v1.4.4.1</external.miku-indexgen-skills.ref>
+    <external.miku-indexgen-skills.skillName>igapyon-miku-indexgen</external.miku-indexgen-skills.skillName>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -32,6 +38,45 @@
                 <argument>${project.basedir}/skills</argument>
               </arguments>
             </configuration>
+          </execution>
+          <execution>
+            <id>prepare-release-staging</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>sh</executable>
+              <arguments>
+                <argument>${project.basedir}/scripts/prepare-release-staging.sh</argument>
+                <argument>${project.basedir}</argument>
+                <argument>${project.build.directory}/release-staging</argument>
+                <argument>${external.miku-indexgen-skills.repo}</argument>
+                <argument>${external.miku-indexgen-skills.ref}</argument>
+                <argument>${external.miku-indexgen-skills.skillName}</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.7.1</version>
+        <configuration>
+          <descriptors>
+            <descriptor>src/assembly/release.xml</descriptor>
+          </descriptors>
+          <finalName>${project.artifactId}-${project.version}</finalName>
+          <appendAssemblyId>false</appendAssemblyId>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-release-archive</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/scripts/prepare-release-staging.sh
+++ b/scripts/prepare-release-staging.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -eu
+
+BASE_DIR=$1
+STAGING_DIR=$2
+EXTERNAL_REPO_URL=$3
+EXTERNAL_REF=$4
+EXTERNAL_SKILL_NAME=$5
+
+EXTERNAL_WORK_DIR="$BASE_DIR/target/external/$EXTERNAL_SKILL_NAME"
+
+rm -rf "$STAGING_DIR" "$EXTERNAL_WORK_DIR"
+mkdir -p "$STAGING_DIR" "$STAGING_DIR/skills" "$BASE_DIR/target/external"
+
+cp "$BASE_DIR/README.md" "$STAGING_DIR/"
+cp "$BASE_DIR/INSTALL.md" "$STAGING_DIR/"
+cp "$BASE_DIR/LICENSE" "$STAGING_DIR/"
+cp "$BASE_DIR/pom.xml" "$STAGING_DIR/"
+cp -R "$BASE_DIR/.mvn" "$STAGING_DIR/"
+cp -R "$BASE_DIR/lib" "$STAGING_DIR/"
+cp -R "$BASE_DIR/skills/." "$STAGING_DIR/skills/"
+
+git clone --depth 1 --branch "$EXTERNAL_REF" "$EXTERNAL_REPO_URL" "$EXTERNAL_WORK_DIR"
+
+if [ ! -d "$EXTERNAL_WORK_DIR/skills/$EXTERNAL_SKILL_NAME" ]; then
+  echo "External skill not found: skills/$EXTERNAL_SKILL_NAME" >&2
+  exit 1
+fi
+
+if [ -e "$STAGING_DIR/skills/$EXTERNAL_SKILL_NAME" ]; then
+  echo "Skill already exists in staging: $EXTERNAL_SKILL_NAME" >&2
+  exit 1
+fi
+
+cp -R "$EXTERNAL_WORK_DIR/skills/$EXTERNAL_SKILL_NAME" "$STAGING_DIR/skills/"
+find "$STAGING_DIR" -name .DS_Store -type f -delete

--- a/src/assembly/release.xml
+++ b/src/assembly/release.xml
@@ -1,0 +1,23 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>release</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>true</includeBaseDirectory>
+  <baseDirectory>${project.artifactId}-${project.version}</baseDirectory>
+
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}/release-staging</directory>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>**</include>
+      </includes>
+      <excludes>
+        <exclude>**/.DS_Store</exclude>
+      </excludes>
+    </fileSet>
+  </fileSets>
+</assembly>


### PR DESCRIPTION
## 概要

利用者向けの skill 配布用 zip archive を Maven で作成し、`v*` タグ push 時に GitHub Release asset として添付する仕組みを追加しました。

archive にはこの repo の `skills/` に加えて、外部管理の `igapyon-miku-indexgen` skill も staging して同梱する構成です。

## 変更内容

- `mvn clean package` で `target/igapyon-agent-skills-<version>.zip` を作成する Maven assembly 設定を追加
- `prepare-package` フェーズで release staging directory を作成するスクリプトを追加
- 外部 repo から `igapyon-miku-indexgen` skill を取得して release archive に同梱する設定を追加
- `v*` タグ push 時に GitHub Actions で release archive をビルドし、GitHub Release asset としてアップロードする workflow を追加
- archive 利用者向けの `INSTALL.md` を追加
- `README.md` に release archive の作成方法、同梱内容、GitHub Release 連携を追記