### PR TITLE
miku-soft SCMのコミット前確認と安全なbranch運用を整備

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260716.2</version>
+  <version>1.20260718.1</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>

--- a/skills/igapyon-miku-scm/SKILL.md
+++ b/skills/igapyon-miku-scm/SKILL.md
@@ -27,9 +27,10 @@ Do not perform remote mutations, history rewrites, tag changes, release publicat
 3. Read [references/scm-rules.md](references/scm-rules.md).
 4. For local Git status inspection, read [references/local-git-readonly.md](references/local-git-readonly.md).
 5. For public GitHub source, branch, Issue, or Release inspection, read [references/github-anonymous-readonly.md](references/github-anonymous-readonly.md).
-6. Preserve unrelated user changes.
-7. Separate local preparation from remote GitHub operations.
-8. Report what was inspected, changed, and left pending.
+6. Before any requested `git add` or `git commit`, read and follow [references/version-increment-confirmation.md](references/version-increment-confirmation.md).
+7. Preserve unrelated user changes.
+8. Separate local preparation from remote GitHub operations.
+9. Report what was inspected, changed, and left pending.
 
 ## Boundaries
 

--- a/skills/igapyon-miku-scm/index.json
+++ b/skills/igapyon-miku-scm/index.json
@@ -3,9 +3,10 @@
  "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
  "basePath": ".",
  "files": [
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":2266,"description":"Use only when the user explicitly names `igapyon-miku-scm`, explicitly asks to apply the miku SCM workflow, or explicitly asks to perform Git, GitHub, GitHub Release, or version-management work under miku-soft SCM rules. Do not activate for generic Git ...","summary":"igapyon-miku-scm"},
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":2427,"description":"Use only when the user explicitly names `igapyon-miku-scm`, explicitly asks to apply the miku SCM workflow, or explicitly asks to perform Git, GitHub, GitHub Release, or version-management work under miku-soft SCM rules. Do not activate for generic Git ...","summary":"igapyon-miku-scm"},
   {"name":"github-anonymous-readonly.md","path":"references/github-anonymous-readonly.md","ext":"md","dir":"references","size":1925,"summary":"GitHub Anonymous READONLY"},
   {"name":"local-git-readonly.md","path":"references/local-git-readonly.md","ext":"md","dir":"references","size":2154,"summary":"Local Git READONLY"},
-  {"name":"scm-rules.md","path":"references/scm-rules.md","ext":"md","dir":"references","size":3414,"summary":"SCM Rules"}
+  {"name":"scm-rules.md","path":"references/scm-rules.md","ext":"md","dir":"references","size":7736,"summary":"SCM Rules"},
+  {"name":"version-increment-confirmation.md","path":"references/version-increment-confirmation.md","ext":"md","dir":"references","size":1283,"summary":"Version Increment Confirmation Before Add or Commit"}
  ]
 }

--- a/skills/igapyon-miku-scm/references/scm-rules.md
+++ b/skills/igapyon-miku-scm/references/scm-rules.md
@@ -14,6 +14,15 @@ This is the initial rule entry point for `igapyon-miku-scm`. Add detailed rules 
 
 - Treat `pr soft reset recommit` and `pr reset recommit` as explicit requests to run the `igapyon-github-writer` PR Soft Reset Recommit workflow.
 - Delegate PR draft composition, backup-branch creation, soft reset, and recommit behavior to `igapyon-github-writer`; do not duplicate that implementation in this skill.
