### PR TITLE
外部 miku-text-bundle skill 参照を v1.0.1 に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ release archive には、この repo の `skills/` に加えて、外部管理�
 同梱する外部 skill は次の通りです。
 
 - `miku-indexgen-skills` `v1.5.1.1`: `skills/igapyon-miku-indexgen/`
-- `miku-text-bundle-skills` `v1.0.0`: `skills/igapyon-miku-text-bundle/`
+- `miku-text-bundle-skills` `v1.0.1`: `skills/igapyon-miku-text-bundle/`
 - `miku-repo-bundle-skills` `v0.5.0.1` (experimental): `skills/igapyon-miku-repo-bundle/`
 - `miku-grep-skills` `v0.10.1.1` (experimental): `skills/igapyon-miku-grep/`
 - `mikuproject-skills` `v0.8.1.1`: `skills/mikuproject/`

--- a/TODO.md
+++ b/TODO.md
@@ -216,7 +216,7 @@
 ## miku Agent Skills 同梱名の igapyon- prefix 移行
 
 - [x] `miku-indexgen-skills` は同梱時の正式 skill 名、`SKILL.md` frontmatter `name`、展開後ディレクトリを `igapyon-miku-indexgen` にする方針へ移行済み
-- [x] `miku-text-bundle-skills` は `v1.0.0` で同梱時の正式 skill 名、`SKILL.md` frontmatter `name`、展開後ディレクトリを `igapyon-miku-text-bundle` にする方針へ移行済み
+- [x] `miku-text-bundle-skills` は `v1.0.1` で同梱時の正式 skill 名、`SKILL.md` frontmatter `name`、展開後ディレクトリを `igapyon-miku-text-bundle` にする方針へ移行済み
 - [x] `miku-repo-bundle-skills` は `v0.5.0.1` で release archive に同梱する
   - 同梱先: `skills/igapyon-miku-repo-bundle/`
   - status: experimental

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260610.1</version>
+  <version>1.20260610.2</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>
@@ -15,7 +15,7 @@
     <external.miku-indexgen-skills.ref>v1.5.1.1</external.miku-indexgen-skills.ref>
     <external.miku-indexgen-skills.skillName>igapyon-miku-indexgen</external.miku-indexgen-skills.skillName>
     <external.miku-text-bundle-skills.repo>https://github.com/igapyon/miku-text-bundle-skills.git</external.miku-text-bundle-skills.repo>
-    <external.miku-text-bundle-skills.ref>v1.0.0</external.miku-text-bundle-skills.ref>
+    <external.miku-text-bundle-skills.ref>v1.0.1</external.miku-text-bundle-skills.ref>
     <external.miku-text-bundle-skills.skillName>igapyon-miku-text-bundle</external.miku-text-bundle-skills.skillName>
     <external.miku-repo-bundle-skills.repo>https://github.com/igapyon/miku-repo-bundle-skills.git</external.miku-repo-bundle-skills.repo>
     <external.miku-repo-bundle-skills.ref>v0.5.0.1</external.miku-repo-bundle-skills.ref>

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260610a
+Version: 20260610b
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

外部同梱 skill `miku-text-bundle-skills` の参照バージョンを `v1.0.1` に更新し、関連ドキュメントとプロジェクト版数を同期します。

## 変更内容

- `pom.xml` のプロジェクトバージョンを `1.20260610.2` に更新
- `pom.xml` の `external.miku-text-bundle-skills.ref` を `v1.0.0` から `v1.0.1` に更新
- `README.md` と `TODO.md` の `miku-text-bundle-skills` 記載を `v1.0.1` に更新
- `skills/igapyon-mikuku-agent/references/VERSION.md` のみくく Version を `20260610b` に更新