### PR TITLE
Add github-writer backup branch workflow

### DIFF
--- a/skills/igapyon-github-writer/SKILL.md
+++ b/skills/igapyon-github-writer/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: igapyon-github-writer
-description: Use only when the user explicitly asks to draft GitHub PR text, GitHub Release notes, GitHub About text, rebuild local commits with soft reset and a drafted PR text as the commit message, or asks to inspect the current branch status using igapyon-github-writer. If the user only asks whether such a skill exists, mention this skill as an available option but do not apply it until asked.
+description: Use only when the user explicitly asks to draft GitHub PR text, GitHub Release notes, GitHub About text, rebuild local commits with soft reset and a drafted PR text as the commit message, create a local backup branch, or inspect the current branch status using igapyon-github-writer. If the user only asks whether such a skill exists, mention this skill as an available option but do not apply it until asked.
 ---
 
 # igapyon-github-writer
 
-This skill drafts Markdown text for GitHub surfaces from local repository evidence. It can also save drafted GitHub text to a local Markdown file, rebuild local commits with soft reset and a drafted PR text as the commit message, and report the current branch status as preparation for GitHub writing work.
+This skill drafts Markdown text for GitHub surfaces from local repository evidence. It can also save drafted GitHub text to a local Markdown file, rebuild local commits with soft reset and a drafted PR text as the commit message, create a local backup branch at the current `HEAD`, and report the current branch status as preparation for GitHub writing work.
 
-Use it only for GitHub writing text, local draft-file saving for that text, explicit PR soft-reset recommit work, and the local branch-status checks that prepare that writing. Do not create PRs, tags, releases, issues, branches, commits, or remote changes unless the user separately asks for that operation.
+Use it only for GitHub writing text, local draft-file saving for that text, explicit PR soft-reset recommit work, explicit local backup-branch creation, and the local branch-status checks that prepare that writing. Do not create PRs, tags, releases, issues, non-backup branches, commits, or remote changes unless the user separately asks for that operation.
 
-Do not use this skill for generic commit summaries, changelogs, branch inspection, or repository cleanup unless the user explicitly asks for GitHub PR, GitHub Release, GitHub About text, PR soft-reset recommit from drafted PR text, branch status through this skill, or names this skill.
+Do not use this skill for generic commit summaries, changelogs, branch inspection, backup operations, or repository cleanup unless the user explicitly asks for GitHub PR, GitHub Release, GitHub About text, PR soft-reset recommit from drafted PR text, local backup-branch creation through this skill, branch status through this skill, or names this skill.
 
 If the user asks whether there is a skill for GitHub PR, Release, or About text, mention this skill as an available option, but do not apply it until the user asks to use it.
 
@@ -23,6 +23,7 @@ Examples:
 - Release mode: `release textつくりたい`, `リリース文を作りたい`, `release notes`, `リリースノート`, `GitHub Release本文`
 - About mode: `GitHub Aboutを書きたい`, `About文`, `リポジトリ説明`, `GitHub説明文`
 - PR Soft Reset Recommit mode: `PR文面でsoft resetしてcommitし直す`, `PR文面をcommit messageに反映して再コミット`, `作文したPR文面でgit commitし直す`
+- Backup Branch mode: `github-writerでバックアップブランチ`, `backup/2026-06-27-2230 みたいなブランチを作る`, `現在HEADをバックアップ`, `soft reset前のバックアップだけ作る`
 - Branch Status mode: `github-writerでブランチ状況`, `今のブランチの状況`, `PR前にブランチ状態を見たい`, `現在ブランチの確認`
 
 If the mode is clear but required evidence is missing, do not draft yet. Ask for the missing target, except for PR mode's default target rule:
@@ -33,9 +34,9 @@ If the mode is clear but required evidence is missing, do not draft yet. Ask for
 
 ## Core Workflow
 
-1. Identify whether the request is for PR, Release, About text, PR Soft Reset Recommit, or Branch Status.
+1. Identify whether the request is for PR, Release, About text, PR Soft Reset Recommit, Backup Branch, or Branch Status.
 2. Read [references/github-writing-rules.md](references/github-writing-rules.md) before drafting.
