### PR TITLE
プロジェクトとみくくスキルのバージョンを更新

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260610.2</version>
+  <version>1.20260613.2</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260610b
+Version: 20260613b
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

プロジェクト全体の Maven バージョンと、みくくスキルの参照用バージョン表記を更新しました。

## 変更内容

- `pom.xml` のバージョンを `1.20260610.2` から `1.20260613.2` に更新
- `igapyon-mikuku-agent` の `VERSION.md` を `20260610b` から `20260613b` に更新