### PR TITLE
外部 miku-soft 系 skill 参照を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,8 +315,8 @@ release archive には、この repo の `skills/` に加えて、外部管理�
 
 同梱する外部 skill は次の通りです。
 
-- `miku-indexgen-skills` `v1.6.1`: `skills/igapyon-miku-indexgen/`
-- `miku-text-bundle-skills` `v1.1.1.2`: `skills/igapyon-miku-text-bundle/`
+- `miku-indexgen-skills` `v1.6.2`: `skills/igapyon-miku-indexgen/`
+- `miku-text-bundle-skills` `v1.3.0`: `skills/igapyon-miku-text-bundle/`
 - `miku-repo-bundle-skills` `v0.5.0.1` (experimental): `skills/igapyon-miku-repo-bundle/`
 - `miku-grep-skills` `v0.10.1.1` (experimental): `skills/igapyon-miku-grep/`
 - `miku-prompt-lint-skills` `v0.4.1`: `skills/igapyon-miku-prompt-lint/`

--- a/pom.xml
+++ b/pom.xml
@@ -5,17 +5,17 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260624.2</version>
+  <version>1.20260627.2</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>
 
   <properties>
     <external.miku-indexgen-skills.repo>https://github.com/igapyon/miku-indexgen-skills.git</external.miku-indexgen-skills.repo>
-    <external.miku-indexgen-skills.ref>v1.6.1</external.miku-indexgen-skills.ref>
+    <external.miku-indexgen-skills.ref>v1.6.2</external.miku-indexgen-skills.ref>
     <external.miku-indexgen-skills.skillName>igapyon-miku-indexgen</external.miku-indexgen-skills.skillName>
     <external.miku-text-bundle-skills.repo>https://github.com/igapyon/miku-text-bundle-skills.git</external.miku-text-bundle-skills.repo>
-    <external.miku-text-bundle-skills.ref>v1.1.1.2</external.miku-text-bundle-skills.ref>
+    <external.miku-text-bundle-skills.ref>v1.3.0</external.miku-text-bundle-skills.ref>
     <external.miku-text-bundle-skills.skillName>igapyon-miku-text-bundle</external.miku-text-bundle-skills.skillName>
     <external.miku-repo-bundle-skills.repo>https://github.com/igapyon/miku-repo-bundle-skills.git</external.miku-repo-bundle-skills.repo>
     <external.miku-repo-bundle-skills.ref>v0.5.0.1</external.miku-repo-bundle-skills.ref>

--- a/skills/igapyon-agent-state-management/index.json
+++ b/skills/igapyon-agent-state-management/index.json
@@ -3,8 +3,8 @@
  "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
  "basePath": ".",
  "files": [
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":4539,"description":"Use only when the user explicitly names igapyon-agent-state-management or uses an igapyon-prefixed trigger phrase such as igapyon 状態管理, igapyon agent 状態管理, igapyon 作業状態, igapyon 作業再開, igapyon goal, igapyon todo, igapyon handoff, or igapyon GOAL TODO DEC...","summary":"Igapyon Agent State Management"},
-  {"name":"markdown-state-files.md","path":"references/markdown-state-files.md","ext":"md","dir":"references","size":4998,"summary":"Markdown State Files"},
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":5796,"description":"Use only when the user explicitly names igapyon-agent-state-management or uses an igapyon-prefixed trigger phrase such as igapyon 状態管理, igapyon agent 状態管理, igapyon 作業状態, igapyon 作業再開, igapyon goal, igapyon todo, igapyon handoff, or igapyon GOAL TODO DEC...","summary":"Igapyon Agent State Management"},
+  {"name":"markdown-state-files.md","path":"references/markdown-state-files.md","ext":"md","dir":"references","size":6350,"summary":"Markdown State Files"},
   {"name":"DECISIONS.md","path":"templates/DECISIONS.md","ext":"md","dir":"templates","size":578,"summary":"Decisions"},
   {"name":"GOAL.md","path":"templates/GOAL.md","ext":"md","dir":"templates","size":680,"summary":"Goal"},
   {"name":"HANDOFF.md","path":"templates/HANDOFF.md","ext":"md","dir":"templates","size":913,"summary":"Handoff"},

--- a/skills/igapyon-github-writer/index.json
+++ b/skills/igapyon-github-writer/index.json
@@ -3,7 +3,7 @@
  "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
  "basePath": ".",
  "files": [
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":6149,"description":"Use only when the user explicitly asks to draft GitHub PR text, GitHub Release notes, GitHub About text, rebuild local commits with soft reset and a drafted PR text as the commit message, create a local backup branch, or inspect the current branch status...","summary":"igapyon-github-writer"},
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":6149,"description":"Use only when the user explicitly asks to draft GitHub PR text, GitHub Release notes, GitHub About text, rebuild local commits with soft reset and a drafted PR text as the commit message, create a local backup branch, or inspect the current branch statu...","summary":"igapyon-github-writer"},
   {"name":"about-writing.md","path":"references/about-writing.md","ext":"md","dir":"references","size":1136,"summary":"GitHub About Writing"},
   {"name":"backup-branch.md","path":"references/backup-branch.md","ext":"md","dir":"references","size":2440,"summary":"Backup Branch"},
   {"name":"branch-status.md","path":"references/branch-status.md","ext":"md","dir":"references","size":2672,"summary":"GitHub Branch Status"},

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260624b
+Version: 20260627b
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

release archive に同梱する外部 miku-soft 系 skill の固定参照を最新化し、リポジトリ全体とみくくのバージョンを `20260627b` に更新します。

## 変更内容

- `miku-indexgen-skills` の取り込み参照を `v1.6.2` に更新
- `miku-text-bundle-skills` の取り込み参照を `v1.3.0` に更新
- README の外部 skill 同梱一覧を更新後の参照に同期
- repo 全体のバージョンを `1.20260627.2` に更新
- みくくのバージョンを `20260627b` に更新
- `mvn package` による skill index 再生成結果を反映