### PR TITLE
外部スキル同期対象に miku-prompt-lint と miku-readfile を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ release archive には、この repo の `skills/` に加えて、外部管理�
 - `miku-text-bundle-skills` `v1.0.1`: `skills/igapyon-miku-text-bundle/`
 - `miku-repo-bundle-skills` `v0.5.0.1` (experimental): `skills/igapyon-miku-repo-bundle/`
 - `miku-grep-skills` `v0.10.1.1` (experimental): `skills/igapyon-miku-grep/`
+- `miku-prompt-lint-skills` `v0.4.1`: `skills/igapyon-miku-prompt-lint/`
+- `miku-readfile-skills` `v0.5.0.2`: `skills/miku-readfile/`
 - `mikuproject-skills` `v0.8.1.1`: `skills/mikuproject/`
 - `mikuscore-skills` `v0.1.0`: `skills/mikuscore/`
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260613.2</version>
+  <version>1.20260620.1</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>
@@ -23,6 +23,12 @@
     <external.miku-grep-skills.repo>https://github.com/igapyon/miku-grep-skills.git</external.miku-grep-skills.repo>
     <external.miku-grep-skills.ref>v0.10.1.1</external.miku-grep-skills.ref>
     <external.miku-grep-skills.skillName>igapyon-miku-grep</external.miku-grep-skills.skillName>
+    <external.miku-prompt-lint-skills.repo>https://github.com/igapyon/miku-prompt-lint-skills.git</external.miku-prompt-lint-skills.repo>
+    <external.miku-prompt-lint-skills.ref>v0.4.1</external.miku-prompt-lint-skills.ref>
+    <external.miku-prompt-lint-skills.skillName>igapyon-miku-prompt-lint</external.miku-prompt-lint-skills.skillName>
+    <external.miku-readfile-skills.repo>https://github.com/igapyon/miku-readfile-skills.git</external.miku-readfile-skills.repo>
+    <external.miku-readfile-skills.ref>v0.5.0.2</external.miku-readfile-skills.ref>
+    <external.miku-readfile-skills.skillName>miku-readfile</external.miku-readfile-skills.skillName>
     <external.mikuproject-skills.repo>https://github.com/igapyon/mikuproject-skills.git</external.mikuproject-skills.repo>
     <external.mikuproject-skills.ref>v0.8.1.1</external.mikuproject-skills.ref>
     <external.mikuproject-skills.skillName>mikuproject</external.mikuproject-skills.skillName>
@@ -93,6 +99,12 @@
                 <argument>${external.miku-grep-skills.repo}</argument>
                 <argument>${external.miku-grep-skills.ref}</argument>
                 <argument>${external.miku-grep-skills.skillName}</argument>
+                <argument>${external.miku-prompt-lint-skills.repo}</argument>
+                <argument>${external.miku-prompt-lint-skills.ref}</argument>
+                <argument>${external.miku-prompt-lint-skills.skillName}</argument>
+                <argument>${external.miku-readfile-skills.repo}</argument>
+                <argument>${external.miku-readfile-skills.ref}</argument>
+                <argument>${external.miku-readfile-skills.skillName}</argument>
                 <argument>${external.mikuproject-skills.repo}</argument>
                 <argument>${external.mikuproject-skills.ref}</argument>
                 <argument>${external.mikuproject-skills.skillName}</argument>

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260613b
+Version: 20260620a
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

外部管理スキルの同期対象に `miku-prompt-lint-skills` と `miku-readfile-skills` を追加し、プロジェクト版数と `igapyon-mikuku-agent` のバージョン情報を更新します。

## 変更内容

- `README.md` の外部管理スキル一覧に `miku-prompt-lint-skills` `v0.4.1` と `miku-readfile-skills` `v0.5.0.2` を追加
- `pom.xml` のプロジェクトバージョンを `1.20260620.1` に更新
- `pom.xml` に `miku-prompt-lint-skills` と `miku-readfile-skills` のリポジトリ、参照タグ、スキル名を追加
- 外部スキル同期処理の引数に上記 2 スキルを追加
- `igapyon-mikuku-agent` のバージョン表記を `20260620a` に更新