### PR TITLE
release archive に複数の外部 miku-soft skill 同梱を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,15 @@ mvn clean package
 archive には `README.md`、`INSTALL.md`、`LICENSE`、`pom.xml`、`.mvn/`、`lib/`、`skills/` を含めます。
 利用者は archive を展開し、`INSTALL.md` の手順で `skills/*` を自分の Codex skills directory へコピーします。
 
-release archive には、この repo の `skills/` に加えて、外部管理の `igapyon-miku-indexgen` skill も同梱します。
+release archive には、この repo の `skills/` に加えて、外部管理の miku-soft 系 skill も同梱します。
 外部 skill は `mvn package` の `prepare-package` フェーズで `target/release-staging/skills/` に取得し、archive 化します。
-取得元は `pom.xml` の `external.miku-indexgen-skills.*` properties で固定します。
+取得元は `pom.xml` の `external.*` properties で固定します。
+
+同梱する外部 skill は次の通りです。
+
+- `miku-indexgen-skills` `v1.4.4.1`: `skills/igapyon-miku-indexgen/`
+- `miku-text-bundle-skills` `v0.8.1`: `skills/miku-text-bundle/`
+- `mikuproject-skills` `v0.8.1.1`: `skills/mikuproject/`
+- `mikuscore-skills` `v0.1.0`: `skills/mikuscore/`
 
 GitHub では `v*` tag が push されたときに GitHub Actions で `mvn clean package` を実行し、生成された zip を GitHub Release asset として添付します。

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,15 @@
     <external.miku-indexgen-skills.repo>https://github.com/igapyon/miku-indexgen-skills.git</external.miku-indexgen-skills.repo>
     <external.miku-indexgen-skills.ref>v1.4.4.1</external.miku-indexgen-skills.ref>
     <external.miku-indexgen-skills.skillName>igapyon-miku-indexgen</external.miku-indexgen-skills.skillName>
+    <external.miku-text-bundle-skills.repo>https://github.com/igapyon/miku-text-bundle-skills.git</external.miku-text-bundle-skills.repo>
+    <external.miku-text-bundle-skills.ref>v0.8.1</external.miku-text-bundle-skills.ref>
+    <external.miku-text-bundle-skills.skillName>miku-text-bundle</external.miku-text-bundle-skills.skillName>
+    <external.mikuproject-skills.repo>https://github.com/igapyon/mikuproject-skills.git</external.mikuproject-skills.repo>
+    <external.mikuproject-skills.ref>v0.8.1.1</external.mikuproject-skills.ref>
+    <external.mikuproject-skills.skillName>mikuproject</external.mikuproject-skills.skillName>
+    <external.mikuscore-skills.repo>https://github.com/igapyon/mikuscore-skills.git</external.mikuscore-skills.repo>
+    <external.mikuscore-skills.ref>v0.1.0</external.mikuscore-skills.ref>
+    <external.mikuscore-skills.skillName>mikuscore</external.mikuscore-skills.skillName>
   </properties>
 
   <build>
@@ -54,6 +63,15 @@
                 <argument>${external.miku-indexgen-skills.repo}</argument>
                 <argument>${external.miku-indexgen-skills.ref}</argument>
                 <argument>${external.miku-indexgen-skills.skillName}</argument>
+                <argument>${external.miku-text-bundle-skills.repo}</argument>
+                <argument>${external.miku-text-bundle-skills.ref}</argument>
+                <argument>${external.miku-text-bundle-skills.skillName}</argument>
+                <argument>${external.mikuproject-skills.repo}</argument>
+                <argument>${external.mikuproject-skills.ref}</argument>
+                <argument>${external.mikuproject-skills.skillName}</argument>
+                <argument>${external.mikuscore-skills.repo}</argument>
+                <argument>${external.mikuscore-skills.ref}</argument>
+                <argument>${external.mikuscore-skills.skillName}</argument>
               </arguments>
             </configuration>
           </execution>

--- a/scripts/prepare-release-staging.sh
+++ b/scripts/prepare-release-staging.sh
@@ -3,13 +3,9 @@ set -eu
 
 BASE_DIR=$1
 STAGING_DIR=$2
