### PR TITLE
外部スキルの参照バージョンを更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,8 +305,8 @@ release archive には、この repo の `skills/` に加えて、外部管理�
 
 同梱する外部 skill は次の通りです。
 
-- `miku-indexgen-skills` `v1.5.1.1`: `skills/igapyon-miku-indexgen/`
-- `miku-text-bundle-skills` `v1.0.1`: `skills/igapyon-miku-text-bundle/`
+- `miku-indexgen-skills` `v1.6.1`: `skills/igapyon-miku-indexgen/`
+- `miku-text-bundle-skills` `v1.1.1.2`: `skills/igapyon-miku-text-bundle/`
 - `miku-repo-bundle-skills` `v0.5.0.1` (experimental): `skills/igapyon-miku-repo-bundle/`
 - `miku-grep-skills` `v0.10.1.1` (experimental): `skills/igapyon-miku-grep/`
 - `miku-prompt-lint-skills` `v0.4.1`: `skills/igapyon-miku-prompt-lint/`

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,10 @@
 
   <properties>
     <external.miku-indexgen-skills.repo>https://github.com/igapyon/miku-indexgen-skills.git</external.miku-indexgen-skills.repo>
-    <external.miku-indexgen-skills.ref>v1.5.1.1</external.miku-indexgen-skills.ref>
+    <external.miku-indexgen-skills.ref>v1.6.1</external.miku-indexgen-skills.ref>
     <external.miku-indexgen-skills.skillName>igapyon-miku-indexgen</external.miku-indexgen-skills.skillName>
     <external.miku-text-bundle-skills.repo>https://github.com/igapyon/miku-text-bundle-skills.git</external.miku-text-bundle-skills.repo>
-    <external.miku-text-bundle-skills.ref>v1.0.1</external.miku-text-bundle-skills.ref>
+    <external.miku-text-bundle-skills.ref>v1.1.1.2</external.miku-text-bundle-skills.ref>
     <external.miku-text-bundle-skills.skillName>igapyon-miku-text-bundle</external.miku-text-bundle-skills.skillName>
     <external.miku-repo-bundle-skills.repo>https://github.com/igapyon/miku-repo-bundle-skills.git</external.miku-repo-bundle-skills.repo>
     <external.miku-repo-bundle-skills.ref>v0.5.0.1</external.miku-repo-bundle-skills.ref>


### PR DESCRIPTION
## 概要

外部管理スキルとして同梱する `miku-indexgen-skills` と `miku-text-bundle-skills` の参照バージョンを更新します。

## 変更内容

- `README.md` の外部 skill 一覧で `miku-indexgen-skills` を `v1.6.1` に更新
- `README.md` の外部 skill 一覧で `miku-text-bundle-skills` を `v1.1.1.2` に更新
- `pom.xml` の `external.miku-indexgen-skills.ref` を `v1.6.1` に更新
- `pom.xml` の `external.miku-text-bundle-skills.ref` を `v1.1.1.2` に更新