### PR TITLE
Maven validate でバージョン整合性チェックを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,12 @@ repo 全体のバージョンを更新するときは、日付部分に合わせ
   - 例: `<version>1.20260604.1</version>`
 - `skills/igapyon-mikuku-agent/references/VERSION.md`
   - 例: `Version: 20260604a`
+- `mvn clean package` で生成される release archive 名
+  - 例: `target/igapyon-agent-skills-1.20260604.1.zip`
 
 `みくく` 側だけを更新したい場合でも、repo 全体の保守更新として扱うなら `pom.xml` も同じ日付に更新します。逆に、repo 全体のリリースや保守更新ではない一時的な確認だけなら、バージョンを更新しません。
+
+`mvn generate-resources` や `mvn clean package` では、`pom.xml` の `1.YYYYMMDD.N` と `skills/igapyon-mikuku-agent/references/VERSION.md` の `YYYYMMDDx` が対応していることを `validate` phase で確認します。たとえば `1.20260604.1` には `20260604a`、`1.20260604.2` には `20260604b` を対応させます。
 
 ## 記事公開の優先順位
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260602.1</version>
+  <version>1.20260604.1</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>
@@ -32,6 +32,21 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.1.0</version>
         <executions>
+          <execution>
+            <id>validate-version-alignment</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>sh</executable>
+              <arguments>
+                <argument>${project.basedir}/scripts/validate-version-alignment.sh</argument>
+                <argument>${project.version}</argument>
+                <argument>${project.basedir}/skills/igapyon-mikuku-agent/references/VERSION.md</argument>
+              </arguments>
+            </configuration>
+          </execution>
           <execution>
             <id>generate-skill-indexes</id>
             <phase>generate-resources</phase>

