### PR TITLE
igapyon-agent-state-management スキルを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ Note 正本側では、`../mikuku-articles/` に 1 セットとして保持し�
 │  ├─ igapyon-ffmpeg-helper/
 │  │  ├─ SKILL.md
 │  │  └─ references/
+│  ├─ igapyon-agent-state-management/
+│  │  ├─ SKILL.md
+│  │  ├─ references/
+│  │  └─ templates/
 │  ├─ igapyon-miku-soft-developer/
 │  │  ├─ SKILL.md
 │  │  └─ references/
@@ -249,6 +253,12 @@ Note 正本側では、`../mikuku-articles/` に 1 セットとして保持し�
 - `igapyon-ffmpeg-helper`
 
   H4essential のオーケストラ録音から、切り出し、単純ゲイン調整、必要なら結合、静止画付き YouTube 用動画作成までの個人用 FFmpeg ワークフロー向け。明示的に指定した場合に利用する。
+
+- `igapyon-agent-state-management`
+
+  AI エージェント作業用の `GOAL.md`、`TODO.md`、`DECISIONS.md` による軽量な状態管理ファイルの作成・整理・運用向け。発火は `igapyon-agent-state-management` の明示、または `igapyon 状態管理`、`igapyon 作業状態`、`igapyon 作業再開`、`igapyon 3ファイル`、`igapyon goal`、`igapyon todo` などの `igapyon` 付き合言葉を基本とする。`igapyon 作業再開` では、3ファイルを新規作成せず、まず既存の repo 状態、`TODO.md`、`GOAL.md`、`DECISIONS.md` などを読んで再開ポイントを整理する。
+
+  名前を思い出せない場合は、`igapyon 状態管理` または `igapyon 作業再開` を合言葉として使う。
 
 - `igapyon-miku-soft-developer`
 

--- a/skills/igapyon-agent-state-management/SKILL.md
+++ b/skills/igapyon-agent-state-management/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: igapyon-agent-state-management
+description: Use only when the user explicitly names igapyon-agent-state-management or uses an igapyon-prefixed trigger phrase such as igapyon 状態管理, igapyon agent 状態管理, igapyon 作業状態, igapyon 作業再開, igapyon 3ファイル, igapyon goal, igapyon todo, or igapyon GOAL TODO DECISIONS. Do not trigger for generic TODO.md maintenance, ordinary project planning, vague handoff discussion, ordinary work resumption, broad Context Engineering talk, or even the GOAL.md + TODO.md + DECISIONS.md workflow unless the user also says igapyon or explicitly names this skill.
+---
+
+# Igapyon Agent State Management
+
+This skill helps set up and maintain a small Markdown-based state-management convention for AI agent work.
+
+The default convention uses three repository-local files:
+
+- `GOAL.md`: define the objective, completion conditions, and stop conditions
+- `TODO.md`: track current tasks, blockers, and repeated failures
+- `DECISIONS.md`: record important decisions and reasons
+
+Use this as a repository workflow skill. It is not tied to a specific character agent, model, editor, or vendor.
+
+## Trigger Phrases
+
+This skill intentionally uses hard triggers. Prefer these phrases when the user has forgotten the exact skill name:
+
+- `igapyon 状態管理`
+- `igapyon 作業状態`
+- `igapyon 作業再開`
+- `igapyon 3ファイル`
+- `igapyon goal`
+- `igapyon todo`
+- `igapyon GOAL TODO DECISIONS`
+
+When answering a general question such as "what skills are available?", describe this skill as the one for `igapyon 状態管理` and `igapyon 作業再開`.
+
+## Core Workflow
+
+1. Inspect the repository before editing.
+2. Check whether `GOAL.md`, `TODO.md`, or `DECISIONS.md` already exist.
+3. Do not overwrite existing files without reading them first.
+4. If `TODO.md` already exists, preserve its existing purpose and add or update only `## AI Agent Current Tasks` when appropriate.
+5. Use [references/three-markdown-state-files.md](references/three-markdown-state-files.md) for the detailed setup rules and initial prompt.
+6. Use templates from [templates/](templates/) when creating new files.
+7. Keep the state files lightweight. Do not turn them into long work logs or broad project documentation.
+
+## Resume Workflow
+
+When the user says `igapyon 作業再開`, treat it as a request to recover the current repository working state, not necessarily to create new files.
+
+1. Inspect the repository state with ordinary local context such as `git status --short`, `README.md`, existing `TODO.md`, and any existing `GOAL.md` or `DECISIONS.md`.
+2. If the three state files already exist, read them and summarize the current objective, next tasks, blockers, and relevant decisions.
+3. If they do not exist, do not create them automatically unless the user asks. Briefly mention that this skill can set up `GOAL.md`, `TODO.md`, and `DECISIONS.md` if needed.
+4. Keep the output focused on what to do next and any uncertainty that needs user confirmation.
+
+## File Roles
+
+Read `GOAL.md` before starting work, before declaring completion, and whenever scope becomes unclear.
+
+Read and update `TODO.md` during work when task status changes, blockers appear, new work is found, or the same failure repeats.
+
+Read `DECISIONS.md` before making or revisiting important decisions, especially when the work appears to loop.
+
+## Existing Files
+
+If a repository already has a human-oriented `TODO.md`, do not replace it and do not force front matter into it.
+
+Instead, add or update this section only:
+
+```markdown
+## AI Agent Current Tasks
+```
+
+If the section already exists, update it in place. Do not duplicate it.
+
+If `GOAL.md` or `DECISIONS.md` already exists, read it and propose a scoped change or add compatible sections. Do not assume it is an AI-agent state file unless the contents indicate that role.
+
+## Templates
+
+- [templates/GOAL.md](templates/GOAL.md)
+- [templates/TODO.md](templates/TODO.md)
+- [templates/DECISIONS.md](templates/DECISIONS.md)
+
+Replace `((TBD: ...))` placeholders with concrete details when the current work is known. Leave them only when the user has not provided enough information.

