### PR TITLE
igapyon-github-writer のPR文面保存とrecommit手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Note 正本側では、`../mikuku-articles/` に 1 セットとして保持し�
 
 - `igapyon-github-writer`
 
-  GitHub PR、GitHub Release、GitHub About に貼る文章の作成向け。明示的に指定した場合に利用する。
+  GitHub PR、GitHub Release、GitHub About に貼る文章の作成向け。明示的に指定した場合に利用する。作文した Markdown は、通常の応答に加えて、ローカルの `workplace/github-writer/` に保存する。`workplace/` がなく `temp/` がある場合のみ `temp/github-writer/` を使い、どちらもなければ `workplace/github-writer/` を作成する。明示指示がある場合に限り、作成済み PR 文面をローカル Git commit message に反映する workflow も扱う。
 
 - `igapyon-diary-writer`
 
@@ -325,3 +325,23 @@ release archive には、この repo の `skills/` に加えて、外部管理�
 - `mikuscore-skills` `v0.1.0`: `skills/mikuscore/`
 
 GitHub では `v*` tag が push されたときに GitHub Actions で `mvn clean package` を実行し、生成された zip を GitHub Release asset として添付します。
+
+## 厳選 text bundle
+
+AI へ渡す参照素材や、Web UI インタフェースへ内容をコピー＆ペーストして利用するための軽量な確認用 bundle として、厳選した skill だけを text bundle 化できます。
+
+```sh
+scripts/build-text-bundle-selection.sh
+```
+
+このスクリプトは、release staging 内の `igapyon-miku-text-bundle` runtime を使い、選んだ skill directory だけを `workplace/text-bundle-dist/` に text bundle として出力します。  
+あわせて、取り回しやすい zip として `workplace/igapyon-agent-skills-bundle-selection-<version>.zip` も生成します。
+
+現在の厳選対象は次の通りです。
+
+- `skills/igapyon-mikuku-agent/`
+- `skills/igapyon-skill-compactor/`
+- `skills/igapyon-agent-state-management/`
+- `skills/igapyon-github-writer/`
+
+`igapyon-miku-text-bundle` runtime がまだ release staging にない場合は、スクリプト内で `mvn package` を実行して staging を準備します。通常の release archive は利用者向けの skill 配布物であり、この厳選 text bundle はブラウザ上のチャットや Web UI へ貼り付けて使いやすくするための、AI 参照・確認・持ち運び用の小さな補助成果物です。

--- a/TODO.md
+++ b/TODO.md
@@ -259,6 +259,101 @@
   - 公開済み URL は記事内に記録済み: https://qiita.com/igapyon/items/e2002183dcdadf00ec59
 - [ ] `20260430-miku-soft-architecture-topic-bank.md` 側では、同テーマを「執筆開始」として更新済み
 
