### PR TITLE
igapyon-repo-conventions に直下リポジトリの未コミット確認手順を追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260623.1</version>
+  <version>1.20260624.2</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>

--- a/skills/igapyon-mikuku-agent/index.json
+++ b/skills/igapyon-mikuku-agent/index.json
@@ -27,7 +27,7 @@
   {"name":"VERSION.md","path":"references/VERSION.md","ext":"md","dir":"references","size":934,"summary":"みくく Version"},
   {"name":"article-writing.md","path":"references/article-writing.md","ext":"md","dir":"references","size":21488,"summary":"みくく担当記事の執筆参照"},
   {"name":"codex-local-token-usage.md","path":"references/codex-local-token-usage.md","ext":"md","dir":"references","size":4034,"summary":"OpenAI Codex CLI Local Token Usage Investigation"},
-  {"name":"graphic-recording.md","path":"references/graphic-recording.md","ext":"md","dir":"references","size":29085,"summary":"みくく担当グラレコ生成参照"},
+  {"name":"graphic-recording.md","path":"references/graphic-recording.md","ext":"md","dir":"references","size":30379,"summary":"みくく担当グラレコ生成参照"},
   {"name":"10-article-to-graphic-recording-text-prompt.md","path":"references/graphic-recording/10-article-to-graphic-recording-text-prompt.md","ext":"md","dir":"references/graphic-recording","size":6095,"summary":"グラレコテキスト生成プロンプト"},
   {"name":"20-graphic-recording-explainer-image-prompt.md","path":"references/graphic-recording/20-graphic-recording-explainer-image-prompt.md","ext":"md","dir":"references/graphic-recording","size":7955,"summary":"グラレコ説明画像 生成AIプロンプト"},
   {"name":"30-generate-graphic-recording-image-prompt.md","path":"references/graphic-recording/30-generate-graphic-recording-image-prompt.md","ext":"md","dir":"references/graphic-recording","size":13004,"summary":"グラレコ説明画像 生成実行プロンプト"},

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260623a
+Version: 20260624b
 
 ## Version Rule
 

--- a/skills/igapyon-repo-conventions/SKILL.md
+++ b/skills/igapyon-repo-conventions/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: igapyon-repo-conventions
-description: Use only when the user explicitly asks to apply or review igapyon's repository conventions for a local Git or GitHub repository, or explicitly mentions igapyon-repo-conventions. Covers repo-side .gitignore rules, .DS_Store exclusion, workplace/.gitkeep setup, .codex/skills exclusion, Java/Maven .mvn/jvm.config handling, and README documentation of repository operation rules.
+description: Use only when the user explicitly asks to apply or review igapyon's repository conventions for a local Git or GitHub repository, or explicitly mentions igapyon-repo-conventions. Covers repo-side .gitignore rules, .DS_Store exclusion, workplace/.gitkeep setup, .codex/skills exclusion, Java/Maven .mvn/jvm.config handling, README documentation of repository operation rules, and parent-directory checks for uncommitted materials across direct child Git repositories.
 ---
 
 # igapyon-repo-conventions
 
-This skill helps Codex apply igapyon's standard repository conventions to a local Git repository.
+This skill helps Codex apply or inspect igapyon's standard repository conventions in a local Git repository or a parent directory that contains multiple repositories.
 
 Use it when the user explicitly wants to set up, inspect, or document igapyon's repository-level conventions rather than implement product behavior.
 
@@ -17,15 +17,20 @@ If the user asks whether there is a skill for repository conventions, mention th
 
 1. Inspect the repository before editing.
 2. Preserve unrelated user changes.
-3. Read [references/repository-rules.md](references/repository-rules.md) before applying concrete conventions.
-4. Document repository operation rules in `README.md` when appropriate.
-5. Verify the final diff and report any pre-existing unrelated changes.
+3. Select the relevant rule or subfeature from the Reference Use section.
+4. Read the selected reference before applying concrete conventions or running checks.
+5. Document repository operation rules in `README.md` when appropriate.
+6. Verify the final diff and report any pre-existing unrelated changes.
 
 Prefer existing repository patterns over introducing a new structure.
 
 ## Reference Use
 
 Use [references/repository-rules.md](references/repository-rules.md) for the concrete rules covering `.gitignore`, `.DS_Store`, `workplace/`, `.codex/skills/`, Java / Maven `.mvn/jvm.config`, and README documentation.
+
+## Subfeatures
+
+Use [references/direct-child-repo-uncommitted-repositories.md](references/direct-child-repo-uncommitted-repositories.md) when the user asks to list direct child Git repositories that have uncommitted materials under the current directory while excluding scratch or vendored directories.
 
 Use files under [references/template/](references/template/) when creating or updating root convention documents such as `CONTRIBUTING.md`, `CONTRIBUTORS.md`, or `THIRD_PARTY_NOTICES.md`.
 Do not leave template placeholders such as `PROJECT_NAME`, `NAME_OR_HANDLE`, or `DEPENDENCY_NAME` in committed files. If required information is unknown, either defer creating the file or create a minimal accurate document without placeholder text.

