### PR TITLE
igapyon-agent-state-management に HANDOFF.md を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Note 正本側では、`../mikuku-articles/` に 1 セットとして保持し�
 
 - `igapyon-agent-state-management`
 
-  AI エージェント作業用の `GOAL.md`、`TODO.md`、`DECISIONS.md` による軽量な状態管理ファイルの作成・整理・運用向け。発火は `igapyon-agent-state-management` の明示、または `igapyon 状態管理`、`igapyon 作業状態`、`igapyon 作業再開`、`igapyon 3ファイル`、`igapyon goal`、`igapyon todo` などの `igapyon` 付き合言葉を基本とする。`igapyon 作業再開` では、3ファイルを新規作成せず、まず既存の repo 状態、`TODO.md`、`GOAL.md`、`DECISIONS.md` などを読んで再開ポイントを整理する。
+  AI エージェント作業用の `GOAL.md`、`TODO.md`、`DECISIONS.md`、`HANDOFF.md` による軽量な状態管理ファイルの作成・整理・運用向け。発火は `igapyon-agent-state-management` の明示、または `igapyon 状態管理`、`igapyon 作業状態`、`igapyon 作業再開`、`igapyon goal`、`igapyon todo`、`igapyon handoff` などの `igapyon` 付き合言葉を基本とする。`igapyon 作業再開` では、状態管理ファイルを新規作成せず、まず既存の repo 状態、`TODO.md`、`GOAL.md`、`DECISIONS.md`、`HANDOFF.md` などを読んで再開ポイントを整理する。
 
   名前を思い出せない場合は、`igapyon 状態管理` または `igapyon 作業再開` を合言葉として使う。
 

--- a/skills/igapyon-agent-state-management/SKILL.md
+++ b/skills/igapyon-agent-state-management/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: igapyon-agent-state-management
-description: Use only when the user explicitly names igapyon-agent-state-management or uses an igapyon-prefixed trigger phrase such as igapyon 状態管理, igapyon agent 状態管理, igapyon 作業状態, igapyon 作業再開, igapyon 3ファイル, igapyon goal, igapyon todo, or igapyon GOAL TODO DECISIONS. Do not trigger for generic TODO.md maintenance, ordinary project planning, vague handoff discussion, ordinary work resumption, broad Context Engineering talk, or even the GOAL.md + TODO.md + DECISIONS.md workflow unless the user also says igapyon or explicitly names this skill.
+description: Use only when the user explicitly names igapyon-agent-state-management or uses an igapyon-prefixed trigger phrase such as igapyon 状態管理, igapyon agent 状態管理, igapyon 作業状態, igapyon 作業再開, igapyon goal, igapyon todo, igapyon handoff, or igapyon GOAL TODO DECISIONS HANDOFF. Do not trigger for generic TODO.md maintenance, ordinary project planning, vague handoff discussion, ordinary work resumption, broad Context Engineering talk, or even the GOAL.md + TODO.md + DECISIONS.md + HANDOFF.md workflow unless the user also says igapyon or explicitly names this skill.
 ---
 
 # Igapyon Agent State Management
 
 This skill helps set up and maintain a small Markdown-based state-management convention for AI agent work.
 
-The default convention uses three repository-local files:
+The default convention uses these repository-local files:
 
 - `GOAL.md`: define the objective, completion conditions, and stop conditions
-- `TODO.md`: track current tasks, blockers, and repeated failures
+- `TODO.md`: track active tasks, blockers, and repeated failures
 - `DECISIONS.md`: record important decisions and reasons
+- `HANDOFF.md`: summarize the current state for the next human or agent
 
 Use this as a repository workflow skill. It is not tied to a specific character agent, model, editor, or vendor.
 
@@ -22,20 +23,20 @@ This skill intentionally uses hard triggers. Prefer these phrases when the user 
 - `igapyon 状態管理`
 - `igapyon 作業状態`
 - `igapyon 作業再開`
-- `igapyon 3ファイル`
 - `igapyon goal`
 - `igapyon todo`
-- `igapyon GOAL TODO DECISIONS`
+- `igapyon handoff`
+- `igapyon GOAL TODO DECISIONS HANDOFF`
 
 When answering a general question such as "what skills are available?", describe this skill as the one for `igapyon 状態管理` and `igapyon 作業再開`.
 
 ## Core Workflow
 
 1. Inspect the repository before editing.
-2. Check whether `GOAL.md`, `TODO.md`, or `DECISIONS.md` already exist.
+2. Check whether `GOAL.md`, `TODO.md`, `DECISIONS.md`, or `HANDOFF.md` already exist.
 3. Do not overwrite existing files without reading them first.
 4. If `TODO.md` already exists, preserve its existing purpose and add or update only `## AI Agent Current Tasks` when appropriate.