+### miku-soft 候補プロダクト案
+
+- [x] miku-soft 利用範囲限定の Office / OOXML 共通基盤を検討する
+  - 名称: `miku-ms-office-core`
+  - GitHub repository: https://github.com/igapyon/miku-ms-office-core
+  - 状態: リポジトリ作成済み、着手済み
+  - 目的: 汎用 Office ライブラリではなく、Microsoft Office 系ファイルについて miku-soft で実際に利用している範囲だけを共通化する
+  - 命名理由: `miku-office-core` より Microsoft Office 対象であることが明確で、`miku-msoffice-core` より単語境界が読みやすい
+  - 対象候補:
+    - `miku-docx2md`
+    - `miku-xlsx2md`
+    - `miku-md2docx`
+    - `miku-md2xlsx`
+    - `mikuproject`
+    - 将来候補の `miku-pptx2md`
+    - 将来候補の `miku-md2pptx`
+  - 初期共通化候補:
+    - ZIP / OOXML package の読み書き
+    - ZIP entry timestamp normalization
+    - ZIP entry ordering
+    - ZIP compression policy
+    - relationships 解決
+    - content types / part path の扱い
+    - XML helper
+    - media 抽出・格納
+    - diagnostics 共通形式
+    - miku-soft 共通の path normalization / UTF-16 sort 方針
+  - 初期非目標:
+    - 汎用 OOXML 実装
+    - Microsoft Office 互換の完全実装
+    - DOCX / XLSX / PPTX / MS Project の意味解釈をすべて一つにまとめること
+    - 各プロダクト固有の Markdown 変換方針や出力判断を共通基盤へ押し込むこと
+  - 判断メモ:
+    - 既存 miku-soft Office 系プロダクトは、基本的にプロジェクト内で Office ファイルの入出力を自前実装してきた
+    - PPTX 系列を追加する前に、重複している低層処理だけを miku-soft 内部向けに整理する段階に来ている
+    - 共通化対象は「miku-soft が使う範囲」に限定し、汎用ライブラリ化でスコープを広げない
+  - 設計エッセンス:
+    - `miku-ms-office-core` は Office 文書の意味を知っている汎用ライブラリではなく、miku-soft 各プロダクトが自分の意味解釈に集中するための共通配管とする
+    - 共通化する線は、ZIP container、ZIP entry timestamp / ordering / compression、OPC package、relationships、content types、part path、media、XML helper、diagnostics まで
+    - ZIP 内ファイルのタイムスタンプ制御は、DOCX / XLSX / PPTX の意味解釈ではなく、再現性ある Microsoft Office 系 package 生成のための低層方針として扱う
+    - DOCX の文書解釈、XLSX の表・セル解釈、PPTX のスライド解釈、Markdown 変換判断、Markdown から Office への組み立て判断は各プロダクトの価値として残す
+    - この線を超えると既存の汎用 Office / OOXML ライブラリに近づき、miku-soft の小ささ、説明可能性、用途限定性が崩れやすい
+- [x] 「次はなに」と問われたら、次の miku-soft 候補として PPTX 系列を進める
+  - 第一候補: `miku-pptx2md`
+  - 第二候補: `miku-md2pptx`
+  - 理由: `miku-docx2md` / `miku-xlsx2md` / `miku-md2docx` / `miku-md2xlsx` と自然につながる Office 文書変換系列であり、AI-friendly Markdown / JSON への橋渡しとして価値が分かりやすい
+  - 進め方: まず `miku-pptx2md` の名前確認、姉妹リポジトリ調査、最小仕様の確定から始める
+- [x] `miku-pptx2md` の実現性を検討する
+  - 位置づけ: `miku-docx2md` / `miku-xlsx2md` の姉妹となる 10 main application
+  - 目的: PowerPoint `.pptx` をローカルで読み、スライド構造を AI-friendly / script-friendly / human-reviewable な Markdown と JSON に抽出する
+  - 入力: `.pptx`
+  - 出力候補:
+    - `output.md`: スライド単位の Markdown
+    - `output.json`: スライド、テキスト、画像、ノート、diagnostics の構造化データ
+    - `media/`: 画像を書き出す場合の抽出先
+  - 初期 CLI 案: `miku-pptx2md input.pptx output.md [options]`
+  - 初期スコープ:
+    - スライドごとに `## Slide N: <title>` を生成する
+    - タイトル、本文、箇条書き、テキストボックスを抽出する
+    - speaker notes を抽出できる場合は `### Notes` として出力する
+    - 画像は `![alt](media/...)` として参照する
+    - 表は可能なら Markdown table にする
+    - 未対応要素、読み飛ばし、欠落、変換ロスは diagnostics に出す
+  - 初期非目標:
+    - PowerPoint の完全な視覚レイアウト再現
+    - SmartArt、グラフ、埋め込みオブジェクト、アニメーション、複雑な重なり順の完全変換
+  - 判断メモ:
+    - PPTX は ZIP + OOXML なので実装可能性は高い
+    - 見た目再現ではなく意味構造の抽出に絞ると miku-soft の方針と合う
+    - 正式決定前に GitHub 上の `miku-pptx2md` 名の現況確認が必要
+- [x] `miku-md2pptx` の実現性を検討する
+  - 位置づけ: `miku-md2docx` / `miku-md2xlsx` の姉妹となる 10 main application
+  - 目的: Markdown から実用的な PowerPoint `.pptx` をローカル生成し、AI や人間が作ったアウトラインをプレゼン資料の初稿へ橋渡しする
+  - 入力: Markdown
+  - 出力候補:
+    - `output.pptx`: 生成した PowerPoint ファイル
+    - `output.json`: Markdown から解釈した slide model と diagnostics
+  - 初期 CLI 案: `miku-md2pptx input.md output.pptx [options]`
+  - 初期スコープ:
+    - `---` または見出しレベルでスライドを分割する
+    - slide title、箇条書き、本文、画像、speaker notes を基本要素として扱う
+    - テーマ、ページ比率、フォント、余白などは少数の安全な既定値から始める
+    - 変換不能な Markdown 要素や、収まりきらないテキストは diagnostics に出す
+    - 生成前の slide model JSON を保存できるようにする
+  - 初期非目標:
+    - 任意の Markdown を美しい商用スライドへ自動デザインすること
+    - PowerPoint の全レイアウト機能、アニメーション、複雑な図形、SmartArt、グラフの完全生成
+    - 入力 Markdown の曖昧な意図を過剰に推測すること
+  - 判断メモ:
+    - `miku-pptx2md` より「出力仕様をどう絞るか」が重要
+    - OOXML の PPTX 生成を完全自前にするのは初期版では重いため、PPTX 書き出しライブラリ採用を検討する余地がある
+    - ただし Markdown 解析、slide model、diagnostics、AI-facing 出力は miku 側の責務として持つのがよい
+    - `miku-pptx2md` と対になるが、同一リポジトリにまとめず別アプリとして考える方が miku-soft の命名と責務に合う
+    - 正式決定前に GitHub 上の `miku-md2pptx` 名の現況確認が必要
+
 ## miku-indexgen-java / miku-indexgen-java-maven 分離反映
 
 - [x] `skills/igapyon-qiita-writer/references/miku-indexgen/20260509-miku-indexgen-usage.md` の差分を確認する

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260620.1</version>
+  <version>1.20260622.1</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>

