### PR TITLE
AIエージェント作業状態管理ファイルを追加

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,32 @@
+---
+purpose: ai-agent-decisions
+read_when:
+  - before_starting_work
+  - when_making_decision
+  - when_looping_or_repeating_work
+update_when:
+  - important_decision_is_made
+  - option_is_rejected
+  - work_is_deferred
+---
+
+# Decisions
+
+This file records important decisions for the AI agent.
+Read this before making or revisiting decisions, especially when the work seems to loop.
+
+## 2026-06-22: Preserve The Existing Root TODO
+
+理由:
+The repository already uses root `TODO.md` as a broad project work memo. Replacing it or forcing front matter into it would mix repository planning with agent-state metadata.
+
+影響:
+AI agent task tracking is added under `## AI Agent Current Tasks` inside the existing `TODO.md`. Repository-level TODO content remains unchanged.
+
+## 2026-06-22: Stop Instead Of Repeating External-Wait Messages
+
+理由:
+When progress depends on user-side work or an external state change, repeated waiting messages do not advance the task and consume context unnecessarily.
+
+影響:
+`GOAL.md` now treats external wait states as a stop condition. The agent should state the stop reason, resume condition, and first resume check once, then end the turn.

--- a/GOAL.md
+++ b/GOAL.md
@@ -1,0 +1,43 @@
+---
+purpose: ai-agent-goal
+read_when:
+  - before_starting_work
+  - before_finishing_work
+  - when_scope_is_unclear
+update_when:
+  - goal_changes
+  - done_conditions_change
+  - stop_conditions_change
+---
+
+# Goal
+
+This file defines what the AI agent is trying to accomplish.
+Read this before starting work, before deciding that work is complete, and whenever scope becomes unclear.
+
+## Objective
+
+Maintain this repository's AI agent work state with lightweight Markdown files:
+
+- `GOAL.md`
+- `TODO.md`
+- `DECISIONS.md`
+- `HANDOFF.md`
+
+For ordinary repository work, keep the active objective here concise and use `TODO.md` for current tasks.
+
+## Done
+
+- Root-level AI agent state files exist where appropriate.
+- Existing repository TODO content is preserved.
+- AI-agent-only task tracking lives in `TODO.md` under `## AI Agent Current Tasks`.
+- Important future decisions can be recorded in `DECISIONS.md`.
+- A compact resume summary can be recorded in `HANDOFF.md`.
+
+## Stop
+
+- Existing human-oriented repository notes would need to be rewritten instead of extended.
+- The current work objective is unclear enough that `GOAL.md` cannot be updated concretely.
+- User-side work or external state changes are required, such as push, release, manual confirmation, or external service operation. In that case, state the stop reason, resume condition, and first resume check once, then end the turn.
+- Do not repeat waiting messages such as "waiting", "still waiting", or "waiting for resume" while blocked on user-side work or an external state change.
+- `TODO.md` の `Retry Log` に同じ原因の失敗が3回記録された

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,43 @@
+---
+purpose: ai-agent-handoff
+read_when:
+  - before_resuming_work
+  - before_handing_off_work
+  - when_context_is_missing
+update_when:
+  - work_is_paused
+  - handoff_summary_changes
+  - verification_status_changes
+---
+
+# Handoff
+
+This file summarizes the current working state for the next human or AI agent.
+Keep it concise. Do not use this as a full work log or a replacement for `TODO.md` and `DECISIONS.md`.
+
+## Current State
+
+- AI agent state management has been initialized for this repository.
+- Root `TODO.md` remains the repository's existing task memo.
+- `GOAL.md`, `DECISIONS.md`, and `HANDOFF.md` provide agent-oriented state, decisions, and resume context.
+
+## Next Action
+
+- For new work, read `GOAL.md`, then check `TODO.md` and update `## AI Agent Current Tasks` with the active task.
+
+## Relevant Files
+
+- `GOAL.md`: Current agent objective, done conditions, and stop conditions.
+- `TODO.md`: Existing repository TODO plus AI agent current tasks.
+- `DECISIONS.md`: Important decisions and reasons.
+- `HANDOFF.md`: Compact resume notes.
+- `README.md`: Repository operating rules and conventions.
+
+## Watch Outs
+
+- Do not rewrite unrelated existing `TODO.md` sections while updating agent task state.
+- Keep state files concise; use repository documentation for durable project rules.
+
+## Last Verification
+
+- 2026-06-22: Inspected `git status --short`, `README.md`, existing `TODO.md`, and state-management templates.

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,27 @@
 - [ ] skill 配布先が必要になったら mirror 方針を決める
 - [ ] UI metadata が必要になったら skill 用の `agents/openai.yaml` を検討する
 
+## AI Agent Current Tasks
+
+This section tracks active work items for AI agents.
+Update this section while working. Do not rewrite unrelated TODO items.
+
+### Tasks
+
+- [x] Initialize lightweight AI agent state files for this repository.
+- [ ] Use this section for the next concrete repository maintenance task.
+
+### Blockers
+
+- なし
+
+### Retry Log
+
+Use this section only when the same task or error is repeated.
+If the same failure appears 3 times, stop and ask the user.
+
+- なし
+
 ## 絶対パス残存の懸念
 
 - [ ] リポジトリ内に残る実環境依存の絶対パスを相対パスまたは環境変数表記へ置き換える


### PR DESCRIPTION
## 概要

リポジトリ直下にAIエージェント向けの軽量な作業状態管理ファイルを追加し、既存の `TODO.md` にAIエージェント用の現在タスク欄を追加します。

## 変更内容

- `GOAL.md` を追加し、AIエージェントが扱う目的、完了条件、停止条件を定義
- `DECISIONS.md` を追加し、重要な判断と理由を記録する場所を定義
- `HANDOFF.md` を追加し、次回作業再開時の簡潔な引き継ぎ情報を記録
- `TODO.md` に `AI Agent Current Tasks` セクションを追加し、既存のTODO内容を残したままAIエージェント用のタスク欄を追加