### PR TITLE
リポジトリバージョンを 1.20260623.1 に更新

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260622.1</version>
+  <version>1.20260623.1</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260622a
+Version: 20260623a
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

リポジトリのバージョン表記を 2026-06-23 版に更新します。

## 変更内容

- `pom.xml` のプロジェクトバージョンを `1.20260622.1` から `1.20260623.1` に更新
- `skills/igapyon-mikuku-agent/references/VERSION.md` の みくく Version を `20260622a` から `20260623a` に更新