--- a/skills/igapyon-repo-conventions/index.json
+++ b/skills/igapyon-repo-conventions/index.json
@@ -3,7 +3,8 @@
  "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
  "basePath": ".",
  "files": [
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":2772,"description":"Use only when the user explicitly asks to apply or review igapyon's repository conventions for a local Git or GitHub repository, or explicitly mentions igapyon-repo-conventions. Covers repo-side .gitignore rules, .DS_Store exclusion, workplace/.gitkeep ...","summary":"igapyon-repo-conventions"},
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":3283,"description":"Use only when the user explicitly asks to apply or review igapyon's repository conventions for a local Git or GitHub repository, or explicitly mentions igapyon-repo-conventions. Covers repo-side .gitignore rules, .DS_Store exclusion, workplace/.gitkeep ...","summary":"igapyon-repo-conventions"},
+  {"name":"direct-child-repo-uncommitted-repositories.md","path":"references/direct-child-repo-uncommitted-repositories.md","ext":"md","dir":"references","size":2092,"summary":"Direct Child Repository Uncommitted Repositories"},
   {"name":"repository-rules.md","path":"references/repository-rules.md","ext":"md","dir":"references","size":3680,"summary":"Repository Rules"},
   {"name":"CONTRIBUTING.md","path":"references/template/CONTRIBUTING.md","ext":"md","dir":"references/template","size":1501,"summary":"Contributing to PROJECT_NAME"},
   {"name":"CONTRIBUTORS.md","path":"references/template/CONTRIBUTORS.md","ext":"md","dir":"references/template","size":161,"summary":"Contributors"},

--- a/skills/igapyon-repo-conventions/references/direct-child-repo-uncommitted-repositories.md
+++ b/skills/igapyon-repo-conventions/references/direct-child-repo-uncommitted-repositories.md
@@ -1,0 +1,87 @@
+# Direct Child Repository Uncommitted Repositories
+
+Use this rule when the user wants to list direct child Git repositories that have uncommitted materials under the current directory.
+
+## Scope
+
+Treat the current directory as the parent directory.
+
+Only inspect Git repositories that are direct child directories of the current directory.
+
+A target repository is a directory that satisfies both conditions:
+
+- `./<repo>/.git` exists.
+- `<repo>` is a direct child directory of the current directory.
+
+Do not inspect nested Git repositories below those direct child repositories.
+
+Example nested repository to ignore:
+
+```text
+./some-repo/references/raw/nested-repo/.git
+```
+
+## Excluded Paths
+
+Within each target repository, exclude changes under these directory names at any depth:
+
+- `workplace/`
+- `vendor/`
+- `tmp/`
+- `temp/`
+
+The exclusion applies both at repository root and under nested directories:
+
+```text
+workplace/**
+**/workplace/**
+vendor/**
+**/vendor/**
+tmp/**
+**/tmp/**
+temp/**
+**/temp/**
+```
+
+## Dirty Repository Judgment
+
+For each target repository, run `git status --porcelain=v1` after applying the excluded paths.
+
+If the filtered status output is not empty, judge that repository as having uncommitted materials.
+
+Include all of these states in the judgment:
+
+- modified files
+- added files
+- deleted files
+- untracked files
+- staged changes
+- unstaged changes
+
+## Reference Command
+
+Run this from the parent directory whose direct children are repositories:
+
+```sh
+find . -mindepth 2 -maxdepth 2 -type d -name .git -print |
+while IFS= read -r gitdir; do
+  repo=${gitdir%/.git}
+  stat_out=$(git -C "$repo" status --porcelain=v1 -- . \
+    ':(exclude)workplace/**' \
+    ':(exclude)**/workplace/**' \
+    ':(exclude)vendor/**' \
+    ':(exclude)**/vendor/**' \
+    ':(exclude)tmp/**' \
+    ':(exclude)**/tmp/**' \
+    ':(exclude)temp/**' \
+    ':(exclude)**/temp/**' \
+    2>/dev/null)
+
+  if [ -n "$stat_out" ]; then
+    printf '%s\n' "$repo"
+    printf '%s\n' "$stat_out" | sed 's/^/  /'
+  fi
+done
+```
+
+Report only repositories that have non-empty filtered status output.


### PR DESCRIPTION
## 概要

igapyon-repo-conventions skill に、現在ディレクトリ直下の Git リポジトリから未コミット素材があるものを一覧するためのサブ機能を追加します。

## 変更内容

- `igapyon-repo-conventions` の説明と本文に、親ディレクトリ配下の直下 Git リポジトリを確認する用途を追記
- 直下リポジトリの判定条件、除外パス、dirty 判定、参照コマンドをまとめた `direct-child-repo-uncommitted-repositories.md` を追加
- `igapyon-repo-conventions/index.json` に新規 reference と更新後の skill メタデータを反映
- `igapyon-mikuku-agent/index.json` の `graphic-recording.md` サイズ情報を更新
- ルート Maven バージョンと `みくく` 内部バージョンを 2026-06-24 の 2 回目更新版へ変更