### PR TITLE
miku-grep-skills を release archive 同梱対象に追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ release archive には、この repo の `skills/` に加えて、外部管理�
 
 - `miku-indexgen-skills` `v1.5.1.1`: `skills/igapyon-miku-indexgen/`
 - `miku-text-bundle-skills` `v0.9.0.1`: `skills/igapyon-miku-text-bundle/`
+- `miku-grep-skills` `v0.10.1.1`: `skills/igapyon-miku-grep/`
 - `mikuproject-skills` `v0.8.1.1`: `skills/mikuproject/`
 - `mikuscore-skills` `v0.1.0`: `skills/mikuscore/`
 

--- a/TODO.md
+++ b/TODO.md
@@ -165,6 +165,10 @@
 
 - [x] `miku-indexgen-skills` は同梱時の正式 skill 名、`SKILL.md` frontmatter `name`、展開後ディレクトリを `igapyon-miku-indexgen` にする方針へ移行済み
 - [x] `miku-text-bundle-skills` は `v0.9.0.1` で同梱時の正式 skill 名、`SKILL.md` frontmatter `name`、展開後ディレクトリを `igapyon-miku-text-bundle` にする方針へ移行済み
+- [x] `miku-grep-skills` は `v0.10.1.1` で同梱時の正式 skill 名、`SKILL.md` frontmatter `name`、展開後ディレクトリを `igapyon-miku-grep` にする方針へ移行済み
+  - 互換 trigger として `miku-grep` は維持する
+- [ ] `miku-readfile-skills` もいずれ外部管理 miku-soft 系 skill として release archive に同梱する
+  - 同梱時は GitHub latest release と skill directory 名を確認し、`pom.xml` の `external.*` properties と `README.md` の同梱一覧を更新する
 - [ ] `mikuproject-skills` も同梱時の正式 skill 名、`SKILL.md` frontmatter `name`、展開後ディレクトリに `igapyon-` prefix を付ける方針へ移行する
   - 現状の同梱先: `skills/mikuproject/`
   - 移行候補: `skills/igapyon-mikuproject/`

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,9 @@
     <external.miku-text-bundle-skills.repo>https://github.com/igapyon/miku-text-bundle-skills.git</external.miku-text-bundle-skills.repo>
     <external.miku-text-bundle-skills.ref>v0.9.0.1</external.miku-text-bundle-skills.ref>
     <external.miku-text-bundle-skills.skillName>igapyon-miku-text-bundle</external.miku-text-bundle-skills.skillName>
+    <external.miku-grep-skills.repo>https://github.com/igapyon/miku-grep-skills.git</external.miku-grep-skills.repo>
+    <external.miku-grep-skills.ref>v0.10.1.1</external.miku-grep-skills.ref>
+    <external.miku-grep-skills.skillName>igapyon-miku-grep</external.miku-grep-skills.skillName>
     <external.mikuproject-skills.repo>https://github.com/igapyon/mikuproject-skills.git</external.mikuproject-skills.repo>
     <external.mikuproject-skills.ref>v0.8.1.1</external.mikuproject-skills.ref>
     <external.mikuproject-skills.skillName>mikuproject</external.mikuproject-skills.skillName>
@@ -81,6 +84,9 @@
                 <argument>${external.miku-text-bundle-skills.repo}</argument>
                 <argument>${external.miku-text-bundle-skills.ref}</argument>
                 <argument>${external.miku-text-bundle-skills.skillName}</argument>
+                <argument>${external.miku-grep-skills.repo}</argument>
+                <argument>${external.miku-grep-skills.ref}</argument>
+                <argument>${external.miku-grep-skills.skillName}</argument>
                 <argument>${external.mikuproject-skills.repo}</argument>
                 <argument>${external.mikuproject-skills.ref}</argument>
                 <argument>${external.mikuproject-skills.skillName}</argument>


### PR DESCRIPTION
## 概要

`miku-grep-skills` を外部管理 skill として release archive の同梱対象に追加します。

## 変更内容

- `pom.xml` に `miku-grep-skills` の外部リポジトリ、参照バージョン、展開後 skill 名を追加
- release archive 生成時の外部 skill 引数に `miku-grep-skills` を追加
- `README.md` の外部管理 skill 同梱一覧に `miku-grep-skills v0.10.1.1` を追加
- `TODO.md` に `miku-grep-skills` の移行完了メモと、今後の `miku-readfile-skills` 同梱候補メモを追加