### PR TITLE
miku-m365 Agent Builder skillを外部同梱に追加して依存版を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,11 +356,12 @@ release staging に全 skill をそろえた後、同梱した index generator �
 同梱する外部 skill は次の通りです。
 
 - `miku-indexgen-skills` `v1.6.2`: `skills/igapyon-miku-indexgen/`
-- `miku-text-bundle-skills` `v1.5.1`: `skills/igapyon-miku-text-bundle/`
+- `miku-text-bundle-skills` `v1.6.0`: `skills/igapyon-miku-text-bundle/`
 - `miku-repo-bundle-skills` `v0.5.0.1` (experimental): `skills/igapyon-miku-repo-bundle/`
 - `miku-grep-skills` `v0.10.1.1` (experimental): `skills/igapyon-miku-grep/`
 - `miku-prompt-lint-skills` `v0.5.0`: `skills/igapyon-miku-prompt-lint/`
-- `miku-ms-office-skills` `v0.6.1`: `skills/igapyon-miku-ms-office/`
+- `miku-m365-agent-builder-skills` `v0.4.3`: `skills/igapyon-miku-m365-agent-builder/`
+- `miku-ms-office-skills` `v0.6.2`: `skills/igapyon-miku-ms-office/`
 - `miku-readfile-skills` `v0.5.0.2`: `skills/miku-readfile/`
 - `mikuproject-skills` `v0.8.1.1`: `skills/mikuproject/`
 - `mikuscore-skills` `v0.1.0`: `skills/mikuscore/`

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260718.1</version>
+  <version>1.20260718.3</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>
@@ -15,7 +15,7 @@
     <external.miku-indexgen-skills.ref>v1.6.2</external.miku-indexgen-skills.ref>
     <external.miku-indexgen-skills.skillName>igapyon-miku-indexgen</external.miku-indexgen-skills.skillName>
     <external.miku-text-bundle-skills.repo>https://github.com/igapyon/miku-text-bundle-skills.git</external.miku-text-bundle-skills.repo>
-    <external.miku-text-bundle-skills.ref>v1.5.1</external.miku-text-bundle-skills.ref>
+    <external.miku-text-bundle-skills.ref>v1.6.0</external.miku-text-bundle-skills.ref>
     <external.miku-text-bundle-skills.skillName>igapyon-miku-text-bundle</external.miku-text-bundle-skills.skillName>
     <external.miku-repo-bundle-skills.repo>https://github.com/igapyon/miku-repo-bundle-skills.git</external.miku-repo-bundle-skills.repo>
     <external.miku-repo-bundle-skills.ref>v0.5.0.1</external.miku-repo-bundle-skills.ref>
@@ -26,8 +26,11 @@
     <external.miku-prompt-lint-skills.repo>https://github.com/igapyon/miku-prompt-lint-skills.git</external.miku-prompt-lint-skills.repo>
     <external.miku-prompt-lint-skills.ref>v0.5.0</external.miku-prompt-lint-skills.ref>
     <external.miku-prompt-lint-skills.skillName>igapyon-miku-prompt-lint</external.miku-prompt-lint-skills.skillName>
+    <external.miku-m365-agent-builder-skills.repo>https://github.com/igapyon/miku-m365-agent-builder-skills.git</external.miku-m365-agent-builder-skills.repo>
+    <external.miku-m365-agent-builder-skills.ref>v0.4.3</external.miku-m365-agent-builder-skills.ref>
+    <external.miku-m365-agent-builder-skills.skillName>igapyon-miku-m365-agent-builder</external.miku-m365-agent-builder-skills.skillName>
     <external.miku-ms-office-skills.repo>https://github.com/igapyon/miku-ms-office-skills.git</external.miku-ms-office-skills.repo>
-    <external.miku-ms-office-skills.ref>v0.6.1</external.miku-ms-office-skills.ref>
+    <external.miku-ms-office-skills.ref>v0.6.2</external.miku-ms-office-skills.ref>
     <external.miku-ms-office-skills.skillName>igapyon-miku-ms-office</external.miku-ms-office-skills.skillName>
     <external.miku-readfile-skills.repo>https://github.com/igapyon/miku-readfile-skills.git</external.miku-readfile-skills.repo>
     <external.miku-readfile-skills.ref>v0.5.0.2</external.miku-readfile-skills.ref>
@@ -105,6 +108,9 @@
                 <argument>${external.miku-prompt-lint-skills.repo}</argument>
                 <argument>${external.miku-prompt-lint-skills.ref}</argument>
                 <argument>${external.miku-prompt-lint-skills.skillName}</argument>
+                <argument>${external.miku-m365-agent-builder-skills.repo}</argument>
+                <argument>${external.miku-m365-agent-builder-skills.ref}</argument>
+                <argument>${external.miku-m365-agent-builder-skills.skillName}</argument>
                 <argument>${external.miku-ms-office-skills.repo}</argument>
                 <argument>${external.miku-ms-office-skills.ref}</argument>
                 <argument>${external.miku-ms-office-skills.skillName}</argument>

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260718a
+Version: 20260718c
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

release archiveへ同梱する外部skillに`miku-m365-agent-builder-skills`を追加し、既存の外部skillを最新の公開tagへ更新します。あわせてリポジトリとみくくのバージョンを更新します。

## 変更内容

- `miku-m365-agent-builder-skills` `v0.4.3`の`igapyon-miku-m365-agent-builder`を外部同梱対象へ追加
- `miku-text-bundle-skills`を`v1.5.1`から`v1.6.0`へ更新
- `miku-ms-office-skills`を`v0.6.1`から`v0.6.2`へ更新
- 外部同梱skill一覧をREADMEへ反映
- リポジトリバージョンを`1.20260718.3`、みくくバージョンを`20260718c`へ更新

## 検証

- `mvn clean package`
- 外部skill 10件を記録した`EXTERNAL_SKILLS.lock`の生成を確認
- `target/igapyon-agent-skills-1.20260718.3.zip`の生成を確認