### PR TITLE
Update bundled miku-ms-office skill

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260629.2</version>
+  <version>1.20260702.2</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>
@@ -27,7 +27,7 @@
     <external.miku-prompt-lint-skills.ref>v0.4.1</external.miku-prompt-lint-skills.ref>
     <external.miku-prompt-lint-skills.skillName>igapyon-miku-prompt-lint</external.miku-prompt-lint-skills.skillName>
     <external.miku-ms-office-skills.repo>https://github.com/igapyon/miku-ms-office-skills.git</external.miku-ms-office-skills.repo>
-    <external.miku-ms-office-skills.ref>v0.4.2</external.miku-ms-office-skills.ref>
+    <external.miku-ms-office-skills.ref>v0.6.1</external.miku-ms-office-skills.ref>
     <external.miku-ms-office-skills.skillName>igapyon-miku-ms-office</external.miku-ms-office-skills.skillName>
     <external.miku-readfile-skills.repo>https://github.com/igapyon/miku-readfile-skills.git</external.miku-readfile-skills.repo>
     <external.miku-readfile-skills.ref>v0.5.0.2</external.miku-readfile-skills.ref>

--- a/skills/igapyon-github-writer/index.json
+++ b/skills/igapyon-github-writer/index.json
@@ -8,7 +8,7 @@
   {"name":"backup-branch.md","path":"references/backup-branch.md","ext":"md","dir":"references","size":2440,"summary":"Backup Branch"},
   {"name":"branch-status.md","path":"references/branch-status.md","ext":"md","dir":"references","size":2672,"summary":"GitHub Branch Status"},
   {"name":"github-writing-rules.md","path":"references/github-writing-rules.md","ext":"md","dir":"references","size":5848,"summary":"GitHub Writing Rules"},
-  {"name":"pr-soft-reset-recommit.md","path":"references/pr-soft-reset-recommit.md","ext":"md","dir":"references","size":4768,"summary":"PR Soft Reset Recommit"},
+  {"name":"pr-soft-reset-recommit.md","path":"references/pr-soft-reset-recommit.md","ext":"md","dir":"references","size":7378,"summary":"PR Soft Reset Recommit"},
   {"name":"pr-writing.md","path":"references/pr-writing.md","ext":"md","dir":"references","size":3124,"summary":"GitHub PR Writing"},
   {"name":"release-writing.md","path":"references/release-writing.md","ext":"md","dir":"references","size":3555,"summary":"GitHub Release Writing"}
  ]

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260629b
+Version: 20260702b
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

zip 同梱対象の外部 skill 参照を確認し、`miku-ms-office-skills` の同梱 ref を最新リリースに更新しました。

## 変更内容

- repo バージョンを `1.20260702.2` に更新
- `miku-ms-office-skills` の外部同梱 ref を `v0.4.2` から `v0.6.1` に更新
- `みくく` バージョンを `20260702b` に更新
- `mvn clean package` による `igapyon-github-writer/index.json` の生成結果を反映

## 確認

- `mvn clean package`
- `target/igapyon-agent-skills-1.20260702.2.zip` の生成