--- a/scripts/build-text-bundle-selection.sh
+++ b/scripts/build-text-bundle-selection.sh
@@ -50,6 +50,16 @@ generate_bundle \
   "miku-skill-compactor-text-bundle" \
   "miku-skill-compactor-text-bundle"
 
+generate_bundle \
+  "$BASE_DIR/skills/igapyon-agent-state-management" \
+  "igapyon-agent-state-management-text-bundle" \
+  "igapyon-agent-state-management-text-bundle"
+
+generate_bundle \
+  "$BASE_DIR/skills/igapyon-github-writer" \
+  "igapyon-github-writer-text-bundle" \
+  "igapyon-github-writer-text-bundle"
+
 (cd "$WORKPLACE_DIR" && zip -r "$(basename "$ZIP_PATH")" text-bundle-dist)
 
 echo "generated: $DIST_DIR"

--- a/skills/igapyon-github-writer/SKILL.md
+++ b/skills/igapyon-github-writer/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: igapyon-github-writer
-description: Use only when the user explicitly asks to draft GitHub PR text, GitHub Release notes, GitHub About text, or asks to inspect the current branch status using igapyon-github-writer. If the user only asks whether such a skill exists, mention this skill as an available option but do not apply it until asked.
+description: Use only when the user explicitly asks to draft GitHub PR text, GitHub Release notes, GitHub About text, rebuild local commits with soft reset and a drafted PR text as the commit message, or asks to inspect the current branch status using igapyon-github-writer. If the user only asks whether such a skill exists, mention this skill as an available option but do not apply it until asked.
 ---
 
 # igapyon-github-writer
 
-This skill drafts Markdown text for GitHub surfaces from local repository evidence. It can also report the current branch status as preparation for GitHub writing work.
+This skill drafts Markdown text for GitHub surfaces from local repository evidence. It can also save drafted GitHub text to a local Markdown file, rebuild local commits with soft reset and a drafted PR text as the commit message, and report the current branch status as preparation for GitHub writing work.
 
