### PR TITLE
プロジェクトとみくく参照バージョンを更新

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260609.3</version>
+  <version>1.20260610.1</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260609c
+Version: 20260610a
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

プロジェクトの Maven バージョンと `igapyon-mikuku-agent` の参照バージョン表記を更新します。

## 変更内容

- `pom.xml` のプロジェクトバージョンを `1.20260610.1` に更新
- `skills/igapyon-mikuku-agent/references/VERSION.md` のみくくバージョンを `20260610a` に更新