-3. Read the mode-specific reference: [references/pr-writing.md](references/pr-writing.md), [references/release-writing.md](references/release-writing.md), [references/about-writing.md](references/about-writing.md), [references/pr-soft-reset-recommit.md](references/pr-soft-reset-recommit.md), or [references/branch-status.md](references/branch-status.md).
+3. Read the mode-specific reference: [references/pr-writing.md](references/pr-writing.md), [references/release-writing.md](references/release-writing.md), [references/about-writing.md](references/about-writing.md), [references/pr-soft-reset-recommit.md](references/pr-soft-reset-recommit.md), [references/backup-branch.md](references/backup-branch.md), or [references/branch-status.md](references/branch-status.md).
 4. Inspect only the repository evidence needed for the requested mode.
 5. Draft or report from evidence without inventing unsupported facts.
 6. For PR, Release, and About modes, save the drafted Markdown using the shared draft-save rules unless the user says not to save.
@@ -51,6 +52,7 @@ Use these mode-specific references:
 - [references/release-writing.md](references/release-writing.md) for GitHub Release title and body drafting
 - [references/about-writing.md](references/about-writing.md) for GitHub About text drafting
 - [references/pr-soft-reset-recommit.md](references/pr-soft-reset-recommit.md) for rebuilding local commits with soft reset and a drafted PR text as the commit message
+- [references/backup-branch.md](references/backup-branch.md) for creating a local backup branch at the current `HEAD`
 - [references/branch-status.md](references/branch-status.md) for current branch status reporting before GitHub writing work
 
 Use `index.json` as the discovery index when you need to confirm the available bundled reference files, but treat `SKILL.md` and files under `references/` as the source of truth.

--- a/skills/igapyon-github-writer/index.json
+++ b/skills/igapyon-github-writer/index.json
@@ -3,11 +3,12 @@
  "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
  "basePath": ".",
  "files": [
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":5548,"description":"Use only when the user explicitly asks to draft GitHub PR text, GitHub Release notes, GitHub About text, rebuild local commits with soft reset and a drafted PR text as the commit message, or asks to inspect the current branch status using igapyon-github...","summary":"igapyon-github-writer"},
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":6149,"description":"Use only when the user explicitly asks to draft GitHub PR text, GitHub Release notes, GitHub About text, rebuild local commits with soft reset and a drafted PR text as the commit message, create a local backup branch, or inspect the current branch status...","summary":"igapyon-github-writer"},
   {"name":"about-writing.md","path":"references/about-writing.md","ext":"md","dir":"references","size":1136,"summary":"GitHub About Writing"},
+  {"name":"backup-branch.md","path":"references/backup-branch.md","ext":"md","dir":"references","size":2440,"summary":"Backup Branch"},
   {"name":"branch-status.md","path":"references/branch-status.md","ext":"md","dir":"references","size":2672,"summary":"GitHub Branch Status"},
   {"name":"github-writing-rules.md","path":"references/github-writing-rules.md","ext":"md","dir":"references","size":5848,"summary":"GitHub Writing Rules"},
-  {"name":"pr-soft-reset-recommit.md","path":"references/pr-soft-reset-recommit.md","ext":"md","dir":"references","size":4248,"summary":"PR Soft Reset Recommit"},
+  {"name":"pr-soft-reset-recommit.md","path":"references/pr-soft-reset-recommit.md","ext":"md","dir":"references","size":4768,"summary":"PR Soft Reset Recommit"},
   {"name":"pr-writing.md","path":"references/pr-writing.md","ext":"md","dir":"references","size":3124,"summary":"GitHub PR Writing"},
   {"name":"release-writing.md","path":"references/release-writing.md","ext":"md","dir":"references","size":3555,"summary":"GitHub Release Writing"}
  ]