--- a/skills/igapyon-agent-state-management/agents/openai.yaml
+++ b/skills/igapyon-agent-state-management/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Agent State Management"
+  short_description: "Manage AI agent state with three Markdown files"
+  default_prompt: "Use $igapyon-agent-state-management to set up GOAL.md, TODO.md, and DECISIONS.md for this repository."
+policy:
+  allow_implicit_invocation: false

--- a/skills/igapyon-agent-state-management/index.json
+++ b/skills/igapyon-agent-state-management/index.json
@@ -1,0 +1,12 @@
+{
+ "generator": "miku-indexgen",
+ "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
+ "basePath": ".",
+ "files": [
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":4165,"description":"Use only when the user explicitly names igapyon-agent-state-management or uses an igapyon-prefixed trigger phrase such as igapyon 状態管理, igapyon agent 状態管理, igapyon 作業状態, igapyon 作業再開, igapyon 3ファイル, igapyon goal, igapyon todo, or igapyon GOAL TODO DECIS...","summary":"Igapyon Agent State Management"},
+  {"name":"three-markdown-state-files.md","path":"references/three-markdown-state-files.md","ext":"md","dir":"references","size":4704,"summary":"Three Markdown State Files"},
+  {"name":"DECISIONS.md","path":"templates/DECISIONS.md","ext":"md","dir":"templates","size":578,"summary":"Decisions"},
+  {"name":"GOAL.md","path":"templates/GOAL.md","ext":"md","dir":"templates","size":680,"summary":"Goal"},
+  {"name":"TODO.md","path":"templates/TODO.md","ext":"md","dir":"templates","size":885,"summary":"Todo"}
+ ]
+}

