### PR TITLE
Add harness operations decisions guidance

### DIFF
--- a/skills/igapyon-agent-state-management/SKILL.md
+++ b/skills/igapyon-agent-state-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: igapyon-agent-state-management
-description: Use only when the user explicitly names igapyon-agent-state-management or uses an igapyon-prefixed trigger phrase such as igapyon 状態管理, igapyon agent 状態管理, igapyon 作業状態, igapyon 作業再開, igapyon goal, igapyon todo, igapyon handoff, or igapyon GOAL TODO DECISIONS HANDOFF. Do not trigger for generic TODO.md maintenance, ordinary project planning, vague handoff discussion, ordinary work resumption, broad Context Engineering talk, or even the GOAL.md + TODO.md + DECISIONS.md + HANDOFF.md workflow unless the user also says igapyon or explicitly names this skill.
+description: Use only when the user explicitly names igapyon-agent-state-management or uses an igapyon-prefixed trigger phrase such as igapyon 状態管理, igapyon agent 状態管理, igapyon 作業状態, igapyon 作業再開, igapyon goal, igapyon todo, igapyon handoff, or igapyon GOAL TODO DECISIONS HANDOFF. Do not trigger for generic TODO.md maintenance, ordinary project planning, vague handoff discussion, ordinary work resumption, broad Context Engineering talk, generic build/test failures, or even the GOAL.md + TODO.md + DECISIONS.md + HANDOFF.md workflow unless the user also says igapyon or explicitly names this skill. When active, also supports repository-local Harness Operations Decisions in DECISIONS.md for reusable build/test/package/comparison/roundtrip execution decisions.
 ---
 
 # Igapyon Agent State Management
@@ -56,6 +56,8 @@ Read `GOAL.md` before starting work, before declaring completion, and whenever s
 Read and update `TODO.md` during work when task status changes, blockers appear, new work is found, or the same failure repeats.
 
 Read `DECISIONS.md` before making or revisiting important decisions, especially when the work appears to loop.
+
+Use `## Harness Operations Decisions` in `DECISIONS.md` for repository-local decisions about build, test, package, comparison, roundtrip, or similar verification harness execution. Record reusable execution decisions, not full failure logs.
 
 Read and update `HANDOFF.md` when pausing work, handing work to another agent, or preparing a compact resume summary. Keep it as a concise current-state summary, not a full work log.
 

--- a/skills/igapyon-agent-state-management/references/markdown-state-files.md
+++ b/skills/igapyon-agent-state-management/references/markdown-state-files.md
@@ -93,6 +93,57 @@ If the same failure appears 3 times, stop and ask the user.
 - Prefer updating existing compatible sections over adding duplicate sections.
 - If a tool-specific entry file exists, such as `AGENTS.md` or `CLAUDE.md`, optionally add a short pointer such as: `Before working, check GOAL.md, TODO.md, DECISIONS.md, and HANDOFF.md.`
 
+## Harness Operations Decisions
+
+Use this repository-local `DECISIONS.md` section when an active igapyon state-management workflow needs to preserve reusable decisions about build, test, package, comparison, roundtrip, or similar verification harness execution:
+
+```markdown
+## Harness Operations Decisions
+```
+
+Record decisions that should guide the next agent or human in this repository. Do not use this section as a raw failure log.
+
+Record:
+
+- failed execution patterns that are likely to repeat
+- known or suspected harness-operation causes
+- successful retry methods that should become the next standard approach
+- recommended execution order for future verification
+- harness design choices to avoid in this repository
+
+Do not record:
+
+- one-off shell input mistakes
+- full failure logs
+- temporary environment trouble with no reusable lesson
+- implementation bug details
+- long work logs that are too specific to reuse
+
+Use this entry shape:
+
+```markdown
+### YYYY-MM-DD: Short decision title
+
+- Context: What failed or what operational risk was found.
+- Decision: The reusable execution decision for this repository.
+- Reason: Why this decision reduces false failures or repeated work.
+- Next time: The recommended command order or harness precaution.
+```
+
+File-role split:
+
+- `TODO.md`: active verification tasks, blockers, repeated failures, and next attempts.
+- `DECISIONS.md`: reusable harness-operation decisions that should survive the current task.
+- `HANDOFF.md`: the latest safe stopping point and current verification status.
+
+Before treating a harness failure as a model reasoning problem or implementation bug, check whether:
+
+- multiple commands are reading or writing the same artifact directory at the same time
+- versioned jar, zip, bundle, or generated artifact names are hard-coded
+- a harness reads build artifacts before they have been generated
+- the `clean`, `package`, `test`, `comparison`, and `roundtrip` order is wrong for this repository
+- a successful retry should be turned into the next standard procedure
+
 ## Interrupting on User Decisions
 
 Stop work and report the state as interrupted when all of these are true:

--- a/skills/igapyon-agent-state-management/templates/DECISIONS.md
+++ b/skills/igapyon-agent-state-management/templates/DECISIONS.md
@@ -24,3 +24,14 @@ Read this before making or revisiting decisions, especially when the work seems 
 
 影響:
 ((TBD: その判断による影響や後続タスクを書く))
+
+## Harness Operations Decisions
+
+Use this section for reusable decisions about build/test/package/comparison/roundtrip harness execution. Do not paste full failure logs here.
+
+### YYYY-MM-DD: Run package before comparison harness
+
+- Context: The comparison harness reads generated artifacts from the build output directory.
+- Decision: Build the required artifacts before running the comparison harness.
+- Reason: Running comparison against missing or stale artifacts caused false failures.
+- Next time: Run the package step first, then run the focused comparison command.


### PR DESCRIPTION
## 概要

`igapyon-agent-state-management` に、リポジトリ内の検証ハーネス運用判断を `DECISIONS.md` へ記録するための `Harness Operations Decisions` ガイドを追加します。

## 変更内容

- `SKILL.md` に、active 時は `DECISIONS.md` の `## Harness Operations Decisions` を扱えることを追記
- generic build/test failure だけでは skill が発火しない制約を description に明記
- `references/markdown-state-files.md` に、記録する内容、記録しない内容、推奨フォーマット、各 state file の役割分担を追加
- `templates/DECISIONS.md` に `## Harness Operations Decisions` の短い説明と最小例を追加

## 確認事項

- skill validation と whitespace check はコミット前に実行済み