### PR TITLE
バージョンを 1.20260608.1 に更新

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260607.1</version>
+  <version>1.20260608.1</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260607a
+Version: 20260608a
 
 ## Version Rule
 


### PR DESCRIPTION
  ## 概要

  リポジトリ全体のバージョンを `1.20260608.1` に更新し、対応するみくくバージョン
  を `20260608a` にそろえました。

  ## 変更内容

  - `pom.xml` のプロジェクトバージョンを `1.20260607.1` から `1.20260608.1` に更 新
  - `skills/igapyon-mikuku-agent/references/VERSION.md` の `Version` を `20260607a` から `20260608a` に更新

  ## 確認

  - `mvn validate` でバージョン整合チェックが成功