-5. Use [references/three-markdown-state-files.md](references/three-markdown-state-files.md) for the detailed setup rules and initial prompt.
+5. Use [references/markdown-state-files.md](references/markdown-state-files.md) for the detailed setup rules and initial prompt.
 6. Use templates from [templates/](templates/) when creating new files.
 7. Keep the state files lightweight. Do not turn them into long work logs or broad project documentation.
 
@@ -43,9 +44,9 @@ When answering a general question such as "what skills are available?", describe
 
 When the user says `igapyon 作業再開`, treat it as a request to recover the current repository working state, not necessarily to create new files.
 
-1. Inspect the repository state with ordinary local context such as `git status --short`, `README.md`, existing `TODO.md`, and any existing `GOAL.md` or `DECISIONS.md`.
-2. If the three state files already exist, read them and summarize the current objective, next tasks, blockers, and relevant decisions.
-3. If they do not exist, do not create them automatically unless the user asks. Briefly mention that this skill can set up `GOAL.md`, `TODO.md`, and `DECISIONS.md` if needed.
+1. Inspect the repository state with ordinary local context such as `git status --short`, `README.md`, existing `TODO.md`, and any existing `GOAL.md`, `DECISIONS.md`, or `HANDOFF.md`.
+2. If the state files already exist, read them and summarize the current objective, next tasks, blockers, relevant decisions, and handoff notes.
+3. If they do not exist, do not create them automatically unless the user asks. Briefly mention that this skill can set up `GOAL.md`, `TODO.md`, `DECISIONS.md`, and `HANDOFF.md` if needed.
 4. Keep the output focused on what to do next and any uncertainty that needs user confirmation.
 
 ## File Roles
@@ -55,6 +56,8 @@ Read `GOAL.md` before starting work, before declaring completion, and whenever s
 Read and update `TODO.md` during work when task status changes, blockers appear, new work is found, or the same failure repeats.
 
 Read `DECISIONS.md` before making or revisiting important decisions, especially when the work appears to loop.
+
+Read and update `HANDOFF.md` when pausing work, handing work to another agent, or preparing a compact resume summary. Keep it as a concise current-state summary, not a full work log.
 
 ## Existing Files
 
@@ -68,12 +71,13 @@ Instead, add or update this section only:
 
 If the section already exists, update it in place. Do not duplicate it.
 
-If `GOAL.md` or `DECISIONS.md` already exists, read it and propose a scoped change or add compatible sections. Do not assume it is an AI-agent state file unless the contents indicate that role.
+If `GOAL.md`, `DECISIONS.md`, or `HANDOFF.md` already exists, read it and propose a scoped change or add compatible sections. Do not assume it is an AI-agent state file unless the contents indicate that role.
 
 ## Templates
 
 - [templates/GOAL.md](templates/GOAL.md)
 - [templates/TODO.md](templates/TODO.md)
 - [templates/DECISIONS.md](templates/DECISIONS.md)
+- [templates/HANDOFF.md](templates/HANDOFF.md)
 
 Replace `((TBD: ...))` placeholders with concrete details when the current work is known. Leave them only when the user has not provided enough information.

--- a/skills/igapyon-agent-state-management/agents/openai.yaml
+++ b/skills/igapyon-agent-state-management/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Agent State Management"
-  short_description: "Manage AI agent state with three Markdown files"
-  default_prompt: "Use $igapyon-agent-state-management to set up GOAL.md, TODO.md, and DECISIONS.md for this repository."
+  short_description: "Manage AI agent state with Markdown files"
+  default_prompt: "Use $igapyon-agent-state-management to set up GOAL.md, TODO.md, DECISIONS.md, and HANDOFF.md for this repository."
 policy:
   allow_implicit_invocation: false

