### PR TITLE
Note Markdown表画像化ワークフローを追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260705.1</version>
+  <version>1.20260706.1</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260705a
+Version: 20260706a
 
 ## Version Rule
 

--- a/skills/igapyon-note-writer/SKILL.md
+++ b/skills/igapyon-note-writer/SKILL.md
@@ -23,6 +23,7 @@ Note 媒体に掲載する、みくく担当の技術エッセイを管理・整
 - 既存 Note 正本の流れ、段落、掲載情報の確認
 - Qiita など別媒体向け原稿から、共通する事実差分だけを Note 正本へ移すこと
 - Note 公開時のグラレコ画像生成工程への案内
+- Note の表示制約に合わせた Markdown 表の画像化工程への案内
 
 本文の主担当は、基本的にみくくです。`igapyon-note-writer` は、みくく文体そのものを詳細に定義し直すのではなく、Note 媒体に載せるための管理・整形・公開補助を担当します。
 
@@ -38,6 +39,8 @@ Note 媒体に掲載する、みくく担当の技術エッセイを管理・整
 - 「Note 公開前に掲載情報を確認して」
 - 「みくく担当記事を Note に出す形にして」
 - 「Qiita ではなく Note 側の正本へ反映して」
+- 「Note 用に Markdown の表を画像化して」
+- 「Note で表が表示できないので画像にして」
 
 次の依頼では、この skill を無理に使いません。
 
@@ -178,6 +181,12 @@ Note へ記事をアップロードする際は、本文 Markdown とは別の�
 
 `igapyon-note-writer` 側では、Note 公開時に `##` 見出しごとのグラレコ画像を用意する前提だけを持ち、グラレコ生成の詳細手順は重複して定義しません。
 
+## Note Markdown Table Images
+
+Note のシステム都合で Markdown の表を PNG 画像に変換する必要がある場合は、[references/note-markdown-table-images.md](references/note-markdown-table-images.md) を読んで適用します。
+
+この工程は Note 公開用の後工程です。正本 Markdown を書き換えず、生成 PNG は Git 管理外の作業領域に置きます。
+
 ## Output Patterns
 
 ### Full Article Draft
@@ -220,6 +229,9 @@ Note へ記事をアップロードする際は、本文 Markdown とは別の�
 - 参照記事の本文を長く流用しない
 - 誇張した成果や宣伝文にしない
 - Note 公開用のグラレコ画像リンクを、明示的な依頼なしに正本 Markdown へ直接書き込まない
+- Note 公開用の Markdown 表画像リンクを、明示的な依頼なしに正本 Markdown へ直接書き込まない
+- Note の表示制約に合わせた表画像化のために、正本 Markdown の表を削除または置換しない
+- Markdown 表から生成した PNG を、明示的な依頼なしに Git 管理対象の本文ディレクトリへ置かない
 - グラレコ画像生成の詳細手順を `igapyon-note-writer` 側へ重複して持たない
 - Note 公開時の標準工程から、`##` 見出しごとのグラレコ画像生成を勝手に省略しない
 

--- a/skills/igapyon-note-writer/index.json
+++ b/skills/igapyon-note-writer/index.json
@@ -3,7 +3,8 @@
  "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
  "basePath": ".",
  "files": [
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":13602,"description":"Use only when the user explicitly asks for igapyon-note-writer, asks for Note publishing metadata or Note canonical article management, or asks to prepare a Mikuku-authored Japanese technical essay for Note. Do not use for generic proofreading, ordinary...","summary":"igapyon-note-writer"},
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":14573,"description":"Use only when the user explicitly asks for igapyon-note-writer, asks for Note publishing metadata or Note canonical article management, or asks to prepare a Mikuku-authored Japanese technical essay for Note. Do not use for generic proofreading, ordinary...","summary":"igapyon-note-writer"},
+  {"name":"note-markdown-table-images.md","path":"references/note-markdown-table-images.md","ext":"md","dir":"references","size":1717,"summary":"Note Markdown Table Images"},
   {"name":"general-note-article-template.md","path":"templates/general-note-article-template.md","ext":"md","dir":"templates","size":2255,"title":"記事タイトル","summary":"はじめに"}
  ]
 }

--- a/skills/igapyon-note-writer/references/note-markdown-table-images.md
+++ b/skills/igapyon-note-writer/references/note-markdown-table-images.md
@@ -1,0 +1,28 @@
+# Note Markdown Table Images
+
+Note のシステム都合で Markdown の表が期待通り表示できない場合は、Note 公開用の後工程として、Markdown 表を PNG 画像に変換して扱います。
+
+この工程は、記事本文の執筆、正本 Markdown の管理、グラレコ画像生成とは分けて扱います。Markdown 表は正本記事の一部として残し、Note へ投入するための画像は一時的な公開補助成果物として扱います。
+
+## Principles
+
+- 正本 Markdown を書き換えない
+- Markdown 表を画像リンクへ自動置換しない
+- 生成 PNG は Git 管理下へ入れない
+- 出力先は `../mikuku-articles/workplace/` 配下など、Git 管理外の作業領域にする
+- 画像は Note への手動アップロード用成果物として扱う
+- 明示的な依頼なしに、生成画像へのリンクを正本 Markdown へ追記しない
+
+## Existing Helper Script
+
+既存の補助スクリプトとして、姉妹リポジトリ側に `../mikuku-articles/workplace/render-markdown-tables.mjs` がある場合があります。
+
+使用する場合は、Playwright で Markdown 表を HTML 表として描画し、PNG を生成する用途に限ります。
+
+## Source Markdown Safety
+
+このスクリプトや同等の処理を使うときは、元記事を書き換えるオプションを使わないでください。
+
+過去に `--replace` のような置換オプションが存在していても、Note 正本運用では使いません。
+
+実行が必要な場合は、ユーザーが明示的に依頼したときだけ実行し、実行前に対象 Markdown と出力先が Git 管理外であることを確認します。


### PR DESCRIPTION
## 概要

Note の表示制約に合わせて、Markdown 表を PNG 画像へ変換する公開補助工程を `igapyon-note-writer` に追加しました。

## 変更内容

- `igapyon-note-writer` の対象作業と利用例に、Note 用 Markdown 表画像化を追加
- Note 公開用の Markdown 表画像化ルールを `references/note-markdown-table-images.md` として分離
- 正本 Markdown を書き換えず、生成 PNG を Git 管理外の作業領域へ置く方針を明記
- Markdown 表画像リンクの自動追記、表の削除・置換、生成 PNG の Git 管理対象化を避ける禁止事項を追加
- `igapyon-note-writer/index.json` に新しい reference を反映
- リポジトリバージョンを `1.20260706.1`、みくくバージョンを `20260706a` に更新

## 確認

- `mvn generate-resources`
- `mvn clean package`