### PR TITLE
Automate PR soft reset recommit preflight and apply flow

### DIFF
--- a/skills/igapyon-github-writer/references/pr-soft-reset-recommit.md
+++ b/skills/igapyon-github-writer/references/pr-soft-reset-recommit.md
@@ -6,6 +6,8 @@ This is not `git commit --amend`. It resets `HEAD` back to a confirmed base whil
 
 This mode changes local Git history. Do not run it automatically after drafting PR text. Do not run it for generic commit summaries or ordinary PR drafting.
 
+This workflow may automate the local-only history rewrite with the bundled Node helper when the user explicitly asks for PR Soft Reset Recommit. The human review gates are expected at push, PR creation, and PR merge. The helper must not push, create PRs, merge PRs, or change remotes.
+
 ## Safety Rules
 
 - Require an explicit user request before running Git commands that rewrite the current commit state.
@@ -19,7 +21,7 @@ This mode changes local Git history. Do not run it automatically after drafting 
 - Do not run `git reset --hard`, `git checkout --`, `git push`, `gh pr create`, or any remote-changing command in this workflow.
 - `git fetch origin` is allowed only to refresh local remote-tracking information.
 - `git reset --soft <base>` rewrites `HEAD` while preserving index and working tree changes. Treat it as a history-rewrite operation and mention that clearly before running it.
-- Default base is `origin/devel` only when the user asks for that base or the repository convention clearly uses it. Otherwise ask for the base branch or remote-tracking ref.
+- Resolve the base from local Git before asking the user. Prefer the current branch upstream (`@{u}`), then local `origin/HEAD`, then local `origin/devel`. Ask for the base branch or remote-tracking ref only when local Git cannot resolve any of those.
 
 ## Inputs
 
@@ -34,7 +36,21 @@ If there is no saved PR draft file, stop this workflow and first create or save 
 
 ## PR Draft Resolution
 
-When the user asks to reuse the PR draft created by PR mode but does not provide `PR_DRAFT`, resolve the candidate lightly from the standard draft-save locations before asking:
+When the user asks to reuse the PR draft created by PR mode but does not provide `PR_DRAFT`, prefer using the bundled Node helper in default read-only mode to resolve the candidate from the standard draft-save locations:
+
+```sh
+node skills/igapyon-github-writer/references/scripts/pr-soft-reset-recommit-preflight.mjs
+```
+
+If `PR_DRAFT` is already known, pass it explicitly:
+
+```sh
+node skills/igapyon-github-writer/references/scripts/pr-soft-reset-recommit-preflight.mjs --pr-draft workplace/github-writer/pr-devel-YYYYMMDDHHMM.md
+```
+
+Without `--apply`, the helper is read-only. It may run local Git inspection commands, resolve the current-branch PR draft candidate, choose a backup branch candidate, and print the final command shape. It must not create branches, reset commits, commit changes, push, or modify files in default mode.
+
+If Node is unavailable or the helper fails, resolve the candidate manually:
 
 1. Determine the current branch with `git branch --show-current`.
 2. Sanitize it with the same `<branch-slug>` rules from `github-writing-rules.md`.
@@ -48,7 +64,38 @@ Before running `git reset --soft`, report the resolved `PR_DRAFT` path and treat
 
 ## Command Shape
 
-When the user explicitly asks to apply the saved PR draft as the commit message and both inputs are confirmed, use this shape:
+When the user explicitly asks to apply the saved PR draft as the commit message and both inputs are confirmed, first run the helper without `--apply` unless it was already run during PR draft resolution:
+
+```sh
+node skills/igapyon-github-writer/references/scripts/pr-soft-reset-recommit-preflight.mjs --pr-draft workplace/github-writer/pr-devel-YYYYMMDDHHMM.md
+```
+
+Review the preflight output before any history rewrite:
+
+- confirm `base` exists
+- confirm `base source` is appropriate
+- confirm `PR draft` is the intended saved draft
+- confirm `backup branch candidate`
+- confirm `Commits To Collapse`
+- confirm `Diff Stat`
+- confirm `git status -sb` does not show unrelated uncommitted changes
+
+After that, prefer applying the local-only rewrite with the Node helper:
+
+```sh
+node skills/igapyon-github-writer/references/scripts/pr-soft-reset-recommit-preflight.mjs --pr-draft workplace/github-writer/pr-devel-YYYYMMDDHHMM.md --apply
+```
+
+The helper will:
+
+- create the backup branch at current `HEAD`
+- run `git reset --soft <base>`
+- run `git commit -F <PR_DRAFT>`
+- report the new `HEAD` and final `git status -sb`
+
+The helper refuses `--apply` when there are existing uncommitted changes unless `--allow-dirty` is also passed. Use `--allow-dirty` only when the user has explicitly confirmed that those uncommitted changes are intentional and should participate in the recommit context.
+
+If Node is unavailable or the helper fails before changing history, use this manual shape:
 
 The example is POSIX-shell style for clarity. When running on Windows PowerShell, cmd.exe, or another shell, translate variable assignment, quoting, and path syntax to the active shell while preserving the same Git steps.
 