+- Before delegating, require a clean working tree and run `git fetch origin` so the reset base is not resolved from stale remote-tracking information.
+- Resolve the reset base, then require it to be an ancestor of the current `HEAD`:
+
+```sh
+git merge-base --is-ancestor <base> HEAD
+```
+
+- If the ancestry check fails, stop. Do not soft-reset onto the advanced base because preserving the old index can accidentally record removal of changes that exist only on the new base. Recover by starting from the refreshed base and carrying forward only the new work, or use a separately approved rebase workflow.
+- Do not run this workflow from a branch ending in `-done`. Treat that branch as frozen and move legitimate follow-up work to a new branch from the refreshed base.
 - After the delegated workflow succeeds, immediately run:
 
 ```sh
@@ -35,22 +44,85 @@ Proceed only when all of these conditions hold:
 - the human explicitly says the displayed commit is OK and authorizes publication
 - the target `<current-branch>-done` local branch does not already exist
 
-After explicit approval, run these commands in order and stop immediately if any command fails:
+After explicit approval, run `git fetch origin`, resolve `<current-branch>`, and determine whether `origin/<current-branch>` already exists.
+
+- For a new remote branch, use normal initial publication and establish its upstream:
+
+```sh
+git push -u origin HEAD
+```
+
+- Only when the same remote branch already exists and the reviewed recommit intentionally rewrote its history, use:
 
 ```sh
 git push --force-with-lease origin HEAD