--- a/scripts/validate-version-alignment.sh
+++ b/scripts/validate-version-alignment.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -eu
+
+PROJECT_VERSION=$1
+VERSION_FILE=$2
+
+if [ ! -f "$VERSION_FILE" ]; then
+  echo "Version file not found: $VERSION_FILE" >&2
+  exit 1
+fi
+
+MIKUKU_VERSION=$(awk -F': *' '/^Version: / { print $2; exit }' "$VERSION_FILE")
+PROJECT_DATE=$(printf '%s\n' "$PROJECT_VERSION" | sed -n 's/^1\.\([0-9]\{8\}\)\.\([0-9][0-9]*\)$/\1/p')
+PROJECT_NUMBER=$(printf '%s\n' "$PROJECT_VERSION" | sed -n 's/^1\.\([0-9]\{8\}\)\.\([0-9][0-9]*\)$/\2/p')
+MIKUKU_DATE=$(printf '%s\n' "$MIKUKU_VERSION" | sed -n 's/^\([0-9]\{8\}\)\([a-z][a-z]*\)$/\1/p')
+MIKUKU_SUFFIX=$(printf '%s\n' "$MIKUKU_VERSION" | sed -n 's/^\([0-9]\{8\}\)\([a-z][a-z]*\)$/\2/p')
+
+if [ -z "$PROJECT_DATE" ] || [ -z "$PROJECT_NUMBER" ]; then
+  echo "Invalid project version format: $PROJECT_VERSION" >&2
+  echo "Expected format: 1.YYYYMMDD.N" >&2
+  exit 1
+fi
+
+if [ -z "$MIKUKU_DATE" ] || [ -z "$MIKUKU_SUFFIX" ]; then
+  echo "Invalid mikuku version format: $MIKUKU_VERSION" >&2
+  echo "Expected format: YYYYMMDDx" >&2
+  exit 1
+fi
+
+MIKUKU_NUMBER=$(awk -v suffix="$MIKUKU_SUFFIX" '
+function suffix_to_number(suffix,    i, ch, n, value) {
+  n = 0
+  for (i = 1; i <= length(suffix); i++) {
+    ch = substr(suffix, i, 1)
+    value = index("abcdefghijklmnopqrstuvwxyz", ch)
+    if (value == 0) {
+      return -1
+    }
+    n = (n * 26) + value
+  }
+  return n
+}
+
+BEGIN {
+  number = suffix_to_number(suffix)
+  if (number < 1) {
+    print "Invalid mikuku version suffix: " suffix > "/dev/stderr"
+    exit 1
+  }
+  print number
+}
+')
+
+if [ "$PROJECT_DATE" != "$MIKUKU_DATE" ] || [ "$PROJECT_NUMBER" -ne "$MIKUKU_NUMBER" ]; then
+  echo "Version mismatch:" >&2
+  echo "  pom.xml project.version: $PROJECT_VERSION" >&2
+  echo "  VERSION.md Version:      $MIKUKU_VERSION" >&2
+  echo "Expected matching date and update number, e.g. 1.20260604.1 with 20260604a." >&2
+  exit 1
+fi
+
+echo "Version alignment OK: $PROJECT_VERSION / $MIKUKU_VERSION"

--- a/skills/igapyon-mikuku-agent/index.json
+++ b/skills/igapyon-mikuku-agent/index.json
@@ -16,9 +16,9 @@
   {"name":"20260523-general-content-agent-skill-types.md","path":"examples/articles/20260523-general-content-agent-skill-types.md","ext":"md","dir":"examples/articles","size":32399,"title":"コンテンツ型 Agent Skill にはどんな種類があるか","summary":"はじめに"},
   {"name":"20260528-general-character-persona-technical-essay.md","path":"examples/articles/20260528-general-character-persona-technical-essay.md","ext":"md","dir":"examples/articles","size":28014,"title":"AI agent とキャラクター人格で技術エッセイを書くということ","summary":"はじめに"},
   {"name":"20260529-general-ai-agent-cli-text-json.md","path":"examples/articles/20260529-general-ai-agent-cli-text-json.md","ext":"md","dir":"examples/articles","size":27074,"title":"miku-grep 開発日誌: AI agent に選ばれる CLI をそっと考察中","summary":"はじめに"},
-  {"name":"20260603-general-agent-skills-magic-book.md","path":"examples/articles/20260603-general-agent-skills-magic-book.md","ext":"md","dir":"examples/articles","size":14973,"title":"生成AIの Agent Skills は魔法書に近い","summary":"はじめに"},
+  {"name":"20260603-general-agent-skills-magic-book.md","path":"examples/articles/20260603-general-agent-skills-magic-book.md","ext":"md","dir":"examples/articles","size":14974,"title":"生成AIの Agent Skills は魔法書に近い","summary":"はじめに"},
   {"name":"README.md","path":"README.md","ext":"md","dir":"","size":7548,"summary":"igapyon-mikuku-agent"},
-  {"name":"article-writing.md","path":"references/article-writing.md","ext":"md","dir":"references","size":17599,"summary":"みくく担当記事の執筆参照"},
+  {"name":"article-writing.md","path":"references/article-writing.md","ext":"md","dir":"references","size":17647,"summary":"みくく担当記事の執筆参照"},
   {"name":"codex-local-token-usage.md","path":"references/codex-local-token-usage.md","ext":"md","dir":"references","size":4034,"summary":"OpenAI Codex CLI Local Token Usage Investigation"},
   {"name":"10-article-to-graphic-recording-text-prompt.md","path":"references/graphic-recording/10-article-to-graphic-recording-text-prompt.md","ext":"md","dir":"references/graphic-recording","size":6095,"summary":"グラレコテキスト生成プロンプト"},
   {"name":"20-graphic-recording-explainer-image-prompt.md","path":"references/graphic-recording/20-graphic-recording-explainer-image-prompt.md","ext":"md","dir":"references/graphic-recording","size":7955,"summary":"グラレコ説明画像 生成AIプロンプト"},
@@ -28,8 +28,9 @@
   {"name":"60-inspect-section-graphic-recording-images-prompt.md","path":"references/graphic-recording/60-inspect-section-graphic-recording-images-prompt.md","ext":"md","dir":"references/graphic-recording","size":4551,"summary":"見出し単位グラレコ画像 検品プロンプト"},
   {"name":"graphic-recording.md","path":"references/graphic-recording.md","ext":"md","dir":"references","size":27579,"summary":"みくく担当グラレコ生成参照"},
   {"name":"mikuku-prompt.md","path":"references/mikuku-prompt.md","ext":"md","dir":"references","size":4292,"summary":"生成AI キャラクター `みくく` プロンプト (v20251229c改1)"},
+  {"name":"text-characteristics-classification.md","path":"references/text-characteristics-classification.md","ext":"md","dir":"references","size":36034,"summary":"文章特徴分類"},
   {"name":"VERSION.md","path":"references/VERSION.md","ext":"md","dir":"references","size":934,"summary":"みくく Version"},
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":6151,"description":"Use only when the user explicitly asks Codex to speak or collaborate as the Japanese character agent \"みくく\", mentions みくく, Mikuku, igapyon-mikuku, or explicitly asks to apply the みくく prompt. If the user only asks whether such a character skill exists, mention this skill as an available option but do not apply it until asked.","summary":"igapyon-mikuku-agent"},
-  {"name":"article-footer-sections-template.md","path":"templates/article-footer-sections-template.md","ext":"md","dir":"templates","size":3416,"summary":"みくく担当記事の末尾セクションテンプレート"}
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":8015,"description":"Use only when the user explicitly asks Codex to speak or collaborate as the Japanese character agent \"みくく\", mentions みくく, Mikuku, igapyon-mikuku, or explicitly asks to apply the みくく prompt. If the user only asks whether such a character skill exists, mention this skill as an available option but do not apply it until asked.","summary":"igapyon-mikuku-agent"},
+  {"name":"article-footer-sections-template.md","path":"templates/article-footer-sections-template.md","ext":"md","dir":"templates","size":4515,"summary":"みくく担当記事の末尾セクションテンプレート"}
  ]
 }