--- a/skills/igapyon-github-writer/references/backup-branch.md
+++ b/skills/igapyon-github-writer/references/backup-branch.md
@@ -1,0 +1,73 @@
+# Backup Branch
+
+Use this workflow when the user explicitly asks `igapyon-github-writer` to create a local backup branch, or when another active `igapyon-github-writer` workflow requires a backup branch before rewriting local history.
+
+This workflow creates a local branch that points at the current `HEAD`. It does not switch branches and it does not preserve uncommitted working-tree or index changes.
+
+## Safety Rules
+
+- Require an explicit user request before creating a standalone backup branch.
+- In PR Soft Reset Recommit mode, create the backup branch immediately before `git reset --soft`.
+- Inspect `git status -sb` and the current `HEAD` before creating the backup branch.
+- Do not run `git fetch`, `git pull`, `git push`, `gh pr create`, or any remote-changing command in this workflow.
+- Do not create tags, releases, issues, pull requests, commits, or non-backup branches.
+- If the working tree or index has changes, report that the backup branch preserves only committed history at `HEAD`.
+- Do not overwrite an existing backup branch. If the generated name exists, add a numeric suffix such as `-2`.
+- If backup branch creation fails, stop before any history rewrite.
+
+## Branch Name
+
+Use this branch name pattern by default:
+
+```text
+backup/<YYYY-MM-DD-HHMM>
+```
+
+Use local time for the timestamp. If the user provides a branch name, use it only when it is under `backup/` and is a valid Git branch name.
+
+## Evidence Commands
+
+Inspect the smallest useful local evidence:
+
+```sh
+git status -sb
+git branch --show-current
+git rev-parse --short HEAD
+git log --oneline --decorate -1
+git branch --list 'backup/*'
+```
+
+## Command Shape
+
+When the backup name is resolved and does not already exist:
+
+```sh
+git branch backup/<YYYY-MM-DD-HHMM> HEAD
+git rev-parse --short backup/<YYYY-MM-DD-HHMM>
+```
+
+If the generated name already exists, choose the next available suffix:
+
+```text
+backup/<YYYY-MM-DD-HHMM>-2
+backup/<YYYY-MM-DD-HHMM>-3
+```
+
+## Output
+
+Return a concise Japanese Markdown report:
+
+```markdown
+## バックアップブランチ
+
+- 作成: `backup/<YYYY-MM-DD-HHMM>`
+- 指すコミット: `<short-hash>` ...
+- 元ブランチ: `...`
+- working tree: ...
+
+## 注意点
+
+- 未コミット変更はバックアップブランチには含まれません。
+```
+
+Add `## 注意点` only when there is something material to call out, such as dirty working tree, staged changes, untracked files, or a generated name collision.

--- a/skills/igapyon-github-writer/references/pr-soft-reset-recommit.md
+++ b/skills/igapyon-github-writer/references/pr-soft-reset-recommit.md
@@ -12,6 +12,9 @@ This mode changes local Git history. Do not run it automatically after drafting 
 - Inspect `git status -sb` before changing anything.
 - Inspect the commits that would be collapsed with `git log --oneline --decorate <base>..HEAD`.
 - Inspect the change size with `git diff --stat <base>...HEAD` or another appropriate diff command before resetting.
+- Create a local backup branch at the current `HEAD` immediately before running `git reset --soft`, using [backup-branch.md](backup-branch.md).
+- Do not proceed to `git reset --soft` if backup branch creation fails.
+- Prefer running backup branch creation and `git reset --soft` as one shell command joined with `&&`, so a single approval can cover the local history rewrite while still stopping if backup creation fails.
 - Do not proceed if there are unrelated uncommitted changes unless the user explicitly confirms how to handle them.
 - Do not run `git reset --hard`, `git checkout --`, `git push`, `gh pr create`, or any remote-changing command in this workflow.
 - `git fetch origin` is allowed only to refresh local remote-tracking information.
@@ -57,7 +60,7 @@ git status -sb
 git fetch origin
 git log --oneline --decorate "$BASE"..HEAD
 git diff --stat "$BASE"...HEAD
-git reset --soft "$BASE"
+git branch backup/<YYYY-MM-DD-HHMM> HEAD && git reset --soft "$BASE"
 git commit -F "$PR_DRAFT"
 git log --oneline --decorate -3
 git status -sb
@@ -70,6 +73,7 @@ Replace the example `BASE` and `PR_DRAFT` values with the confirmed values befor
 After execution, report:
 
 - the base used for `git reset --soft`
+- the backup branch created before `git reset --soft`
 - the saved PR draft path used for `git commit -F`
 - whether `git commit -F` succeeded
 - the new commit hash if available


### PR DESCRIPTION
## 概要

igapyon-github-writer に、ローカルバックアップブランチ作成モードを追加します。

## 変更内容

- `igapyon-github-writer` の説明とモード一覧に Backup Branch mode を追加
- `references/backup-branch.md` を追加し、`backup/<YYYY-MM-DD-HHMM>` 形式のローカルバックアップブランチ作成手順、確認コマンド、注意点を定義
- PR soft reset recommit workflow で、`git reset --soft` の直前にバックアップブランチを作成するルールとコマンド例を追加
- `index.json` に新しい参照ファイルと更新後のメタデータを反映