-EXTERNAL_REPO_URL=$3
-EXTERNAL_REF=$4
-EXTERNAL_SKILL_NAME=$5
+shift 2
 
-EXTERNAL_WORK_DIR="$BASE_DIR/target/external/$EXTERNAL_SKILL_NAME"
-
-rm -rf "$STAGING_DIR" "$EXTERNAL_WORK_DIR"
+rm -rf "$STAGING_DIR" "$BASE_DIR/target/external"
 mkdir -p "$STAGING_DIR" "$STAGING_DIR/skills" "$BASE_DIR/target/external"
 
 cp "$BASE_DIR/README.md" "$STAGING_DIR/"
@@ -20,17 +16,32 @@ cp -R "$BASE_DIR/.mvn" "$STAGING_DIR/"
 cp -R "$BASE_DIR/lib" "$STAGING_DIR/"
 cp -R "$BASE_DIR/skills/." "$STAGING_DIR/skills/"
 
-git clone --depth 1 --branch "$EXTERNAL_REF" "$EXTERNAL_REPO_URL" "$EXTERNAL_WORK_DIR"
+while [ "$#" -gt 0 ]; do
+  if [ "$#" -lt 3 ]; then
+    echo "External skill arguments must be repo/ref/skillName triples" >&2
+    exit 1
+  fi
 
-if [ ! -d "$EXTERNAL_WORK_DIR/skills/$EXTERNAL_SKILL_NAME" ]; then
-  echo "External skill not found: skills/$EXTERNAL_SKILL_NAME" >&2
-  exit 1
-fi
+  EXTERNAL_REPO_URL=$1
+  EXTERNAL_REF=$2
+  EXTERNAL_SKILL_NAME=$3
+  shift 3
 
-if [ -e "$STAGING_DIR/skills/$EXTERNAL_SKILL_NAME" ]; then
-  echo "Skill already exists in staging: $EXTERNAL_SKILL_NAME" >&2
-  exit 1
-fi
+  EXTERNAL_WORK_DIR="$BASE_DIR/target/external/$EXTERNAL_SKILL_NAME"
 
-cp -R "$EXTERNAL_WORK_DIR/skills/$EXTERNAL_SKILL_NAME" "$STAGING_DIR/skills/"
+  git clone --depth 1 --branch "$EXTERNAL_REF" "$EXTERNAL_REPO_URL" "$EXTERNAL_WORK_DIR"
+
+  if [ ! -d "$EXTERNAL_WORK_DIR/skills/$EXTERNAL_SKILL_NAME" ]; then
+    echo "External skill not found: skills/$EXTERNAL_SKILL_NAME" >&2
+    exit 1
+  fi
+
+  if [ -e "$STAGING_DIR/skills/$EXTERNAL_SKILL_NAME" ]; then
+    echo "Skill already exists in staging: $EXTERNAL_SKILL_NAME" >&2
+    exit 1
+  fi
+
+  cp -R "$EXTERNAL_WORK_DIR/skills/$EXTERNAL_SKILL_NAME" "$STAGING_DIR/skills/"
+done
+
 find "$STAGING_DIR" -name .DS_Store -type f -delete


### PR DESCRIPTION
## 概要

release archive 作成時に同梱する外部 skill を、`igapyon-miku-indexgen` だけでなく複数の miku-soft 系 skill へ拡張しました。

`prepare-release-staging.sh` は外部 skill の `repo/ref/skillName` を複数組受け取れるようになり、Maven properties で取得元と対象 skill を固定しています。

## 変更内容

- `pom.xml` に外部 skill 取得設定を追加
  - `miku-text-bundle-skills` `v0.8.1`
  - `mikuproject-skills` `v0.8.1.1`
  - `mikuscore-skills` `v0.1.0`
- `prepare-release-staging.sh` を複数の外部 skill に対応
  - `repo/ref/skillName` の3要素セットを繰り返し処理
  - 外部取得作業ディレクトリをまとめて初期化
  - skill 未検出や同名 skill 競合時のエラー処理を維持
- `README.md` の release archive 説明を更新
  - 外部管理の miku-soft 系 skill を同梱する方針へ修正
  - 同梱対象の外部 repo、tag、skill path を明記