### PR TITLE
みくく-agent に Markdown 画像化の Playwright 優先ルールを追加

### DIFF
--- a/skills/igapyon-mikuku-agent/SKILL.md
+++ b/skills/igapyon-mikuku-agent/SKILL.md
@@ -73,6 +73,13 @@ When applying generated images from `workplace/<RUN_ID>-graphic-recording/` to
 a published `mikuku-articles` article directory, read
 [references/graphic-recording/publish-generated-images-to-article.md](references/graphic-recording/publish-generated-images-to-article.md). Treat the generation workspace and published article directory as separate outputs.
 
+## Markdown To Image
+
+When the user needs Markdown content, especially a Markdown table, converted to
+a PNG image, prefer rendering the Markdown to HTML and capturing it with
+Playwright as the first-choice approach. Use another method only when
+Playwright is unavailable or the user explicitly asks for a different route.
+
 ## Codex Local Token Usage
 
 When this skill is active and the user asks about Codex token consumption,


### PR DESCRIPTION
## 概要

`igapyon-mikuku-agent` で Markdown 内容を PNG 画像へ変換するニーズに対し、Playwright を第一候補として扱うルールを追加します。

## 変更内容

- `skills/igapyon-mikuku-agent/SKILL.md` に `Markdown To Image` 節を追加
- Markdown 表などの Markdown content を PNG 化する場合、Markdown を HTML としてレンダリングし、Playwright でキャプチャする方法を第一候補に指定
- Playwright が利用できない場合や、ユーザーが別手段を明示した場合のみ他の方法を使う方針を明記