--- a/skills/igapyon-agent-state-management/index.json
+++ b/skills/igapyon-agent-state-management/index.json
@@ -3,10 +3,11 @@
  "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
  "basePath": ".",
  "files": [
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":4165,"description":"Use only when the user explicitly names igapyon-agent-state-management or uses an igapyon-prefixed trigger phrase such as igapyon 状態管理, igapyon agent 状態管理, igapyon 作業状態, igapyon 作業再開, igapyon 3ファイル, igapyon goal, igapyon todo, or igapyon GOAL TODO DECIS...","summary":"Igapyon Agent State Management"},
-  {"name":"three-markdown-state-files.md","path":"references/three-markdown-state-files.md","ext":"md","dir":"references","size":4704,"summary":"Three Markdown State Files"},
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":4539,"description":"Use only when the user explicitly names igapyon-agent-state-management or uses an igapyon-prefixed trigger phrase such as igapyon 状態管理, igapyon agent 状態管理, igapyon 作業状態, igapyon 作業再開, igapyon goal, igapyon todo, igapyon handoff, or igapyon GOAL TODO DEC...","summary":"Igapyon Agent State Management"},
+  {"name":"markdown-state-files.md","path":"references/markdown-state-files.md","ext":"md","dir":"references","size":4998,"summary":"Markdown State Files"},
   {"name":"DECISIONS.md","path":"templates/DECISIONS.md","ext":"md","dir":"templates","size":578,"summary":"Decisions"},
   {"name":"GOAL.md","path":"templates/GOAL.md","ext":"md","dir":"templates","size":680,"summary":"Goal"},
-  {"name":"TODO.md","path":"templates/TODO.md","ext":"md","dir":"templates","size":885,"summary":"Todo"}
+  {"name":"HANDOFF.md","path":"templates/HANDOFF.md","ext":"md","dir":"templates","size":913,"summary":"Handoff"},
+  {"name":"TODO.md","path":"templates/TODO.md","ext":"md","dir":"templates","size":893,"summary":"Todo"}
  ]
 }

--- a/skills/igapyon-agent-state-management/references/markdown-state-files.md
+++ b/skills/igapyon-agent-state-management/references/markdown-state-files.md
@@ -1,4 +1,4 @@
-# Three Markdown State Files
+# Markdown State Files
 
 Use this reference when setting up or resuming lightweight AI agent state management in a repository.
 
@@ -8,14 +8,15 @@ The goal is to externalize the minimum state needed for an AI agent and a human 
 
 This workflow has two closely related uses:
 
-- Setup: create or align `GOAL.md`, `TODO.md`, and `DECISIONS.md`.
-- Resume: read existing repository state and any available state files to recover the current objective, next tasks, blockers, and decisions.
+- Setup: create or align `GOAL.md`, `TODO.md`, `DECISIONS.md`, and `HANDOFF.md`.
+- Resume: read existing repository state and any available state files to recover the current objective, next tasks, blockers, decisions, and handoff summary.
 
 The default files are:
 
 - `GOAL.md`: what the work is trying to accomplish and how to know when it is done
-- `TODO.md`: the current working state, next tasks, blockers, and repeated failures
+- `TODO.md`: active tasks, blockers, and repeated failures
 - `DECISIONS.md`: important decisions, rejected options, and the reasons behind them
+- `HANDOFF.md`: compact resume notes for the next human or AI agent
 
 This is a Context Engineering convention, not a product-specific config format. The front matter is a readable hint for agents and humans; it is not assumed to be interpreted by any tool automatically.
 
@@ -24,11 +25,12 @@ This is a Context Engineering convention, not a product-specific config format. 
 Use or adapt this prompt when the user asks to initialize the convention:
 
 ````markdown
-このリポジトリに、AI エージェント作業用の状態管理ファイルを3つ作成してください。
+このリポジトリに、AI エージェント作業用の状態管理ファイルを作成してください。
 
 - `GOAL.md`
 - `TODO.md`
 - `DECISIONS.md`
+- `HANDOFF.md`
 
 ただし、同名ファイルがすでに存在する場合は、上書きしないでください。
 既存の `TODO.md` が人間用TODOやプロジェクト運用ファイルとして使われている場合は、新しいTODOファイルを増やさず、既存 `TODO.md` の中に `## AI Agent Current Tasks` セクションを追加して、AI エージェント用の現在地をそこへ記録してください。
@@ -47,10 +49,10 @@ Use or adapt this prompt when the user says `igapyon 作業再開` or otherwise 
 このリポジトリの AI エージェント作業状態を確認して、作業再開ポイントを整理してください。
 
 まず `git status --short`、`README.md`、既存の `TODO.md` を確認してください。
-`GOAL.md`、`DECISIONS.md` が存在する場合はそれも読んでください。
+`GOAL.md`、`DECISIONS.md`、`HANDOFF.md` が存在する場合はそれも読んでください。
 
-新しい `GOAL.md`、`TODO.md`、`DECISIONS.md` は、まだ作成しないでください。
-既存状態から、現在の目的、次にやること、blocker、重要な判断、確認が必要な点を短くまとめてください。
+新しい `GOAL.md`、`TODO.md`、`DECISIONS.md`、`HANDOFF.md` は、まだ作成しないでください。
+既存状態から、現在の目的、次にやること、blocker、重要な判断、handoff 要約、確認が必要な点を短くまとめてください。
 ```
 
 ## Existing TODO.md Section
@@ -60,7 +62,7 @@ When an existing `TODO.md` should be preserved, add only this section if it is m
 ```markdown
 ## AI Agent Current Tasks
 
