### PR TITLE
igapyon-agent-state-management に user-decision blocked state の手順を追加

### DIFF
--- a/skills/igapyon-agent-state-management/SKILL.md
+++ b/skills/igapyon-agent-state-management/SKILL.md
@@ -59,6 +59,28 @@ Read `DECISIONS.md` before making or revisiting important decisions, especially 
 
 Read and update `HANDOFF.md` when pausing work, handing work to another agent, or preparing a compact resume summary. Keep it as a concise current-state summary, not a full work log.
 
+## User-Decision Blocked State
+
+If all safe autonomous work is complete, the remaining work requires explicit user judgment, repeating would only restate the same waiting condition, and the goal is not complete, mark the active goal as `blocked` instead of leaving it open.
+
+Use this especially when the only remaining decisions are human choices such as whether to commit or discard a rollback, whether to keep or discard binary artifact changes, or whether to continue after the user explicitly says to pause, stop, or `中断`.
+
+Before blocking, update the state files when they exist:
+
+- `TODO.md`: list the unresolved decisions under blockers or current tasks.
+- `HANDOFF.md`: record the safe stopping point, next valid user actions, and last verification status.
+- `DECISIONS.md`: record only decisions that have actually been made, not pending choices.
+
+When reporting the blocked state, include:
+
+- `Status: blocked`
+- `Reason: user decision required`
+- the exact remaining decisions
+- the current safe stopping point
+- the next valid user actions
+
+Do not keep sending repeated waiting summaries after this condition is reached. Block once and wait for a new user instruction.
+
 ## Existing Files
 
 If a repository already has a human-oriented `TODO.md`, do not replace it and do not force front matter into it.

--- a/skills/igapyon-agent-state-management/references/markdown-state-files.md
+++ b/skills/igapyon-agent-state-management/references/markdown-state-files.md
@@ -93,6 +93,45 @@ If the same failure appears 3 times, stop and ask the user.
 - Prefer updating existing compatible sections over adding duplicate sections.
 - If a tool-specific entry file exists, such as `AGENTS.md` or `CLAUDE.md`, optionally add a short pointer such as: `Before working, check GOAL.md, TODO.md, DECISIONS.md, and HANDOFF.md.`
 
+## Blocking on User Decisions
+
+Mark the active goal as `blocked` when all of these are true:
+
+- All work the agent can safely perform autonomously is complete.
+- Every remaining item requires explicit user judgment.
+- Repeating the work would only restate the same waiting condition.
+- The goal is not complete.
+
+Common examples:
+
+- The user must decide whether to commit or discard a version rollback.
+- The user must decide whether to keep or discard binary artifact changes.
+- The user explicitly says to pause, stop, or `中断`, and the remaining work already requires user input.
+
+Before marking the goal blocked, update existing state files with the current stopping point:
+
+- `TODO.md`: unresolved decisions under `Tasks` or `Blockers`.
+- `HANDOFF.md`: safe stopping point, next valid user actions, and last verification status.
+- `DECISIONS.md`: only decisions already made, not undecided options.
+
+Use this reporting shape:
+
+```text
+Status: blocked
+Reason: user decision required
+
+Remaining decisions:
+- ((exact user decision needed))
+
+Safe stopping point:
+- ((what is complete and safe now))
+
+Next user actions:
+- ((valid instruction the user can give next))
+```
+
+Do not keep responding with repeated waiting summaries after this condition is reached. Block once and wait for a new user instruction.
+
 ## Creation Templates
 
 Use the files under `templates/` as the source templates:


### PR DESCRIPTION
## 概要

igapyon-agent-state-management に、ユーザー判断待ちで安全に進められない場合に active goal を `blocked` として扱う手順を追加しました。

## 変更内容

- `SKILL.md` に `User-Decision Blocked State` セクションを追加し、ユーザー判断が必要な停止条件、状態ファイル更新、報告内容を明文化
- `markdown-state-files.md` に `Blocking on User Decisions` セクションを追加し、Markdown 状態ファイル運用時の blocked 判定条件と報告テンプレートを追加