### PR TITLE
miku-ms-office-skills を release archive 同梱対象に追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ release archive には、この repo の `skills/` に加えて、外部管理�
 - `miku-repo-bundle-skills` `v0.5.0.1` (experimental): `skills/igapyon-miku-repo-bundle/`
 - `miku-grep-skills` `v0.10.1.1` (experimental): `skills/igapyon-miku-grep/`
 - `miku-prompt-lint-skills` `v0.4.1`: `skills/igapyon-miku-prompt-lint/`
+- `miku-ms-office-skills` `v0.4.0.2`: `skills/igapyon-miku-ms-office/`
 - `miku-readfile-skills` `v0.5.0.2`: `skills/miku-readfile/`
 - `mikuproject-skills` `v0.8.1.1`: `skills/mikuproject/`
 - `mikuscore-skills` `v0.1.0`: `skills/mikuscore/`

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260628.2</version>
+  <version>1.20260628.3</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>
@@ -26,6 +26,9 @@
     <external.miku-prompt-lint-skills.repo>https://github.com/igapyon/miku-prompt-lint-skills.git</external.miku-prompt-lint-skills.repo>
     <external.miku-prompt-lint-skills.ref>v0.4.1</external.miku-prompt-lint-skills.ref>
     <external.miku-prompt-lint-skills.skillName>igapyon-miku-prompt-lint</external.miku-prompt-lint-skills.skillName>
+    <external.miku-ms-office-skills.repo>https://github.com/igapyon/miku-ms-office-skills.git</external.miku-ms-office-skills.repo>
+    <external.miku-ms-office-skills.ref>v0.4.0.2</external.miku-ms-office-skills.ref>
+    <external.miku-ms-office-skills.skillName>igapyon-miku-ms-office</external.miku-ms-office-skills.skillName>
     <external.miku-readfile-skills.repo>https://github.com/igapyon/miku-readfile-skills.git</external.miku-readfile-skills.repo>
     <external.miku-readfile-skills.ref>v0.5.0.2</external.miku-readfile-skills.ref>
     <external.miku-readfile-skills.skillName>miku-readfile</external.miku-readfile-skills.skillName>
@@ -102,6 +105,9 @@
                 <argument>${external.miku-prompt-lint-skills.repo}</argument>
                 <argument>${external.miku-prompt-lint-skills.ref}</argument>
                 <argument>${external.miku-prompt-lint-skills.skillName}</argument>
+                <argument>${external.miku-ms-office-skills.repo}</argument>
+                <argument>${external.miku-ms-office-skills.ref}</argument>
+                <argument>${external.miku-ms-office-skills.skillName}</argument>
                 <argument>${external.miku-readfile-skills.repo}</argument>
                 <argument>${external.miku-readfile-skills.ref}</argument>
                 <argument>${external.miku-readfile-skills.skillName}</argument>

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260628b
+Version: 20260628c
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

`miku-ms-office-skills` を外部管理 skill として release archive に同梱する設定を追加します。

## 変更内容

- `pom.xml` に `miku-ms-office-skills` `v0.4.0.2` の取得元、固定 ref、同梱先 skill 名を追加
- `prepare-package` フェーズの外部 skill 取得引数に `igapyon-miku-ms-office` を追加
- README の同梱外部 skill 一覧に `miku-ms-office-skills` を追加
- repo 全体のバージョンを `1.20260628.3`、みくく Version を `20260628c` に更新

## 確認

- `mvn package`