-This section tracks the current working state for AI agents.
+This section tracks active work items for AI agents.
 Update this section while working. Do not rewrite unrelated TODO items.
 
 ### Tasks
@@ -83,12 +85,13 @@ If the same failure appears 3 times, stop and ask the user.
 ## Operating Rules
 
 - Keep `GOAL.md` focused on objective, done conditions, and stop conditions.
-- Keep `TODO.md` focused on current state, not full history.
+- Keep `TODO.md` focused on active tasks, blockers, and repeated failures, not full history or handoff prose.
 - Keep `DECISIONS.md` focused on important decisions and their reasons, not every thought or command.
+- Keep `HANDOFF.md` focused on compact resume notes, not task tracking or long work logs.
 - Use `Retry Log` only when the same task or error repeats.
 - If the same failure appears three times for the same underlying cause, stop and ask the user.
 - Prefer updating existing compatible sections over adding duplicate sections.
-- If a tool-specific entry file exists, such as `AGENTS.md` or `CLAUDE.md`, optionally add a short pointer such as: `Before working, check GOAL.md, TODO.md, and DECISIONS.md.`
+- If a tool-specific entry file exists, such as `AGENTS.md` or `CLAUDE.md`, optionally add a short pointer such as: `Before working, check GOAL.md, TODO.md, DECISIONS.md, and HANDOFF.md.`
 
 ## Creation Templates
 
@@ -97,3 +100,4 @@ Use the files under `templates/` as the source templates:
 - `templates/GOAL.md`
 - `templates/TODO.md`
 - `templates/DECISIONS.md`
+- `templates/HANDOFF.md`

--- a/skills/igapyon-agent-state-management/templates/HANDOFF.md
+++ b/skills/igapyon-agent-state-management/templates/HANDOFF.md
@@ -1,0 +1,36 @@
+---
+purpose: ai-agent-handoff
+read_when:
+  - before_resuming_work
+  - before_handing_off_work
+  - when_context_is_missing
+update_when:
+  - work_is_paused
+  - handoff_summary_changes
+  - verification_status_changes
+---
+
+# Handoff
+
+This file summarizes the current working state for the next human or AI agent.
+Keep it concise. Do not use this as a full work log or a replacement for `TODO.md` and `DECISIONS.md`.
+
+## Current State
+
+- ((TBD: いま何が終わっていて、何が途中かを書く))
+
+## Next Action
+
+- ((TBD: 次に最初にやることを書く))
+
+## Relevant Files
+
+- `((TBD: path/to/file))`: ((TBD: なぜ読む必要があるかを書く))
+
+## Watch Outs
+
+- ((TBD: 注意点、壊しやすい点、未確認事項を書く。なければ「なし」と書く))
+
+## Last Verification
+
+- ((TBD: 最後に通したコマンドや確認結果を書く。未実施なら「未実施」と書く))

--- a/skills/igapyon-agent-state-management/templates/TODO.md
+++ b/skills/igapyon-agent-state-management/templates/TODO.md
@@ -13,12 +13,12 @@ update_when:
 
 # Todo
 
-This file tracks the current working state for the AI agent.
-Update this while working so the next agent can resume from the current state.
+This file tracks the active tasks, blockers, and repeated failures for the AI agent.
+Use `HANDOFF.md` for compact resume notes for the next human or agent.
 
 ## AI Agent Current Tasks
 
-This section tracks the current working state for AI agents.
+This section tracks active work items for AI agents.
 Update this section while working. Do not rewrite unrelated TODO items.
 
 ### Tasks


### PR DESCRIPTION
## 概要

`igapyon-agent-state-management` の状態管理ファイルに `HANDOFF.md` を追加し、引き継ぎ・作業再開用の要約を `TODO.md` から分離しました。

## 変更内容

- `HANDOFF.md` テンプレートを追加し、現在状態、次の作業、関連ファイル、注意点、最終確認を記録できるようにしました。
- `SKILL.md` の説明、発火語、再開手順、ファイル役割を `HANDOFF.md` を含む構成へ更新しました。
- 詳細参照を `references/markdown-state-files.md` に整理し、旧 `three-markdown-state-files.md` を置き換えました。
- `TODO.md` テンプレートの責務を active tasks、blockers、retry log に絞り、引き継ぎ要約は `HANDOFF.md` を使う説明に変更しました。
- `README.md` と `agents/openai.yaml` の説明を更新しました。
- `index.json` を再生成し、新しい参照ファイルと `HANDOFF.md` テンプレートを反映しました。