### PR TITLE
みくくバージョンとリポジトリ作業ガイダンスを更新

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260702.2</version>
+  <version>1.20260704.1</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>

--- a/skills/igapyon-mikuku-agent/SKILL.md
+++ b/skills/igapyon-mikuku-agent/SKILL.md
@@ -21,10 +21,30 @@ First read and apply [references/mikuku-prompt.md](references/mikuku-prompt.md).
 If the user asks to activate `みくく`, answer briefly in the configured style and
 continue using it in the conversation. Do not overperform the character.
 
+Immediately after this skill is selected for a turn, if the task is being done
+inside a local repository or project workspace and a root `README.md` is
+available, read that `README.md` before deciding task scope. Treat it as the
+project's local operating guidance where it does not conflict with higher
+priority instructions.
+
 - For normal collaboration, answer in a polite, reserved Japanese tone with light `みくく` markers.
 - For coding or repository work, prioritize correctness, file references, verification results, and concise status updates.
 - For refusals, use the configured phrase once, then provide a short safe alternative when useful.
 - Avoid making claims about private future knowledge, real-world hidden facts, or unverifiable identity.
+
+## Repository Work
+
+When this skill is active and the user asks `みくく` to do repository
+maintenance, version updates, release preparation, bundled-skill updates, or
+other work governed by the current repository's operating rules, apply the
+`README.md` at the root of the currently open repository or project as the
+local operating guidance.
+
+For version or release-related work, apply the `バージョン更新` section of the
+current repository root `README.md` as the repository rule. In particular,
+check the root `pom.xml`, `skills/igapyon-mikuku-agent/references/VERSION.md`,
+and the expected release archive name when a repository version update is in
+scope.
 
 ## Version
 
@@ -116,6 +136,7 @@ representative image choice or asset semantics.
 - [references/graphic-recording.md](references/graphic-recording.md): graphic recording workflow entry for `みくく` article explainers.
 - [references/graphic-recording/publish-generated-images-to-article.md](references/graphic-recording/publish-generated-images-to-article.md): procedure for applying generated graphic recording images to published `mikuku-articles` article directories.
 - [references/codex-local-token-usage.md](references/codex-local-token-usage.md): OpenAI Codex CLI-only local token usage investigation prompt and caveats.
+- Current repository or project root `README.md`: local operating rules to read immediately after this skill is selected, and to apply before repository maintenance, version updates, and release preparation.
 
 ## Resource Organization
 

--- a/skills/igapyon-mikuku-agent/index.json
+++ b/skills/igapyon-mikuku-agent/index.json
@@ -4,7 +4,7 @@
  "basePath": ".",
  "files": [
   {"name":"README.md","path":"README.md","ext":"md","dir":"","size":7548,"summary":"igapyon-mikuku-agent"},
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":6863,"description":"Use only when the user explicitly asks Codex to speak or collaborate as the Japanese character agent \"みくく\", mentions みくく, Mikuku, igapyon-mikuku, or explicitly asks to apply the みくく prompt. If the user only asks whether such a character skill exists, me...","summary":"igapyon-mikuku-agent"},
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":8393,"description":"Use only when the user explicitly asks Codex to speak or collaborate as the Japanese character agent \"みくく\", mentions みくく, Mikuku, igapyon-mikuku, or explicitly asks to apply the みくく prompt. If the user only asks whether such a character skill exists, me...","summary":"igapyon-mikuku-agent"},
   {"name":"agent-skills-magic-book-prompt.md","path":"assets/article/agent-skills-magic-book-prompt.md","ext":"md","dir":"assets/article","size":1593,"summary":"Agent Skills Magic Book Prompt"},
   {"name":"mikuku-portrait-short-prompt.md","path":"assets/mikuku/mikuku-portrait-short-prompt.md","ext":"md","dir":"assets/mikuku","size":628,"summary":"Mikuku Portrait Short Prompt"},
   {"name":"20260509-general-agent-skills-activation.md","path":"examples/articles/20260509-general-agent-skills-activation.md","ext":"md","dir":"examples/articles","size":14789,"summary":"Agent Skills の発火は、どのように起きているのか"},

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260702b
+Version: 20260704a
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

みくくのバージョンを `20260704a` に更新し、リポジトリ全体の Maven バージョンと整合させました。

あわせて、`igapyon-mikuku-agent` が選択された直後に、現在開いているリポジトリまたはプロジェクトのルート `README.md` を読み、ローカル運用ガイダンスとして扱うルールを追加しました。

## 変更内容

- `pom.xml` の project version を `1.20260704.1` に更新
- `skills/igapyon-mikuku-agent/references/VERSION.md` のみくく version を `20260704a` に更新
- `skills/igapyon-mikuku-agent/SKILL.md` に、skill 選択直後の root `README.md` 読み込みルールを追加
- version / release 関連作業では、current repository root `README.md` の `バージョン更新` セクションを適用するよう明記
- `skills/igapyon-mikuku-agent/index.json` を再生成

## 確認

- `mvn generate-resources`