--- a/skills/igapyon-agent-state-management/references/three-markdown-state-files.md
+++ b/skills/igapyon-agent-state-management/references/three-markdown-state-files.md
@@ -1,0 +1,99 @@
+# Three Markdown State Files
+
+Use this reference when setting up or resuming lightweight AI agent state management in a repository.
+
+## Purpose
+
+The goal is to externalize the minimum state needed for an AI agent and a human to resume work without relying only on conversation history.
+
+This workflow has two closely related uses:
+
+- Setup: create or align `GOAL.md`, `TODO.md`, and `DECISIONS.md`.
+- Resume: read existing repository state and any available state files to recover the current objective, next tasks, blockers, and decisions.
+
+The default files are:
+
+- `GOAL.md`: what the work is trying to accomplish and how to know when it is done
+- `TODO.md`: the current working state, next tasks, blockers, and repeated failures
+- `DECISIONS.md`: important decisions, rejected options, and the reasons behind them
+
+This is a Context Engineering convention, not a product-specific config format. The front matter is a readable hint for agents and humans; it is not assumed to be interpreted by any tool automatically.
+
+## Initial User Prompt
+
+Use or adapt this prompt when the user asks to initialize the convention:
+
+````markdown
+このリポジトリに、AI エージェント作業用の状態管理ファイルを3つ作成してください。
+
+- `GOAL.md`
+- `TODO.md`
+- `DECISIONS.md`
+
+ただし、同名ファイルがすでに存在する場合は、上書きしないでください。
+既存の `TODO.md` が人間用TODOやプロジェクト運用ファイルとして使われている場合は、新しいTODOファイルを増やさず、既存 `TODO.md` の中に `## AI Agent Current Tasks` セクションを追加して、AI エージェント用の現在地をそこへ記録してください。
+
+新規作成するファイルには、AI エージェントが後から読んだときに用途が分かるよう、front matter と短い運用ヒントを入れてください。
+すでに同名ファイルが存在する場合は、上書きせず、内容を確認してから差分提案にしてください。
+既存 `TODO.md` に `## AI Agent Current Tasks` セクションを追加する場合は、既存ファイルの形式を尊重し、無理に front matter を追加しないでください。
+`((TBD: ...))` はプレースホルダーです。実際の作業内容が分かる場合は、作成時に具体的な内容へ置き換えてください。分からない場合は、TBD のまま残し、作業開始時に確認してください。
+````
+
+## Resume Prompt
+
+Use or adapt this prompt when the user says `igapyon 作業再開` or otherwise explicitly asks to resume through this state-management workflow:
+
+```markdown
+このリポジトリの AI エージェント作業状態を確認して、作業再開ポイントを整理してください。
+
+まず `git status --short`、`README.md`、既存の `TODO.md` を確認してください。
+`GOAL.md`、`DECISIONS.md` が存在する場合はそれも読んでください。
+
+新しい `GOAL.md`、`TODO.md`、`DECISIONS.md` は、まだ作成しないでください。
+既存状態から、現在の目的、次にやること、blocker、重要な判断、確認が必要な点を短くまとめてください。
+```
+
+## Existing TODO.md Section
+
+When an existing `TODO.md` should be preserved, add only this section if it is missing:
+
+```markdown
+## AI Agent Current Tasks
+
+This section tracks the current working state for AI agents.
+Update this section while working. Do not rewrite unrelated TODO items.
+
+### Tasks
+
+- [ ] ((TBD: 最初の作業項目を書く))
+- [ ] ((TBD: 必要なら追加する))
+
+### Blockers
+
+- ((TBD: なければ「なし」と書く))
+
+### Retry Log
+
+Use this section only when the same task or error is repeated.
+If the same failure appears 3 times, stop and ask the user.
+
+- ((TBD: YYYY-MM-DD / task / failure / changed approach))
+```
+
+## Operating Rules
+
+- Keep `GOAL.md` focused on objective, done conditions, and stop conditions.
+- Keep `TODO.md` focused on current state, not full history.
+- Keep `DECISIONS.md` focused on important decisions and their reasons, not every thought or command.
+- Use `Retry Log` only when the same task or error repeats.
+- If the same failure appears three times for the same underlying cause, stop and ask the user.
+- Prefer updating existing compatible sections over adding duplicate sections.
+- If a tool-specific entry file exists, such as `AGENTS.md` or `CLAUDE.md`, optionally add a short pointer such as: `Before working, check GOAL.md, TODO.md, and DECISIONS.md.`
+
+## Creation Templates
+
+Use the files under `templates/` as the source templates:
+
+- `templates/GOAL.md`
+- `templates/TODO.md`
+- `templates/DECISIONS.md`

