### PR TITLE
Update bundled miku-ms-office skill

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -24,10 +24,13 @@ Keep it concise. Do not use this as a full work log or a replacement for `TODO.m
 - `policy.allow_implicit_invocation: false` was removed from `igapyon-agent-state-management` and `igapyon-skill-compactor` `agents/openai.yaml` files.
 - The miku-soft Agent Skill starter skeleton was moved from `assets/agent-skills/skills/__SKILL_NAME__/SKILL.md` to `assets/agent-skills/templates/skill/SKILL.md.template`.
 - `DECISIONS.md` records the durable policy: avoid hidden discovery controls and keep skill templates outside discovery shapes.
+- 2026-06-29 release-bundled external skill refs were checked against upstream tags.
+  Only `miku-ms-office-skills` needed an update; `pom.xml` and README now pin
+  it at `v0.4.2`.
 
 ## Next Action
 
-- Resume later with the open `TODO.md` AI Agent task: update bundled skills after identifying the affected bundled skills and source of truth.
+- No open bundled-skill update task remains after the 2026-06-29 check.
 - For any later new work, read `GOAL.md`, then check `TODO.md` and update `## AI Agent Current Tasks` with the active task.
 
 ## Relevant Files
@@ -50,3 +53,6 @@ Keep it concise. Do not use this as a full work log or a replacement for `TODO.m
 - 2026-06-23: Source and installed copies were checked: no `allow_implicit_invocation` remained in the two affected skills.
 - 2026-06-23: Source and installed `igapyon-miku-soft-developer/assets/agent-skills` trees were checked: no real `SKILL.md` template remained under the starter assets.
 - 2026-06-23: Fresh Codex session skill list includes `igapyon-agent-state-management` and `igapyon-skill-compactor`, and does not include `__SKILL_NAME__`.
+- 2026-06-29: `mvn package` passed after updating the release-bundled
+  `miku-ms-office-skills` ref to `v0.4.2`; the generated zip includes
+  `skills/igapyon-miku-ms-office/runtime/miku-xlsx2md-1.2.3.mjs`.

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ release archive には、この repo の `skills/` に加えて、外部管理�
 - `miku-repo-bundle-skills` `v0.5.0.1` (experimental): `skills/igapyon-miku-repo-bundle/`
 - `miku-grep-skills` `v0.10.1.1` (experimental): `skills/igapyon-miku-grep/`
 - `miku-prompt-lint-skills` `v0.4.1`: `skills/igapyon-miku-prompt-lint/`
-- `miku-ms-office-skills` `v0.4.1`: `skills/igapyon-miku-ms-office/`
+- `miku-ms-office-skills` `v0.4.2`: `skills/igapyon-miku-ms-office/`
 - `miku-readfile-skills` `v0.5.0.2`: `skills/miku-readfile/`
 - `mikuproject-skills` `v0.8.1.1`: `skills/mikuproject/`
 - `mikuscore-skills` `v0.1.0`: `skills/mikuscore/`

--- a/TODO.md
+++ b/TODO.md
@@ -44,7 +44,7 @@ Update this section while working. Do not rewrite unrelated TODO items.
   - Installed copy updated under `/Users/igapyon/.codex/skills`.
   - Verified in fresh session: `__SKILL_NAME__` no longer appears in the
     available-skills list.
-- [ ] Update bundled skills later.
+- [x] Update bundled skills later.
   - User note on 2026-06-23: bundled skills will need to be updated later.
   - Before starting, identify which bundled skills are meant and whether the
     source of truth is this repository's `skills/` tree, installed
@@ -52,6 +52,14 @@ Update this section while working. Do not rewrite unrelated TODO items.
   - After updating, refresh any generated indexes or package artifacts required
     by the affected skills and verify the loaded available-skills list if
     discovery behavior may change.
+  - Completed on 2026-06-29 for release-bundled external skills in `pom.xml`.
+    Checked upstream tags for all 9 external skill repositories; only
+    `miku-ms-office-skills` had a newer tag than the pinned ref.
+  - Changed release pin and README list from `miku-ms-office-skills` `v0.4.1`
+    to `v0.4.2`.
+  - Verified with `mvn package`; release staging and
+    `target/igapyon-agent-skills-1.20260629.2.zip` were generated
+    successfully.
 
 ### Blockers
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260629.1</version>
+  <version>1.20260629.2</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>
@@ -27,7 +27,7 @@
     <external.miku-prompt-lint-skills.ref>v0.4.1</external.miku-prompt-lint-skills.ref>
     <external.miku-prompt-lint-skills.skillName>igapyon-miku-prompt-lint</external.miku-prompt-lint-skills.skillName>
     <external.miku-ms-office-skills.repo>https://github.com/igapyon/miku-ms-office-skills.git</external.miku-ms-office-skills.repo>
-    <external.miku-ms-office-skills.ref>v0.4.1</external.miku-ms-office-skills.ref>
+    <external.miku-ms-office-skills.ref>v0.4.2</external.miku-ms-office-skills.ref>
     <external.miku-ms-office-skills.skillName>igapyon-miku-ms-office</external.miku-ms-office-skills.skillName>
     <external.miku-readfile-skills.repo>https://github.com/igapyon/miku-readfile-skills.git</external.miku-readfile-skills.repo>
     <external.miku-readfile-skills.ref>v0.5.0.2</external.miku-readfile-skills.ref>

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260629a
+Version: 20260629b
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

release archive に同梱する外部 skill の更新チェック結果に合わせて、`miku-ms-office-skills` の固定 ref と関連する repository version を更新します。

## 変更内容

- release 同梱対象の `miku-ms-office-skills` を `v0.4.1` から `v0.4.2` に更新
- `igapyon-agent-skills` の repository version を `1.20260629.2` に更新
- `みくく` version を `20260629b` に更新
- README の外部 skill 同梱一覧を更新
- TODO と HANDOFF に同梱 skill 更新チェックの完了状況と検証結果を記録

## 検証

- `mvn clean package`