-Use it only for GitHub writing text and the local branch-status checks that prepare that writing. Do not create PRs, tags, releases, issues, branches, commits, or remote changes unless the user separately asks for that operation.
+Use it only for GitHub writing text, local draft-file saving for that text, explicit PR soft-reset recommit work, and the local branch-status checks that prepare that writing. Do not create PRs, tags, releases, issues, branches, commits, or remote changes unless the user separately asks for that operation.
 
-Do not use this skill for generic commit summaries, changelogs, branch inspection, or repository cleanup unless the user explicitly asks for GitHub PR, GitHub Release, GitHub About text, branch status through this skill, or names this skill.
+Do not use this skill for generic commit summaries, changelogs, branch inspection, or repository cleanup unless the user explicitly asks for GitHub PR, GitHub Release, GitHub About text, PR soft-reset recommit from drafted PR text, branch status through this skill, or names this skill.
 
 If the user asks whether there is a skill for GitHub PR, Release, or About text, mention this skill as an available option, but do not apply it until the user asks to use it.
 
@@ -22,6 +22,7 @@ Examples:
 - PR mode: `pr textつくりたい`, `PR文面を作りたい`, `pull request本文`, `プルリク説明`, `PRタイトルと本文`
 - Release mode: `release textつくりたい`, `リリース文を作りたい`, `release notes`, `リリースノート`, `GitHub Release本文`
 - About mode: `GitHub Aboutを書きたい`, `About文`, `リポジトリ説明`, `GitHub説明文`
+- PR Soft Reset Recommit mode: `PR文面でsoft resetしてcommitし直す`, `PR文面をcommit messageに反映して再コミット`, `作文したPR文面でgit commitし直す`
 - Branch Status mode: `github-writerでブランチ状況`, `今のブランチの状況`, `PR前にブランチ状態を見たい`, `現在ブランチの確認`
 
 If the mode is clear but required evidence is missing, do not draft yet. Ask for the missing target, except for PR mode's default target rule:
@@ -32,12 +33,13 @@ If the mode is clear but required evidence is missing, do not draft yet. Ask for
 
 ## Core Workflow
 
-1. Identify whether the request is for PR, Release, About text, or Branch Status.
+1. Identify whether the request is for PR, Release, About text, PR Soft Reset Recommit, or Branch Status.
 2. Read [references/github-writing-rules.md](references/github-writing-rules.md) before drafting.
-3. Read the mode-specific reference: [references/pr-writing.md](references/pr-writing.md), [references/release-writing.md](references/release-writing.md), [references/about-writing.md](references/about-writing.md), or [references/branch-status.md](references/branch-status.md).
+3. Read the mode-specific reference: [references/pr-writing.md](references/pr-writing.md), [references/release-writing.md](references/release-writing.md), [references/about-writing.md](references/about-writing.md), [references/pr-soft-reset-recommit.md](references/pr-soft-reset-recommit.md), or [references/branch-status.md](references/branch-status.md).
 4. Inspect only the repository evidence needed for the requested mode.
 5. Draft or report from evidence without inventing unsupported facts.
-6. Return the final answer using the format required by the selected reference.
+6. For PR, Release, and About modes, save the drafted Markdown using the shared draft-save rules unless the user says not to save.
+7. Return the final answer using the format required by the selected reference.
 
 ## Reference Use
 
@@ -48,6 +50,7 @@ Use these mode-specific references:
 - [references/pr-writing.md](references/pr-writing.md) for GitHub PR title and body drafting
 - [references/release-writing.md](references/release-writing.md) for GitHub Release title and body drafting
 - [references/about-writing.md](references/about-writing.md) for GitHub About text drafting
+- [references/pr-soft-reset-recommit.md](references/pr-soft-reset-recommit.md) for rebuilding local commits with soft reset and a drafted PR text as the commit message
 - [references/branch-status.md](references/branch-status.md) for current branch status reporting before GitHub writing work
 
 Use `index.json` as the discovery index when you need to confirm the available bundled reference files, but treat `SKILL.md` and files under `references/` as the source of truth.
@@ -60,4 +63,4 @@ Before finishing:
 
 - ensure the final answer contains no absolute paths, home directories, or working directories
 - ensure unsupported items are marked `未確認`, `要確認`, or omitted
