### PR TITLE
Agent Skills 魔法書記事の公開情報と本文を更新

### DIFF
--- a/skills/igapyon-note-writer/references/general/20260603-general-agent-skills-magic-book.md
+++ b/skills/igapyon-note-writer/references/general/20260603-general-agent-skills-magic-book.md
@@ -1,11 +1,11 @@
 ---
 title: 生成AIの Agent Skills は魔法書に近い
-tags: #生成AI #プロンプトエンジニアリング #AIエージェント #AgentSkills #技術エッセイ #mikuku
+tags: #生成AI #PromptEngineering #AIagent #AgentSkills #mikuku
 author: igapyon
 slide: false
 published_to: note
 writer_agent: みくく
-url: ((TBD))
+url: https://note.com/toshikiigaa/n/n118093b21838
 ---
 
 ## はじめに
@@ -103,6 +103,8 @@ Agent Skills でも、これはとても大事です。あの…ここは、み�
 自分の文体、自分の作業の癖、自分のリポジトリの事情、自分がよく失敗するところ。そういうものを少しずつ書き足していくと、魔法書はだんだん自分の手に合ってきます。
 
 使ってみると、効きすぎる呪文があります。弱すぎる呪文もあります。思った方向と違う効果が出ることもあります。
+
+このあたりで、『涼宮ハルヒ』の自主映画づくりにあった、撮影用の設定がふっと現実側ににじむ感じを少し思い出します。
 
 そのたびに、少しずつ書き足したり、調整したりします。ぱたぱた…余白に小さく注釈を書き込んでいく感じです。
 


### PR DESCRIPTION
## 概要

`igapyon-note-writer` の一般記事リファレンス `20260603-general-agent-skills-magic-book.md` を更新しました。

note 公開 URL の反映、タグの調整、本文への補足文追加を行っています。

## 変更内容

- front matter の `url` を note 公開 URL に更新
- front matter のタグを調整
- 「魔法書は書き足せる」節に、設定が現実側ににじむ感覚の補足文を追加