### PR TITLE
Add agent skill trace guidance

### DIFF
--- a/skills/igapyon-agent-state-management/SKILL.md
+++ b/skills/igapyon-agent-state-management/SKILL.md
@@ -50,6 +50,14 @@ When the user says `igapyon 作業再開`, treat it as a request to recover the 
 3. If they do not exist, do not create them automatically unless the user asks. Briefly mention that this skill can set up `GOAL.md`, `TODO.md`, `DECISIONS.md`, and `HANDOFF.md` if needed.
 4. Keep the output focused on what to do next and any uncertainty that needs user confirmation.
 
+## Agent Skill Trace
+
+When this skill is active and the user asks about logs, traces, Markdown reads, `SKILL.md` read timing, or when Agent Skills became active, briefly introduce the optional Agent Skill Trace design.
+
+Do not enable tracing automatically. Enable it only when the user explicitly asks to turn on Agent Skill Trace or gives an equally clear instruction to start recording the trace.
+
+Use [references/agent-skill-trace.md](references/agent-skill-trace.md) for the detailed trace policy, output location, event shape, and privacy rules.
+
 ## File Roles
 
 Read `GOAL.md` before starting work, before declaring completion, and whenever scope becomes unclear.

--- a/skills/igapyon-agent-state-management/index.json
+++ b/skills/igapyon-agent-state-management/index.json
@@ -3,7 +3,8 @@
  "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
  "basePath": ".",
  "files": [
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":6380,"description":"Use only when the user explicitly names igapyon-agent-state-management or uses an igapyon-prefixed trigger phrase such as igapyon 状態管理, igapyon agent 状態管理, igapyon 作業状態, igapyon 作業再開, igapyon goal, igapyon todo, igapyon handoff, or igapyon GOAL TODO DEC...","summary":"Igapyon Agent State Management"},
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":6932,"description":"Use only when the user explicitly names igapyon-agent-state-management or uses an igapyon-prefixed trigger phrase such as igapyon 状態管理, igapyon agent 状態管理, igapyon 作業状態, igapyon 作業再開, igapyon goal, igapyon todo, igapyon handoff, or igapyon GOAL TODO DEC...","summary":"Igapyon Agent State Management"},
+  {"name":"agent-skill-trace.md","path":"references/agent-skill-trace.md","ext":"md","dir":"references","size":3865,"summary":"Agent Skill Trace"},
   {"name":"markdown-state-files.md","path":"references/markdown-state-files.md","ext":"md","dir":"references","size":10106,"summary":"Markdown State Files"},
   {"name":"DECISIONS.md","path":"templates/DECISIONS.md","ext":"md","dir":"templates","size":1152,"summary":"Decisions"},
   {"name":"GOAL.md","path":"templates/GOAL.md","ext":"md","dir":"templates","size":680,"summary":"Goal"},

--- a/skills/igapyon-agent-state-management/references/agent-skill-trace.md
+++ b/skills/igapyon-agent-state-management/references/agent-skill-trace.md
@@ -1,0 +1,106 @@
+# Agent Skill Trace
+
+Agent Skill Trace is an optional development-time diagnostic aid for Agent Skills.
+
+This feature is intentionally narrow and should stay off by default. It exists to help a Skill author understand when a Skill became active, when `SKILL.md` was read, when Markdown reference files were read, and which trace-relevant decisions occurred during an `igapyon-agent-state-management` workflow.
+
+## Activation Policy
+
+Do not enable Agent Skill Trace automatically.
+
+When `igapyon-agent-state-management` is active and the user asks about logs, traces, Markdown reads, `SKILL.md` read timing, or when Agent Skills became active, introduce Agent Skill Trace as an available diagnostic option.
+
+Enable tracing only when the user explicitly asks to turn it on. Accept clear instructions such as:
+
+- "Agent Skill Trace を ON にして"
+- "トレースを開始して"
+- "Skill 読み込みタイミングを jsonl に記録して"
+- "この作業では Agent Skill Trace を有効化して"
+
+Do not treat vague curiosity as activation. Questions such as "ログは見られる?", "いつ読んだか知りたい", or "トレースできる?" should receive an explanation of the feature and a note that it requires explicit opt-in.
+
+## Output Location
+
+Trace files are JSONL and are split by local date.
+
+Prefer this path when `workplace/` exists:
+
+```text
+workplace/agent-skill-trace/YYYY-MM-DD.trace.jsonl
+```
+
+If `workplace/` does not exist and `temp/` exists, use:
+
+```text
+temp/agent-skill-trace/YYYY-MM-DD.trace.jsonl
+```
+
+If neither directory exists, create:
+
+```text
+workplace/agent-skill-trace/YYYY-MM-DD.trace.jsonl
+```
+
+Use the repository-local timezone context when available. For this repository's normal local work, that is Asia/Tokyo.
+
+`workplace/*` is already Git-ignored in this repository. Do not add trace JSONL files to Git. If the fallback `temp/` path is used in another repository, make sure the trace output remains local-only and is not committed.
+
+## Event Scope
+
+Keep trace events small and operational. Record facts about Skill activation and file access, not content.
+
+Recommended event types:
+
+- `skill_trace_enabled`
+- `skill_activated`
+- `skill_instruction_read`
+- `skill_reference_read`
+- `skill_trace_decision`
+- `skill_trace_disabled`
+
+Optional event types:
+
+- `tool_called`
+- `fallback`
+- `blocked`
+
+## JSONL Shape
+
+Each line should be one compact JSON object.
+
+```json
+{"ts":"2026-06-28T10:15:23+09:00","event":"skill_activated","skill":"igapyon-agent-state-management","reason":"explicit user trigger","source":"agent-skill-trace"}
+```
+
+Suggested fields:
+
+- `ts`: ISO 8601 timestamp with offset
+- `event`: short event name
+- `skill`: Skill name when applicable
+- `path`: repository-relative path when applicable
+- `reason`: short explanation
+- `source`: `agent-skill-trace`
+
+## Privacy Rules
+
+Do not write full user messages, file contents, generated drafts, secrets, tokens, credentials, API keys, environment dumps, command output, or long reasoning traces into the JSONL file.
+
+Prefer short reason labels over raw text. For example, use `"reason":"explicit user trigger"` rather than copying the user's full sentence.
+
+When in doubt, omit the field.
+
+## Minimal Start Event
+
+When tracing is explicitly enabled, the first line should be a `skill_trace_enabled` event.
+
+```json
+{"ts":"2026-06-28T10:15:00+09:00","event":"skill_trace_enabled","skill":"igapyon-agent-state-management","path":"workplace/agent-skill-trace/2026-06-28.trace.jsonl","reason":"explicit user opt-in","source":"agent-skill-trace"}
+```
+
+## Minimal Stop Event
+
+If tracing is explicitly disabled during the same work, write a final `skill_trace_disabled` event.
+
+```json
+{"ts":"2026-06-28T10:45:00+09:00","event":"skill_trace_disabled","skill":"igapyon-agent-state-management","reason":"explicit user opt-out","source":"agent-skill-trace"}
+```


### PR DESCRIPTION
## 概要

`igapyon-agent-state-management` に、Agent Skill Trace の案内と参照仕様を追加します。

## 変更内容

- `igapyon-agent-state-management` 発火中にログ、トレース、Markdown 読み込み、`SKILL.md` 読み込みタイミングを聞かれた場合、任意の Agent Skill Trace を紹介する入口を追加
- Agent Skill Trace を自動では有効化せず、明示的な opt-in がある場合のみ有効化する方針を追加
- 日別 JSONL の出力先、イベント種別、JSONL 形式、プライバシールールを `references/agent-skill-trace.md` に追加
- 新しい参照ファイルを `index.json` に反映