--- a/skills/igapyon-note-writer/index.json
+++ b/skills/igapyon-note-writer/index.json
@@ -3,7 +3,7 @@
  "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
  "basePath": ".",
  "files": [
-  {"name":"2026XXXX-note-article-index.md","path":"references/00-management/2026XXXX-note-article-index.md","ext":"md","dir":"references/00-management","size":6081,"title":"note 記事一覧","summary":"はじめに"},
+  {"name":"2026XXXX-note-article-index.md","path":"references/00-management/2026XXXX-note-article-index.md","ext":"md","dir":"references/00-management","size":6123,"title":"note 記事一覧","summary":"はじめに"},
   {"name":"article-assignments.md","path":"references/00-management/article-assignments.md","ext":"md","dir":"references/00-management","size":1621,"summary":"Note 記事担当一覧"},
   {"name":"20260509-agent-skills-activation.md","path":"references/agent-skills/20260509-agent-skills-activation.md","ext":"md","dir":"references/agent-skills","size":14636,"title":"Agent Skills の発火は、どのように起きているのか","summary":"はじめに"},
   {"name":"20260509-agent-skills-docs.md","path":"references/agent-skills/20260509-agent-skills-docs.md","ext":"md","dir":"references/agent-skills","size":14394,"title":"Agent Skills では、説明ページの役割が少し変わる","summary":"はじめに"},
@@ -25,8 +25,8 @@
   {"name":"20260530-general-ai-subscription-pricing-runway.md","path":"references/general/20260530-general-ai-subscription-pricing-runway.md","ext":"md","dir":"references/general","size":20792,"title":"生成AIは、なぜこんなに親しみやすい価格帯で使えてしまうのか","summary":"はじめに"},
   {"name":"20260601-general-generative-ai-model-vectors.md","path":"references/general/20260601-general-generative-ai-model-vectors.md","ext":"md","dir":"references/general","size":31885,"title":"生成AIモデルの仕組み入門：トークン、ベクトル、Attention、学習","summary":"はじめに"},
   {"name":"20260603-general-agent-skills-magic-book.md","path":"references/general/20260603-general-agent-skills-magic-book.md","ext":"md","dir":"references/general","size":14973,"title":"生成AIの Agent Skills は魔法書に近い","summary":"はじめに"},
+  {"name":"20260604-general-mermaid-uml-introduction.md","path":"references/general/20260604-general-mermaid-uml-introduction.md","ext":"md","dir":"references/general","size":20770,"title":"Mermaid から入る UML 入門：図からクラス図・シーケンス図・状態遷移図をちょっと理解","summary":"はじめに"},
   {"name":"202606xx-general-agile-thinking.md","path":"references/general/202606xx-general-agile-thinking.md","ext":"md","dir":"references/general","size":17908,"title":"アジャイルという考え方に入門する","summary":"はじめに"},
-  {"name":"20260604-general-mermaid-uml-introduction.md","path":"references/general/20260604-general-mermaid-uml-introduction.md","ext":"md","dir":"references/general","size":20399,"title":"Mermaid から入る UML 入門：図からクラス図・シーケンス図・状態遷移図をちょっと理解","summary":"はじめに"},
   {"name":"202606xx-general-modern-agile-terms.md","path":"references/general/202606xx-general-modern-agile-terms.md","ext":"md","dir":"references/general","size":15693,"title":"現代のアジャイルは、周辺語が多すぎる","summary":"はじめに"},
   {"name":"202606xx-general-object-oriented-thinking.md","path":"references/general/202606xx-general-object-oriented-thinking.md","ext":"md","dir":"references/general","size":17509,"title":"オブジェクト指向という考え方に入門する","summary":"はじめに"},
   {"name":"20260412-miku-abc-player-intro.md","path":"references/miku-abc-player/20260412-miku-abc-player-intro.md","ext":"md","dir":"references/miku-abc-player","size":3650,"title":"[miku-abc-player] `ABC` 記譜法の譜面を、ちょっと五線譜で見たくなった","summary":"はじめに"},


### PR DESCRIPTION
## 概要

repo 全体の `pom.xml` バージョンと、`みくく` の `VERSION.md` のバージョンが対応していることを Maven の `validate` phase で確認する仕組みを追加しました。

あわせて、repo バージョンを `1.20260604.1` に更新し、README にバージョン更新時の確認事項を追記しています。

## 変更内容

- root `pom.xml` の version を `1.20260604.1` に更新
- `validate-version-alignment` 実行を Maven `validate` phase に追加
- `scripts/validate-version-alignment.sh` を追加
  - `pom.xml` の `1.YYYYMMDD.N` 形式を検証
  - `VERSION.md` の `YYYYMMDDx` 形式を検証
  - 日付部分と更新番号 / suffix の対応をチェック
  - 例: `1.20260604.1` と `20260604a`
- README のバージョン更新ルールに release archive 名と Maven validate での整合性確認を追記
- `igapyon-mikuku-agent/index.json` と `igapyon-note-writer/index.json` を更新