-- for PR, Release, and About modes, ensure the final answer is wrapped with `~~~~markdown` and `~~~~`
+- for PR, Release, and About modes, ensure the drafted Markdown is wrapped with `~~~~markdown` and `~~~~`; if a file was saved, mention only the relative saved path outside the wrapped block

--- a/skills/igapyon-github-writer/index.json
+++ b/skills/igapyon-github-writer/index.json
@@ -3,11 +3,12 @@
  "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
  "basePath": ".",
  "files": [
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":4533,"description":"Use only when the user explicitly asks to draft GitHub PR text, GitHub Release notes, GitHub About text, or asks to inspect the current branch status using igapyon-github-writer. If the user only asks whether such a skill exists, mention this skill as a...","summary":"igapyon-github-writer"},
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":5548,"description":"Use only when the user explicitly asks to draft GitHub PR text, GitHub Release notes, GitHub About text, rebuild local commits with soft reset and a drafted PR text as the commit message, or asks to inspect the current branch status using igapyon-github...","summary":"igapyon-github-writer"},
   {"name":"about-writing.md","path":"references/about-writing.md","ext":"md","dir":"references","size":1136,"summary":"GitHub About Writing"},
   {"name":"branch-status.md","path":"references/branch-status.md","ext":"md","dir":"references","size":2672,"summary":"GitHub Branch Status"},
-  {"name":"github-writing-rules.md","path":"references/github-writing-rules.md","ext":"md","dir":"references","size":3946,"summary":"GitHub Writing Rules"},
-  {"name":"pr-writing.md","path":"references/pr-writing.md","ext":"md","dir":"references","size":3055,"summary":"GitHub PR Writing"},
+  {"name":"github-writing-rules.md","path":"references/github-writing-rules.md","ext":"md","dir":"references","size":5848,"summary":"GitHub Writing Rules"},
+  {"name":"pr-soft-reset-recommit.md","path":"references/pr-soft-reset-recommit.md","ext":"md","dir":"references","size":4248,"summary":"PR Soft Reset Recommit"},
+  {"name":"pr-writing.md","path":"references/pr-writing.md","ext":"md","dir":"references","size":3124,"summary":"GitHub PR Writing"},
   {"name":"release-writing.md","path":"references/release-writing.md","ext":"md","dir":"references","size":3555,"summary":"GitHub Release Writing"}
  ]
 }

--- a/skills/igapyon-github-writer/references/github-writing-rules.md
+++ b/skills/igapyon-github-writer/references/github-writing-rules.md
@@ -10,7 +10,8 @@ Shared writing rules for `igapyon-github-writer`.
 - Do not invent intent, benefits, compatibility, version numbers, release dates, test results, package publication status, or external URLs.
 - If information is missing, write `未確認`, `要確認`, or omit that claim.
 - If making an inference from file names or diffs, mark it with `推測:`.
-- The final answer must be one Markdown block wrapped with outer tildes: start with `~~~~markdown` and end with `~~~~`.
+- The drafted GitHub text in the final answer must be wrapped with outer tildes: start with `~~~~markdown` and end with `~~~~`.
+- If the draft was saved to a file, mention only the relative saved path outside the wrapped block. Do not include absolute paths.
 
 ## Evidence Workflow
 
@@ -66,3 +67,32 @@ git diff --no-ext-diff --no-renames <range>
 When the resolved range uses `START^..HEAD` and `START^` is unavailable, inspect the root case explicitly and mark uncertainties as `要確認`.
 
 Prefer concise summaries over copying large diffs. Mention only files, modules, behavior, and documents that are visible in the inspected evidence.
