### PR TITLE
agent 状態管理 skill の運用ルールを更新

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260627.2</version>
+  <version>1.20260628.1</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>

--- a/skills/igapyon-agent-state-management/SKILL.md
+++ b/skills/igapyon-agent-state-management/SKILL.md
@@ -37,8 +37,9 @@ When answering a general question such as "what skills are available?", describe
 3. Do not overwrite existing files without reading them first.
 4. If `TODO.md` already exists, preserve its existing purpose and add or update only `## AI Agent Current Tasks` when appropriate.
 5. Use [references/markdown-state-files.md](references/markdown-state-files.md) for the detailed setup rules and initial prompt.
-6. Use templates from [templates/](templates/) when creating new files.
-7. Keep the state files lightweight. Do not turn them into long work logs or broad project documentation.
+6. When a root `README.md` exists, add or propose a short AI-agent note that points agents to `GOAL.md`, `TODO.md`, `DECISIONS.md`, and `HANDOFF.md`.
+7. Use templates from [templates/](templates/) when creating new files.
+8. Keep the state files lightweight. Do not turn them into long work logs or broad project documentation.
 
 ## Resume Workflow
 

--- a/skills/igapyon-agent-state-management/index.json
+++ b/skills/igapyon-agent-state-management/index.json
@@ -3,9 +3,9 @@
  "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
  "basePath": ".",
  "files": [
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":5796,"description":"Use only when the user explicitly names igapyon-agent-state-management or uses an igapyon-prefixed trigger phrase such as igapyon 状態管理, igapyon agent 状態管理, igapyon 作業状態, igapyon 作業再開, igapyon goal, igapyon todo, igapyon handoff, or igapyon GOAL TODO DEC...","summary":"Igapyon Agent State Management"},
-  {"name":"markdown-state-files.md","path":"references/markdown-state-files.md","ext":"md","dir":"references","size":6350,"summary":"Markdown State Files"},
-  {"name":"DECISIONS.md","path":"templates/DECISIONS.md","ext":"md","dir":"templates","size":578,"summary":"Decisions"},
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":6380,"description":"Use only when the user explicitly names igapyon-agent-state-management or uses an igapyon-prefixed trigger phrase such as igapyon 状態管理, igapyon agent 状態管理, igapyon 作業状態, igapyon 作業再開, igapyon goal, igapyon todo, igapyon handoff, or igapyon GOAL TODO DEC...","summary":"Igapyon Agent State Management"},
+  {"name":"markdown-state-files.md","path":"references/markdown-state-files.md","ext":"md","dir":"references","size":10106,"summary":"Markdown State Files"},
+  {"name":"DECISIONS.md","path":"templates/DECISIONS.md","ext":"md","dir":"templates","size":1152,"summary":"Decisions"},
   {"name":"GOAL.md","path":"templates/GOAL.md","ext":"md","dir":"templates","size":680,"summary":"Goal"},
   {"name":"HANDOFF.md","path":"templates/HANDOFF.md","ext":"md","dir":"templates","size":913,"summary":"Handoff"},
   {"name":"TODO.md","path":"templates/TODO.md","ext":"md","dir":"templates","size":893,"summary":"Todo"}

--- a/skills/igapyon-agent-state-management/references/markdown-state-files.md
+++ b/skills/igapyon-agent-state-management/references/markdown-state-files.md
@@ -38,6 +38,7 @@ Use or adapt this prompt when the user asks to initialize the convention:
 新規作成するファイルには、AI エージェントが後から読んだときに用途が分かるよう、front matter と短い運用ヒントを入れてください。
 すでに同名ファイルが存在する場合は、上書きせず、内容を確認してから差分提案にしてください。
 既存 `TODO.md` に `## AI Agent Current Tasks` セクションを追加する場合は、既存ファイルの形式を尊重し、無理に front matter を追加しないでください。
+root の `README.md` が存在する場合は、AI agent 向け情報として `GOAL.md`、`TODO.md`、`DECISIONS.md`、`HANDOFF.md` を確認するよう促す短いセクションまたは箇条書きを追加してください。既存 README の構成を尊重し、README が存在しない場合はこの目的だけで新規作成しないでください。
 `((TBD: ...))` はプレースホルダーです。実際の作業内容が分かる場合は、作成時に具体的な内容へ置き換えてください。分からない場合は、TBD のまま残し、作業開始時に確認してください。
 ````
 
@@ -92,6 +93,41 @@ If the same failure appears 3 times, stop and ask the user.
 - If the same failure appears three times for the same underlying cause, stop and ask the user.
 - Prefer updating existing compatible sections over adding duplicate sections.
 - If a tool-specific entry file exists, such as `AGENTS.md` or `CLAUDE.md`, optionally add a short pointer such as: `Before working, check GOAL.md, TODO.md, DECISIONS.md, and HANDOFF.md.`
+
+## Root README.md Agent Note
+
+When setting up this workflow in a repository that already has a root
+`README.md`, add or propose a concise AI-agent note that tells future agents to
+check the state files before starting work.
+
+Do not create a new `README.md` solely for this purpose. Respect the existing
+README structure and keep the note short.
+
+Example:
+
+```markdown
+## AI Agent Notes
+
+Before working in this repository, check `GOAL.md`, `TODO.md`,
+`DECISIONS.md`, and `HANDOFF.md` when they exist. These files record the current
+objective, active tasks, decisions, and handoff notes for AI agent work.
+```
+
+## DECISIONS.md Update Trigger
+
+Do not write to `DECISIONS.md` merely because an AI agent attempt failed.
+
+Write or propose a `DECISIONS.md` entry only when the failure reveals a
+reusable repository policy, constraint, or preferred workflow. The decision
+should help prevent repeated work for a future human or agent.
+
+Use this rule of thumb:
+
+- If it is only a one-off failed attempt, do not record it in `DECISIONS.md`.
+- If it is useful current-state context, record it in `TODO.md` or `HANDOFF.md`.
+- If it becomes a reusable prevention rule, propose a `DECISIONS.md` entry.
+- If the policy update is small and obvious, the agent may add it directly.
+- If the policy change is strong or ambiguous, confirm it with the human first.
 
 ## Harness Operations Decisions
 

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260627b
+Version: 20260628a
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

igapyon-agent-state-management に、AI agent が状態管理ファイルを把握しやすくするための README 案内ルールと、失敗試行を DECISIONS.md に記録する判断基準を追加しました。

## 変更内容

- repository root の `README.md` が存在する場合、AI agent 向け note として `GOAL.md`、`TODO.md`、`DECISIONS.md`、`HANDOFF.md` の確認を促すルールを追加
- `DECISIONS.md` には失敗した試行をそのまま記録せず、再利用可能な方針・制約・標準手順になった場合だけ記録または提案するルールを追加
- `igapyon-agent-state-management` の参照ドキュメントと `SKILL.md` を更新
- `mvn generate-resources` により `skills/igapyon-agent-state-management/index.json` を更新
- repository version を `1.20260628.1`、みくく version を `20260628a` に更新

## 検証

- `mvn validate`
- `mvn generate-resources`