--- a/skills/igapyon-agent-state-management/templates/DECISIONS.md
+++ b/skills/igapyon-agent-state-management/templates/DECISIONS.md
@@ -1,0 +1,26 @@
+---
+purpose: ai-agent-decisions
+read_when:
+  - before_starting_work
+  - when_making_decision
+  - when_looping_or_repeating_work
+update_when:
+  - important_decision_is_made
+  - option_is_rejected
+  - work_is_deferred
+---
+
+# Decisions
+
+This file records important decisions for the AI agent.
+Read this before making or revisiting decisions, especially when the work seems to loop.
+
+((TBD: YYYY-MM-DD))
+
+## ((TBD: 判断のタイトルを書く))
+
+理由:
+((TBD: なぜその判断をしたのかを書く))
+
+影響:
+((TBD: その判断による影響や後続タスクを書く))

--- a/skills/igapyon-agent-state-management/templates/GOAL.md
+++ b/skills/igapyon-agent-state-management/templates/GOAL.md
@@ -1,0 +1,31 @@
+---
+purpose: ai-agent-goal
+read_when:
+  - before_starting_work
+  - before_finishing_work
+  - when_scope_is_unclear
+update_when:
+  - goal_changes
+  - done_conditions_change
+  - stop_conditions_change
+---
+
+# Goal
+
+This file defines what the AI agent is trying to accomplish.
+Read this before starting work, before deciding that work is complete, and whenever scope becomes unclear.
+
+## Objective
+
+((TBD: 今回の目的を書く))
+
+## Done
+
+- ((TBD: 完了条件を書く))
+- ((TBD: 必要なら追加する))
+
+## Stop
+
+- ((TBD: 停止して相談する条件を書く))
+- `TODO.md` の `Retry Log` に同じ原因の失敗が3回記録された
+- ((TBD: 必要なら追加する))

--- a/skills/igapyon-agent-state-management/templates/TODO.md
+++ b/skills/igapyon-agent-state-management/templates/TODO.md
@@ -1,0 +1,38 @@
+---
+purpose: ai-agent-todo
+read_when:
+  - before_starting_work
+  - during_work
+  - before_finishing_work
+update_when:
+  - task_status_changes
+  - new_task_is_found
+  - blocker_is_found
+  - repeated_failure_is_found
+---
+
+# Todo
+
+This file tracks the current working state for the AI agent.
+Update this while working so the next agent can resume from the current state.
+
+## AI Agent Current Tasks
+
+This section tracks the current working state for AI agents.
+Update this section while working. Do not rewrite unrelated TODO items.
+
+### Tasks
+
+- [ ] ((TBD: 最初の作業項目を書く))
+- [ ] ((TBD: 必要なら追加する))
+
+### Blockers
+
+- ((TBD: なければ「なし」と書く))
+
+### Retry Log
+
+Use this section only when the same task or error is repeated.
+If the same failure appears 3 times, stop and ask the user.
+
+- ((TBD: YYYY-MM-DD / task / failure / changed approach))


### PR DESCRIPTION
## 概要

AI エージェント作業用の軽量な状態管理ワークフローとして、`igapyon-agent-state-management` スキルを追加しました。

## 変更内容

- `igapyon-agent-state-management` スキルを新規追加
- `GOAL.md`、`TODO.md`、`DECISIONS.md` の3ファイルで作業状態を管理する運用ルールを追加
- `igapyon 作業再開` などのトリガー時に、既存状態を読んで再開ポイントを整理する Resume Workflow を定義
- 3ファイル運用の詳細リファレンスと初期化・再開用プロンプト例を追加
- `GOAL.md`、`TODO.md`、`DECISIONS.md` のテンプレートを追加
- `agents/openai.yaml` と `index.json` を追加
- `README.md` に新スキルのディレクトリ構成と説明を追記