### PR TITLE
PR対象未指定時に最新コミットを使うルールを追加

### DIFF
--- a/skills/igapyon-github-writer/SKILL.md
+++ b/skills/igapyon-github-writer/SKILL.md
@@ -24,9 +24,9 @@ Examples:
 - About mode: `GitHub Aboutを書きたい`, `About文`, `リポジトリ説明`, `GitHub説明文`
 - Branch Status mode: `github-writerでブランチ状況`, `今のブランチの状況`, `PR前にブランチ状態を見たい`, `現在ブランチの確認`
 
-If the mode is clear but required evidence is missing, do not draft yet. Ask for the missing target:
+If the mode is clear but required evidence is missing, do not draft yet. Ask for the missing target, except for PR mode's default target rule:
 
-- PR mode: ask for the target commit ID, explicit Git range, or branch comparison.
+- PR mode: if the user asks for PR text without specifying a commit ID, Git range, branch comparison, or working-tree target, first run `git log --oneline --decorate -1` to resolve the current latest commit, then use that single commit as the PR target. Do not include uncommitted working-tree changes.
 - Release mode: ask for the start commit ID, explicit Git range, or tag/range target.
 - About mode: ask whether to use `README.md` and project metadata, or ask for the source text when repository evidence is not obvious.
 

--- a/skills/igapyon-github-writer/index.json
+++ b/skills/igapyon-github-writer/index.json
@@ -5,9 +5,9 @@
  "files": [
   {"name":"about-writing.md","path":"references/about-writing.md","ext":"md","dir":"references","size":1136,"summary":"GitHub About Writing"},
   {"name":"branch-status.md","path":"references/branch-status.md","ext":"md","dir":"references","size":2672,"summary":"GitHub Branch Status"},
-  {"name":"github-writing-rules.md","path":"references/github-writing-rules.md","ext":"md","dir":"references","size":3282,"summary":"GitHub Writing Rules"},
-  {"name":"pr-writing.md","path":"references/pr-writing.md","ext":"md","dir":"references","size":2860,"summary":"GitHub PR Writing"},
+  {"name":"github-writing-rules.md","path":"references/github-writing-rules.md","ext":"md","dir":"references","size":3946,"summary":"GitHub Writing Rules"},
+  {"name":"pr-writing.md","path":"references/pr-writing.md","ext":"md","dir":"references","size":3055,"summary":"GitHub PR Writing"},
   {"name":"release-writing.md","path":"references/release-writing.md","ext":"md","dir":"references","size":3555,"summary":"GitHub Release Writing"},
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":4271,"description":"Use only when the user explicitly asks to draft GitHub PR text, GitHub Release notes, GitHub About text, or asks to inspect the current branch status using igapyon-github-writer. If the user only asks whether such a skill exists, mention this skill as an available option but do not apply it until asked.","summary":"igapyon-github-writer"}
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":4533,"description":"Use only when the user explicitly asks to draft GitHub PR text, GitHub Release notes, GitHub About text, or asks to inspect the current branch status using igapyon-github-writer. If the user only asks whether such a skill exists, mention this skill as an available option but do not apply it until asked.","summary":"igapyon-github-writer"}
  ]
 }

--- a/skills/igapyon-github-writer/references/github-writing-rules.md
+++ b/skills/igapyon-github-writer/references/github-writing-rules.md
@@ -24,6 +24,7 @@ Use these interpretations unless the user explicitly says otherwise:
 - `<commit> の変更内容`: use exactly that single commit.
 - `<base>..<head>`: use Git's normal exclusive-left range; changes reachable from `<head>` but not from `<base>`.
 - `<base>...<head>`: use Git's normal merge-base comparison semantics.
+- PR request without a commit ID, explicit Git range, branch comparison, or working-tree target: first run `git log --oneline --decorate -1` to resolve the current latest commit ID, then use that single commit as the PR target. Inspect it as `<resolved-commit>` / `<resolved-commit>^..<resolved-commit>` and do not include uncommitted working-tree changes.
 - Release request with only a start commit ID: implicitly treat it as `<start>` through `HEAD`, including the change introduced by `<start>`; use `<start>^..HEAD`.
 - `<start> から HEAD まで` with wording that says `<start>` itself is included: use `<start>^..HEAD`.
 - `<start> から HEAD まで` in Release mode: treat `<start>` itself as included by default; use `<start>^..HEAD` unless the user explicitly says to exclude `<start>`.
@@ -37,6 +38,14 @@ For PR text, a request that says `対象コミット <commit> における変更
 For Release text, a start commit ID implies `from <start> through HEAD, including <start>`. Inspect `<start>^..HEAD` unless the user explicitly provides another range.
 
 After resolving the target, inspect the requested evidence.
+
+For a PR request without an explicit target:
+
+```sh
+git log --oneline --decorate -1
+```
+
+Use the commit ID shown by that command as the single commit target for the following inspection commands. Do not silently use an older commit ID from the conversation when the user's latest request omits the target.
 
 For a single commit:
 

--- a/skills/igapyon-github-writer/references/pr-writing.md
+++ b/skills/igapyon-github-writer/references/pr-writing.md
@@ -10,11 +10,12 @@ After `igapyon-github-writer` is active, enter PR mode for similar wording such 
 
 ## Target Rules
 
-- A commit ID or explicit Git range is required input for PR drafting.
-- If the user asks for PR text without a commit ID, commit range, branch comparison, or explicit working-tree target, ask for the target before drafting.
-- In that case, ask briefly in Japanese, for example: `対象コミットID、Git範囲、またはブランチ比較を教えてください。`
+- If the user asks for PR text without a commit ID, commit range, branch comparison, or explicit working-tree target, first run `git log --oneline --decorate -1` to resolve the current latest commit ID.
+- Use the commit ID shown by that command as the single commit PR target.
+- Interpret that default as `<resolved-commit>^..<resolved-commit>` for the change content, and inspect the single commit `<resolved-commit>`.
+- This default means committed history only. Do not include uncommitted working-tree changes unless the user explicitly asks for them.
 - If the user says `対象コミット <commit> における変更内容`, draft from exactly that commit.
-- Do not include parent commits, child commits, `HEAD`, or the current working tree unless the user explicitly asks for them.
+- Do not include parent commits, child commits, additional ranges, or the current working tree unless the user explicitly asks for them.
 - If the user gives a commit range, use that range exactly after applying the shared target-resolution rules.
 - If the PR target cannot be resolved from the request, ask for the commit, range, or branch comparison before drafting.
 


### PR DESCRIPTION
  ## 概要

  `igapyon-github-writer` の PR 文面作成ルールを更新し、PR 対象が明示されていな
  い場合は、コミット済み履歴の最新 1 件を対象にするようにしました。

  ## 変更内容

  - PR mode で対象コミット、Git 範囲、ブランチ比較、作業ツリー対象が指定されてい ない場合のデフォルト挙動を追加
  - 無指定時は `git log --oneline --decorate -1` で現在の最新コミット ID を解決 し、その単一コミットを PR 対象にするよう明記
  - デフォルト対象を `<resolved-commit>^..<resolved-commit>` として扱い、未コ ミットの作業ツリー変更を含めないことを明記
  - `SKILL.md`、PR writing rules、共通 GitHub writing rules の説明を同じ方針に更 新
  - `index.json` のファイルサイズ情報を更新