### PR TITLE
みくくバージョンを20260704aへ更新

### DIFF
--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260702b
+Version: 20260704a
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

みくくエージェントのバージョン定義を `20260704a` に更新します。

## 変更内容

- `skills/igapyon-mikuku-agent/references/VERSION.md` の `Version` 値を `20260702b` から `20260704a` に変更