-git pull
-git branch -m "$(git branch --show-current)" "$(git branch --show-current)-done"
+```
+
+Treat `git push --force-with-lease origin HEAD` as an authorized remote history update only for this reviewed rewrite case. Do not replace it with plain `--force`, and do not use force for a new remote branch.
+
+After a successful push, do not run `git pull`. Fetch and compare the pushed remote feature branch with local `HEAD` instead:
+
+```sh
+git fetch origin
+git rev-list --left-right --count HEAD...origin/<current-branch>
+```
+
+Require the comparison result to be `0 0`. Only after it matches, run:
+
+```sh
+git branch -m "<current-branch>" "<current-branch>-done"
 git status -sb
 ```
 
-Treat `git push --force-with-lease origin HEAD` as an authorized remote history update only for this post-review workflow. Do not replace it with plain `--force`.
+Run the selected push, remote verification, rename, and status steps in order and stop immediately if any step fails. Do not treat earlier approval to run PR Soft Reset Recommit as approval to publish. Require the human's OK after displaying the new commit log. If push or remote verification fails, do not rename the branch. Do not create a Pull Request in this sequence.
 
-Do not treat earlier approval to run PR Soft Reset Recommit as approval to publish. Require the human's OK after displaying the new commit log. If push is rejected by the lease check, stop without pulling or renaming the branch and report the rejection. Do not create a Pull Request in this sequence.
+## Next Work Branch After PR Completion
+
+Run this workflow only after the Pull Request has been created and merged, and then the human explicitly instructs the agent to create the next work branch. Do not infer merge completion from local Git state, push output, or branch naming. Do not create the next work branch immediately after push or local `-done` rename while the PR is still open or its merge is unconfirmed.
+
+Interpret a local branch name ending in `-done` only as an operational marker that the post-recommit publication sequence probably reached the rename performed after push. It does not prove that a Pull Request was created or merged. Never use `-done` alone to decide that PR work is complete; require the human's explicit statement that the PR was merged before running this workflow.
+
+Treat a `-done` branch as frozen: do not add new work, stage changes, create commits, or run PR Soft Reset Recommit on it. If the prior PR was merged and the human requests continued work, refresh the base and create the next work branch first. If the prior PR was not merged but a correction is required, stop and require an explicitly designed recovery path instead of silently continuing on `-done`.
+
+Build the new branch name as:
+
+```text
+<base>-tiga<MMDD><hour-code><minute-tens-code><minute-ones-code>
+```
+
+Use these naming rules:
+
+- `<base>` is the base branch name, such as `devel`.
+- `tiga` identifies the user.
+- `<MMDD>` is the local month and day, such as `0718` for July 18.
+- Encode hour `0` through `23` with one zero-origin alphabet character: `a=0`, `b=1`, through `x=23`.
+- Encode the two decimal minute digits separately with zero-origin alphabet characters: `a=0`, `b=1`, through `j=9`.
+- Therefore minute `00` is `aa`, minute `45` is `ef`, and minute `59` is `fj`.
+
+For example, `devel-tiga0718tef` means base `devel`, user `tiga`, July 18, 19:45.
+
+After resolving a unique branch name from the current local date and time, run:
+
+```sh
+git fetch origin
+git switch -c devel-tiga0718tef origin/devel
+git status -sb
+```
+
+Replace the example branch and base with the resolved values. Stop if fetch fails or if the resolved local branch already exists. Report the final branch and status.
+
+For follow-up work accidentally committed after the previous PR content, prefer this recovery shape after human authorization:
+
+1. Preserve the current `HEAD` with a local backup branch.
+2. Run `git fetch origin` and create a new work branch from the refreshed base.
+3. Carry forward only commits or patches that contain work not already merged into the base.
+4. Verify the resulting diff against the base before publication.
+5. Publish the new remote branch with `git push -u origin HEAD`; do not force-push it.
 
 ## Initial Safety Rules
 
 - Inspect before changing.
+- Before `git add` or `git commit`, apply the mandatory human confirmation gate in [version-increment-confirmation.md](version-increment-confirmation.md).
 - Resolve the exact repository, branch, remote, commit, tag, release, and version target needed for the request.
 - Preserve unrelated working-tree changes.
 - Treat local Git work and remote GitHub work as separate operations.

--- a/skills/igapyon-miku-scm/references/version-increment-confirmation.md
+++ b/skills/igapyon-miku-scm/references/version-increment-confirmation.md
@@ -1,0 +1,20 @@
+# Version Increment Confirmation Before Add or Commit
+
+Treat version-increment confirmation as a mandatory human gate before running `git add` or `git commit` under the miku SCM workflow.
+
+## Confirmation Gate
+
+1. Inspect the intended staging or commit scope and preserve unrelated changes.
+2. Before the first `git add` or `git commit` in that batch, ask the human explicitly:
+
+```text
+バージョンのインクリメント忘れはありませんか？
+```
+
+3. Wait for the human's answer. Do not run `git add` or `git commit` while the answer is pending.
+4. Proceed only after the human confirms that no required increment was forgotten, or after any required version change has been handled and the human confirms it.
+5. If the human says an increment is needed, stop the add/commit sequence. Do not change a version automatically unless a separately documented workflow and explicit instruction authorize it.
+
+An explicit version confirmation already given for the same unchanged batch satisfies this gate. Ask again if the intended diff changes after confirmation or a new add/commit batch begins.
+
+This gate governs whether staging and committing may proceed. Continue to use `igapyon-github-writer` for commit-message composition when its workflow is explicitly requested.

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260716b
+Version: 20260718a
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

`igapyon-miku-scm` に、コミット前のバージョン確認、PR完了後の次branch作成、PR Soft Reset Recommitとpush前後の安全確認を追加します。マージ済み内容を重複させず、最新baseから未マージ分だけを引き継ぐ復旧方針も定義します。

## 変更内容

- `git add`または`git commit`の前に、バージョンインクリメント忘れを人間へ問う確認ゲートを追加
- `-done`をpush後のローカル目印として扱い、PR作成・マージの完了判定には使用しない規則を追加
- `-done` branchを凍結し、新規作業、stage、commit、PR Soft Reset Recommitを禁止
- PRマージ後、人間の明示指示により日時コード付きの次作業branchを最新baseから作る手順を追加
- soft reset前にoriginをfetchし、baseがHEADの祖先であることを確認する安全ゲートを追加
- 新規remote branchでは通常push、既存branchの意図的な履歴書換時のみ`--force-with-lease`を使用
- push後の`git pull`を廃止し、fetch後にlocal HEADとremote feature branchの一致を検証
- マージ済み内容を除き、未マージのcommitまたはpatchだけを新branchへ移す復旧方針を追加
- プロジェクトバージョンを`1.20260718.1`、みくくバージョンを`20260718a`へ更新
- `igapyon-miku-scm`の`index.json`を再生成

## 検証

- `mvn generate-resources`
- `skill-creator`の`quick_validate.py`による`igapyon-miku-scm`検証
- `git diff --check`
- `git merge-base --is-ancestor origin/devel HEAD`