+
+## Draft Save Rules
+
+For PR, Release, and About modes, save the final drafted Markdown to a local file unless the user explicitly says not to save.
+
+Do not save Branch Status output by default. Branch Status is a report, not GitHub paste-ready drafted text.
+
+Save only the inner Markdown draft, without the outer `~~~~markdown` wrapper.
+
+Resolve the save base in this order:
+
+1. Determine the repository root with `git rev-parse --show-toplevel`. If that fails, use the current working directory as the project-equivalent root.
+2. If `<root>/workplace/` exists, save under `<root>/workplace/github-writer/`.
+3. If `<root>/temp/` exists, save under `<root>/temp/github-writer/`.
+4. If neither exists, create `<root>/workplace/github-writer/` and save there.
+
+Do not save outside the project-equivalent root unless the user explicitly provides an output path.
+
+Use safe, lowercase filenames based on local time. Include a 12-digit year-month-day-hour-minute timestamp (`YYYYMMDDHHMM`) in PR draft filenames so repeated drafts on the same branch remain sortable and easy to resolve:
+
+- PR mode: `pr-<branch-slug>-<YYYYMMDDHHMM>.md` when the current branch name is available; otherwise `pr-<YYYYMMDDHHMM>.md`
+- Release mode: `release-<YYYYMMDDHHMM>.md`
+- About mode: `about-<YYYYMMDDHHMM>.md`
+
+For `<branch-slug>`, use the current branch from `git branch --show-current`. Sanitize it by lowercasing it and replacing characters outside `[a-z0-9._-]` with `-`. If the sanitized branch is empty, omit it.
+
+Do not overwrite an existing draft file. If a generated path already exists, add another short suffix such as `-2`.
+
+After saving, report the saved path relative to the repository root or current working directory. Never report a home directory or absolute path.

--- a/skills/igapyon-github-writer/references/pr-soft-reset-recommit.md
+++ b/skills/igapyon-github-writer/references/pr-soft-reset-recommit.md
@@ -1,0 +1,78 @@
+# PR Soft Reset Recommit
+
+Use this workflow only when the user explicitly asks to rebuild local commits by soft-resetting to a base and recommitting with a saved PR draft as the commit message.
+
+This is not `git commit --amend`. It resets `HEAD` back to a confirmed base while preserving the index and working tree, then creates a new commit from the preserved changes.
+
+This mode changes local Git history. Do not run it automatically after drafting PR text. Do not run it for generic commit summaries or ordinary PR drafting.
+
+## Safety Rules
+
+- Require an explicit user request before running Git commands that rewrite the current commit state.
+- Inspect `git status -sb` before changing anything.
+- Inspect the commits that would be collapsed with `git log --oneline --decorate <base>..HEAD`.
+- Inspect the change size with `git diff --stat <base>...HEAD` or another appropriate diff command before resetting.
+- Do not proceed if there are unrelated uncommitted changes unless the user explicitly confirms how to handle them.
+- Do not run `git reset --hard`, `git checkout --`, `git push`, `gh pr create`, or any remote-changing command in this workflow.
+- `git fetch origin` is allowed only to refresh local remote-tracking information.
+- `git reset --soft <base>` rewrites `HEAD` while preserving index and working tree changes. Treat it as a history-rewrite operation and mention that clearly before running it.
+- Default base is `origin/devel` only when the user asks for that base or the repository convention clearly uses it. Otherwise ask for the base branch or remote-tracking ref.
+
+## Inputs
+
+This workflow has two required inputs:
+
+- `BASE`: the confirmed reset base, such as `origin/devel`
+- `PR_DRAFT`: the saved PR draft file, preferably under `workplace/github-writer/` or `temp/github-writer/`
+
+The PR draft file must contain the inner Markdown draft, without the outer `~~~~markdown` wrapper.
+
+If there is no saved PR draft file, stop this workflow and first create or save the PR draft through PR mode. Do not use `mktemp`, inline heredoc, or `cat <<EOF` as a fallback.
+
+## PR Draft Resolution
+
+When the user asks to reuse the PR draft created by PR mode but does not provide `PR_DRAFT`, resolve the candidate lightly from the standard draft-save locations before asking:
+
+1. Determine the current branch with `git branch --show-current`.
+2. Sanitize it with the same `<branch-slug>` rules from `github-writing-rules.md`.
+3. Look for PR draft files in the standard GitHub writer draft directories, preferring files named `pr-<branch-slug>-<YYYYMMDDHHMM>.md`.
+4. If multiple branch-matching drafts exist, choose the newest by the 12-digit timestamp embedded in the filename.
+5. If filename timestamps are missing or tied, use file modification time as a fallback and mention the ambiguity.
+
+Do not automatically choose a PR draft for another branch. If no current-branch match exists, report the available PR drafts and ask the user to confirm which one to use.
+
+Before running `git reset --soft`, report the resolved `PR_DRAFT` path and treat it as the confirmed draft only when the user clearly asked to use the latest matching PR draft, or when the branch match and newest timestamp make the choice unambiguous.
+
+## Command Shape
+
+When the user explicitly asks to apply the saved PR draft as the commit message and both inputs are confirmed, use this shape:
+
+The example is POSIX-shell style for clarity. When running on Windows PowerShell, cmd.exe, or another shell, translate variable assignment, quoting, and path syntax to the active shell while preserving the same Git steps.
+
+```sh
+BASE=origin/devel
+PR_DRAFT=workplace/github-writer/pr-devel-YYYYMMDDHHMM.md
+
+git status -sb
+git fetch origin
+git log --oneline --decorate "$BASE"..HEAD
+git diff --stat "$BASE"...HEAD
+git reset --soft "$BASE"
+git commit -F "$PR_DRAFT"
+git log --oneline --decorate -3
+git status -sb
+```
+
+Replace the example `BASE` and `PR_DRAFT` values with the confirmed values before running.
+
+## Output
+
+After execution, report:
+
+- the base used for `git reset --soft`
+- the saved PR draft path used for `git commit -F`
+- whether `git commit -F` succeeded
+- the new commit hash if available
+- the final `git status -sb`
+
+Do not include absolute paths.

