### PR TITLE
外部管理 skill の同梱設定を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,8 +306,9 @@ release archive には、この repo の `skills/` に加えて、外部管理�
 同梱する外部 skill は次の通りです。
 
 - `miku-indexgen-skills` `v1.5.1.1`: `skills/igapyon-miku-indexgen/`
-- `miku-text-bundle-skills` `v0.9.0.1`: `skills/igapyon-miku-text-bundle/`
-- `miku-grep-skills` `v0.10.1.1`: `skills/igapyon-miku-grep/`
+- `miku-text-bundle-skills` `v1.0.0`: `skills/igapyon-miku-text-bundle/`
+- `miku-repo-bundle-skills` `v0.5.0.1` (experimental): `skills/igapyon-miku-repo-bundle/`
+- `miku-grep-skills` `v0.10.1.1` (experimental): `skills/igapyon-miku-grep/`
 - `mikuproject-skills` `v0.8.1.1`: `skills/mikuproject/`
 - `mikuscore-skills` `v0.1.0`: `skills/mikuscore/`
 

--- a/TODO.md
+++ b/TODO.md
@@ -197,8 +197,12 @@
 ## miku Agent Skills 同梱名の igapyon- prefix 移行
 
 - [x] `miku-indexgen-skills` は同梱時の正式 skill 名、`SKILL.md` frontmatter `name`、展開後ディレクトリを `igapyon-miku-indexgen` にする方針へ移行済み
-- [x] `miku-text-bundle-skills` は `v0.9.0.1` で同梱時の正式 skill 名、`SKILL.md` frontmatter `name`、展開後ディレクトリを `igapyon-miku-text-bundle` にする方針へ移行済み
+- [x] `miku-text-bundle-skills` は `v1.0.0` で同梱時の正式 skill 名、`SKILL.md` frontmatter `name`、展開後ディレクトリを `igapyon-miku-text-bundle` にする方針へ移行済み
+- [x] `miku-repo-bundle-skills` は `v0.5.0.1` で release archive に同梱する
+  - 同梱先: `skills/igapyon-miku-repo-bundle/`
+  - status: experimental
 - [x] `miku-grep-skills` は `v0.10.1.1` で同梱時の正式 skill 名、`SKILL.md` frontmatter `name`、展開後ディレクトリを `igapyon-miku-grep` にする方針へ移行済み
+  - status: experimental
   - 互換 trigger として `miku-grep` は維持する
 - [ ] `miku-readfile-skills` もいずれ外部管理 miku-soft 系 skill として release archive に同梱する
   - 同梱時は GitHub latest release と skill directory 名を確認し、`pom.xml` の `external.*` properties と `README.md` の同梱一覧を更新する

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260609.1</version>
+  <version>1.20260609.3</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>
@@ -15,8 +15,11 @@
     <external.miku-indexgen-skills.ref>v1.5.1.1</external.miku-indexgen-skills.ref>
     <external.miku-indexgen-skills.skillName>igapyon-miku-indexgen</external.miku-indexgen-skills.skillName>
     <external.miku-text-bundle-skills.repo>https://github.com/igapyon/miku-text-bundle-skills.git</external.miku-text-bundle-skills.repo>
-    <external.miku-text-bundle-skills.ref>v0.9.0.1</external.miku-text-bundle-skills.ref>
+    <external.miku-text-bundle-skills.ref>v1.0.0</external.miku-text-bundle-skills.ref>
     <external.miku-text-bundle-skills.skillName>igapyon-miku-text-bundle</external.miku-text-bundle-skills.skillName>
+    <external.miku-repo-bundle-skills.repo>https://github.com/igapyon/miku-repo-bundle-skills.git</external.miku-repo-bundle-skills.repo>
+    <external.miku-repo-bundle-skills.ref>v0.5.0.1</external.miku-repo-bundle-skills.ref>
+    <external.miku-repo-bundle-skills.skillName>igapyon-miku-repo-bundle</external.miku-repo-bundle-skills.skillName>
     <external.miku-grep-skills.repo>https://github.com/igapyon/miku-grep-skills.git</external.miku-grep-skills.repo>
     <external.miku-grep-skills.ref>v0.10.1.1</external.miku-grep-skills.ref>
     <external.miku-grep-skills.skillName>igapyon-miku-grep</external.miku-grep-skills.skillName>
@@ -84,6 +87,9 @@
                 <argument>${external.miku-text-bundle-skills.repo}</argument>
                 <argument>${external.miku-text-bundle-skills.ref}</argument>
                 <argument>${external.miku-text-bundle-skills.skillName}</argument>
+                <argument>${external.miku-repo-bundle-skills.repo}</argument>
+                <argument>${external.miku-repo-bundle-skills.ref}</argument>
+                <argument>${external.miku-repo-bundle-skills.skillName}</argument>
                 <argument>${external.miku-grep-skills.repo}</argument>
                 <argument>${external.miku-grep-skills.ref}</argument>
                 <argument>${external.miku-grep-skills.skillName}</argument>

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260609a
+Version: 20260609c
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

外部管理している miku 系 skill の同梱情報を更新し、`miku-repo-bundle-skills` を release archive の同梱対象に追加します。

## 変更内容

- `pom.xml` のプロジェクトバージョンを `1.20260609.3` に更新
- `miku-text-bundle-skills` の参照バージョンを `v1.0.0` に更新
- `miku-repo-bundle-skills` `v0.5.0.1` を外部 skill として追加
- `README.md` の外部 skill 同梱一覧に `miku-repo-bundle-skills` を追加
- `miku-repo-bundle-skills` と `miku-grep-skills` の status を experimental として記載
- `TODO.md` の igapyon-prefix 移行状況を更新
- `igapyon-mikuku-agent` の参照バージョン表記を `20260609c` に更新