### PR TITLE
Update bundled miku-ms-office skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ release archive には、この repo の `skills/` に加えて、外部管理�
 - `miku-repo-bundle-skills` `v0.5.0.1` (experimental): `skills/igapyon-miku-repo-bundle/`
 - `miku-grep-skills` `v0.10.1.1` (experimental): `skills/igapyon-miku-grep/`
 - `miku-prompt-lint-skills` `v0.4.1`: `skills/igapyon-miku-prompt-lint/`
-- `miku-ms-office-skills` `v0.4.0.2`: `skills/igapyon-miku-ms-office/`
+- `miku-ms-office-skills` `v0.4.1`: `skills/igapyon-miku-ms-office/`
 - `miku-readfile-skills` `v0.5.0.2`: `skills/miku-readfile/`
 - `mikuproject-skills` `v0.8.1.1`: `skills/mikuproject/`
 - `mikuscore-skills` `v0.1.0`: `skills/mikuscore/`

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260628.4</version>
+  <version>1.20260629.1</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>
@@ -27,7 +27,7 @@
     <external.miku-prompt-lint-skills.ref>v0.4.1</external.miku-prompt-lint-skills.ref>
     <external.miku-prompt-lint-skills.skillName>igapyon-miku-prompt-lint</external.miku-prompt-lint-skills.skillName>
     <external.miku-ms-office-skills.repo>https://github.com/igapyon/miku-ms-office-skills.git</external.miku-ms-office-skills.repo>
-    <external.miku-ms-office-skills.ref>v0.4.0.2</external.miku-ms-office-skills.ref>
+    <external.miku-ms-office-skills.ref>v0.4.1</external.miku-ms-office-skills.ref>
     <external.miku-ms-office-skills.skillName>igapyon-miku-ms-office</external.miku-ms-office-skills.skillName>
     <external.miku-readfile-skills.repo>https://github.com/igapyon/miku-readfile-skills.git</external.miku-readfile-skills.repo>
     <external.miku-readfile-skills.ref>v0.5.0.2</external.miku-readfile-skills.ref>

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260628d
+Version: 20260629a
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

release archive に同梱する `miku-ms-office-skills` の参照バージョンを最新の `v0.4.1` に更新します。

## 変更内容

- `pom.xml` の repository version を `1.20260629.1` に更新
- `pom.xml` の `miku-ms-office-skills` 参照を `v0.4.0.2` から `v0.4.1` に更新
- `README.md` の release archive 同梱一覧を `miku-ms-office-skills v0.4.1` に更新
- `igapyon-mikuku-agent` の参照バージョンを `20260629a` に更新

## 検証

- `mvn clean package`