--- a/skills/igapyon-github-writer/references/pr-writing.md
+++ b/skills/igapyon-github-writer/references/pr-writing.md
@@ -34,11 +34,12 @@ Interpret that request as:
 - inclusion: only the change introduced by `<commit>`
 - output language: Japanese
 - output format: Markdown
-- required top-level headings: `# PR Title` and `# PR Body`
+- first line: PR title text only, without a heading marker or label
+- following content: PR body Markdown
 - final wrapper: one block from `~~~~markdown` to `~~~~`
 - source of facts: the current conversation, the user's input, and inspected local Git evidence only
 
-The final Markdown must keep the top-level headings exactly as `# PR Title` and `# PR Body` so downstream tooling can parse the response.
+Do not add artificial labels or headings such as `# PR Title`, `# PR Body`, `PR Title:`, or `PR Body:`. The drafted text should be directly usable as the PR title and PR body content.
 
 ## Drafting Rules
 
@@ -56,11 +57,7 @@ Draft for reviewers:
 Use this output shape:
 
 ```markdown
-# PR Title
-
 ...
-
-# PR Body
 
 ## 概要
 

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260620a
+Version: 20260622a
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

`igapyon-github-writer` に、GitHub向け文面のローカル保存ルールと、保存済みPR文面を使って local commit を soft reset から作り直す workflow を追加しました。

## 変更内容

- `igapyon-github-writer` の説明と mode phrase に、PR soft reset recommit workflow を追加
- GitHub PR / Release / About 文面を `workplace/github-writer/` に保存するルールを追加
- PRドラフトの保存ファイル名に `YYYYMMDDHHMM` の年月日時分 timestamp を含める方針を明記
- reset recommit 時のPRドラフト探索で、`pr-<branch-slug>-<YYYYMMDDHHMM>.md` を優先するように整理
- PR文面出力形式を、PR title と PR body をそのまま貼れる形に整理
- `pr-soft-reset-recommit.md` を追加し、`git reset --soft` と `git commit -F` による再コミット手順を定義
- `igapyon-github-writer/index.json` を更新
- README の `igapyon-github-writer` 説明に、文面保存とPR文面を commit message に反映する workflow を追記
- README に厳選 text bundle の説明、実行方法、出力先、現在の対象 skill を追加
- 厳選 text bundle の対象に `igapyon-agent-state-management` と `igapyon-github-writer` を追加
- TODO に miku-soft の Office / PPTX 系候補プロダクト検討メモを追加
- `pom.xml` のプロジェクトバージョンを `1.20260622.1` に更新
- `igapyon-mikuku-agent` の参照バージョンを `20260622a` に更新