@@ -67,6 +114,8 @@ git status -sb
 ```
 
 Replace the example `BASE` and `PR_DRAFT` values with the confirmed values before running.
+
+The Node helper replaces the manual local rewrite only when invoked with `--apply`. It still must not push, create a PR, merge a PR, or change remotes.
 
 ## Output
 

--- a/skills/igapyon-github-writer/references/scripts/pr-soft-reset-recommit-preflight.mjs
+++ b/skills/igapyon-github-writer/references/scripts/pr-soft-reset-recommit-preflight.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const usage = `Usage:
+  node skills/igapyon-github-writer/references/scripts/pr-soft-reset-recommit-preflight.mjs [--base <base>] [--pr-draft <path>] [--repo <path>] [--apply] [--allow-dirty]
+
+By default this is a read-only helper. It resolves PR draft candidates, backup
+branch names, and Git evidence for PR Soft Reset Recommit mode.
+
+With --apply, it performs the local-only rewrite:
+  git branch <backup> HEAD
+  git reset --soft <base>
+  git commit -F <pr-draft>
+
+It never pushes, creates PRs, merges PRs, or changes remotes.`;
+
+function parseArgs(argv) {
+  const args = { repo: process.cwd(), base: "", prDraft: "" };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else if (arg === "--base") {
+      args.base = argv[++i] ?? "";
+    } else if (arg === "--pr-draft") {
+      args.prDraft = argv[++i] ?? "";
+    } else if (arg === "--repo") {
+      args.repo = argv[++i] ?? "";
+    } else if (arg === "--apply") {
+      args.apply = true;
+    } else if (arg === "--allow-dirty") {
+      args.allowDirty = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function git(repo, args, options = {}) {
+  const result = spawnSync("git", args, {
+    cwd: repo,
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  if (result.status !== 0 && !options.allowFailure) {
+    const message = (result.stderr || result.stdout || "").trim();
+    throw new Error(`git ${args.join(" ")} failed${message ? `: ${message}` : ""}`);
+  }
+  return {
+    ok: result.status === 0,
+    stdout: (result.stdout || "").trimEnd(),
+    stderr: (result.stderr || "").trimEnd(),
+  };
+}
+
+function resolveDefaultBase(root) {
+  const upstream = git(root, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], {
+    allowFailure: true,
+  });
+  if (upstream.ok && upstream.stdout) {
+    return { base: upstream.stdout, source: "current branch upstream" };
+  }
+
+  const remoteHead = git(root, ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"], {
+    allowFailure: true,
+  });
+  if (remoteHead.ok && remoteHead.stdout.startsWith("refs/remotes/")) {
+    return {
+      base: remoteHead.stdout.replace(/^refs\/remotes\//, ""),
+      source: "local origin/HEAD",
+    };
+  }
+
+  const originDevel = git(root, ["rev-parse", "--verify", "--quiet", "origin/devel"], {
+    allowFailure: true,
+  });
+  if (originDevel.ok) {
+    return { base: "origin/devel", source: "local origin/devel fallback" };
+  }
+
+  return { base: "", source: "unresolved" };
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+function slugBranch(branch) {
+  return branch.toLowerCase().replaceAll(/[^a-z0-9._-]/g, "-");
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function ymdhm(date) {
+  const pad = (n) => String(n).padStart(2, "0");
+  return [
+    date.getFullYear(),
+    "-",
+    pad(date.getMonth() + 1),
+    "-",
+    pad(date.getDate()),
+    "-",
+    pad(date.getHours()),
+    pad(date.getMinutes()),
+  ].join("");
+}
+
+function findDrafts(root, branch) {
+  const slug = slugBranch(branch);
+  if (!slug) return { slug, drafts: [] };
+
+  const dirs = ["workplace/github-writer", "temp/github-writer"];
+  const drafts = [];
+  const pattern = new RegExp(`^pr-${escapeRegExp(slug)}-(\\d{12})(?:-[a-z0-9._-]+)?\\.md$`);
+
+  for (const dir of dirs) {
+    const fullDir = path.join(root, dir);
+    if (!existsSync(fullDir)) continue;
+    for (const name of readdirSync(fullDir)) {
+      const match = name.match(pattern);
+      if (!match) continue;
+      const absolute = path.join(fullDir, name);
+      const st = statSync(absolute);
+      drafts.push({
+        rel: path.relative(root, absolute),
+        timestamp: match[1],
+        mtimeMs: st.mtimeMs,
+      });
+    }
+  }
+
+  drafts.sort((a, b) => {
+    const byTimestamp = b.timestamp.localeCompare(a.timestamp);
+    if (byTimestamp !== 0) return byTimestamp;
+    return b.mtimeMs - a.mtimeMs;
+  });
+
+  return { slug, drafts };
+}
+
+function chooseBackup(existingBranches) {
+  const base = `backup/${ymdhm(new Date())}`;
+  const existing = new Set(
+    existingBranches
+      .split("\n")
+      .map((line) => line.replace(/^\*?\s*/, "").trim())
+      .filter(Boolean),
+  );
+  if (!existing.has(base)) return base;
+  for (let i = 2; i < 100; i += 1) {
+    const candidate = `${base}-${i}`;
+    if (!existing.has(candidate)) return candidate;
+  }
+  throw new Error(`Could not find an available backup branch name for ${base}`);
+}
+
+function hasDirtyStatus(status) {
+  return status
+    .split("\n")
+    .slice(1)
+    .some((line) => line.trim() !== "");
+}
+
+function listBlock(lines) {
+  return lines.length > 0 ? lines.map((line) => `- ${line}`).join("\n") : "- なし";
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage);
+    return;
+  }
+
+  const root = git(args.repo, ["rev-parse", "--show-toplevel"]).stdout;
+  const resolvedBase = args.base
+    ? { base: args.base, source: "explicit --base" }
+    : resolveDefaultBase(root);
+  if (!resolvedBase.base) {
+    throw new Error("Could not resolve base from --base, current branch upstream, local origin/HEAD, or origin/devel.");
+  }
+  const branch = git(root, ["branch", "--show-current"], { allowFailure: true }).stdout;
+  const status = git(root, ["status", "-sb"]).stdout;
+  const head = git(root, ["log", "--oneline", "--decorate", "-1"]).stdout;
+  const baseOk = git(root, ["rev-parse", "--verify", "--quiet", resolvedBase.base], { allowFailure: true }).ok;
+  const collapsedLog = baseOk
+    ? git(root, ["log", "--oneline", "--decorate", `${resolvedBase.base}..HEAD`], { allowFailure: true }).stdout
+    : "";
+  const diffStat = baseOk
+    ? git(root, ["diff", "--stat", `${resolvedBase.base}...HEAD`], { allowFailure: true }).stdout
+    : "";
+  const existingBackups = git(root, ["branch", "--list", "backup/*"], { allowFailure: true }).stdout;
+  const backup = chooseBackup(existingBackups);
+
+  const { slug, drafts } = findDrafts(root, branch);
+  const explicitDraft = args.prDraft ? path.relative(root, path.resolve(root, args.prDraft)) : "";
+  const resolvedDraft = explicitDraft || drafts[0]?.rel || "";
+  const resolvedDraftAbs = resolvedDraft ? path.resolve(root, resolvedDraft) : "";
+  const draftExists = resolvedDraftAbs ? existsSync(resolvedDraftAbs) : false;
+  const draftStatus = explicitDraft
+    ? draftExists ? "明示指定された PR draft が存在します。" : "明示指定された PR draft が見つかりません。"
+    : resolvedDraft
+      ? "現在ブランチに一致する最新 PR draft 候補を解決しました。"
+      : "現在ブランチに一致する PR draft 候補が見つかりません。";
+  const dirty = hasDirtyStatus(status);
+
+  console.log(`# PR Soft Reset Recommit ${args.apply ? "Apply" : "Preflight"}
+
+${args.apply
+  ? "Apply mode was requested. This helper may perform a local-only history rewrite after validation. It never pushes, creates a PR, merges a PR, or changes remotes."
+  : "This helper is read-only. It did not create branches, reset commits, commit changes, push, or modify files."}
+
+## Resolved Inputs
+
+- base: \`${resolvedBase.base}\` (${baseOk ? "exists" : "not found"})
+- base source: ${resolvedBase.source}
+- current branch: \`${branch || "(detached or unknown)"}\`
+- branch slug: \`${slug || "(none)"}\`
+- PR draft: ${resolvedDraft ? `\`${resolvedDraft}\`` : "`未解決`"}
+- PR draft status: ${draftStatus}
+- backup branch candidate: \`${backup}\`
+- dirty status: ${dirty ? "`yes`" : "`no`"}
+
+## Status
+
+\`\`\`text
+${status || "(empty)"}
+\`\`\`
+
+## HEAD
+
+\`\`\`text
+${head || "(empty)"}
+\`\`\`
+
+## Commits To Collapse
+
+\`\`\`text
+${baseOk ? collapsedLog || "(none)" : "base was not found; skipped"}
+\`\`\`
+
+## Diff Stat
+
+\`\`\`text
+${baseOk ? diffStat || "(empty)" : "base was not found; skipped"}
+\`\`\`
+
+## Branch-Matching PR Draft Candidates
+
+${listBlock(drafts.slice(0, 10).map((draft) => `\`${draft.rel}\` (${draft.timestamp})`))}
+
+## Command Shape After Explicit Approval
+
+\`\`\`sh
+git branch ${shellQuote(backup)} HEAD && git reset --soft ${shellQuote(resolvedBase.base)}
+git commit -F ${resolvedDraft ? shellQuote(resolvedDraft) : "<PR_DRAFT>"}
+\`\`\`
+`);
+
+  if (!args.apply) return;
+
+  if (!baseOk) {
+    throw new Error(`Cannot apply because base was not found: ${resolvedBase.base}`);
+  }
+  if (!resolvedDraft || !draftExists) {
+    throw new Error("Cannot apply because PR draft is unresolved or missing.");
+  }
+  if (dirty && !args.allowDirty) {
+    throw new Error("Cannot apply with existing uncommitted changes. Re-run with --allow-dirty only if those changes are intentional.");
+  }
+
+  git(root, ["branch", backup, "HEAD"]);
+  git(root, ["reset", "--soft", resolvedBase.base]);
+  git(root, ["commit", "-F", resolvedDraft]);
+
+  const newHead = git(root, ["log", "--oneline", "--decorate", "-1"]).stdout;
+  const finalStatus = git(root, ["status", "-sb"]).stdout;
+
+  console.log(`## Apply Result
+
+- backup branch created: \`${backup}\`
+- committed with PR draft: \`${resolvedDraft}\`
+- new HEAD:
+
+\`\`\`text
+${newHead || "(empty)"}
+\`\`\`
+
+- final status:
+
+\`\`\`text
+${finalStatus || "(empty)"}
+\`\`\`
+`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  console.error("");
+  console.error(usage);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## 概要

`igapyon-github-writer` の PR soft reset recommit workflow で、ローカルの履歴再構成を補助する Node helper を追加し、手順ドキュメントを更新しました。

## 変更内容

- PR soft reset recommit workflow で、現在ブランチの upstream などから reset base を解決する方針を明記
- 保存済み PR draft、backup branch 候補、collapse 対象 commit、diff stat、dirty status を確認する read-only preflight helper を追加
- `--apply` 指定時に backup branch 作成、`git reset --soft`、`git commit -F` を実行する local-only helper flow を追加
- helper が push、PR 作成、merge、remote 変更を行わない前提をドキュメント化