### PR TITLE
miku-soft SCMのGitHub参照とバージョン運用を拡充

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260718.3</version>
+  <version>1.20260719.1</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>

--- a/skills/igapyon-miku-scm/SKILL.md
+++ b/skills/igapyon-miku-scm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: igapyon-miku-scm
-description: Use only when the user explicitly names `igapyon-miku-scm`, explicitly asks to apply the miku SCM workflow, or explicitly asks to perform Git, GitHub, GitHub Release, or version-management work under miku-soft SCM rules. Do not activate for generic Git or GitHub questions, ordinary repository inspection, or release-note writing.
+description: Use only when the user explicitly names `igapyon-miku-scm`, explicitly asks to apply the miku SCM workflow, or explicitly asks to perform Git, GitHub, GitHub Release, or version-management work under miku-soft SCM rules. Supports date-based and Semantic Version increments, public GitHub Issue rewrite handoffs, and READONLY audits that compare committed package or Maven versions with tags, Releases, and required distribution assets. Do not activate for generic Git or GitHub questions, ordinary repository inspection, or release-note writing.
 ---
 
 # igapyon-miku-scm
@@ -11,12 +11,15 @@ Keep this skill small and add concrete workflows incrementally. Put detailed Git
 
 ## Current Scope
 
-Support policy guidance and read-only inspection for:
+Support documented workflows and read-only inspection for:
 
 - Git operations
 - GitHub operations
+- local repository GitHub URL resolution
+- public GitHub Issue rewrite handoff for human updates
 - GitHub Releases
-- version management
+- version, tag, Release, and distribution-asset consistency audits
+- date-based and semantic version increment workflows
 
 Do not perform remote mutations, history rewrites, tag changes, release publication, or version changes until the relevant workflow is explicitly documented under `references/` and the user explicitly requests the operation.
 
@@ -26,15 +29,19 @@ Do not perform remote mutations, history rewrites, tag changes, release publicat
 2. Inspect repository state before proposing or performing work.
 3. Read [references/scm-rules.md](references/scm-rules.md).
 4. For local Git status inspection, read [references/local-git-readonly.md](references/local-git-readonly.md).
-5. For public GitHub source, branch, Issue, or Release inspection, read [references/github-anonymous-readonly.md](references/github-anonymous-readonly.md).
-6. Before any requested `git add` or `git commit`, read and follow [references/version-increment-confirmation.md](references/version-increment-confirmation.md).
-7. Preserve unrelated user changes.
-8. Separate local preparation from remote GitHub operations.
-9. Report what was inspected, changed, and left pending.
+5. For a local repository GitHub URL query, read [references/github-repository-url.md](references/github-repository-url.md).
+6. For a public GitHub Issue rewrite that a human will paste into GitHub, read [references/github-anonymous-readonly.md](references/github-anonymous-readonly.md) and [references/github-issue-rewrite-handoff.md](references/github-issue-rewrite-handoff.md).
+7. For a version, tag, Release, and distribution-asset consistency audit, read [references/github-anonymous-readonly.md](references/github-anonymous-readonly.md) and [references/version-tag-release-audit.md](references/version-tag-release-audit.md).
+8. For a requested version increment, read [references/version-increment.md](references/version-increment.md).
+9. For other public GitHub source, branch, Issue, or Release inspection, read [references/github-anonymous-readonly.md](references/github-anonymous-readonly.md).
+10. Before any requested `git add` or `git commit`, read and follow [references/version-increment-confirmation.md](references/version-increment-confirmation.md).
+11. Preserve unrelated user changes.
+12. Separate local preparation from remote GitHub operations.
+13. Report what was inspected, changed, and left pending.
 
 ## Boundaries
 
-- Treat commit-message composition and other SCM-facing writing, including GitHub PR, Release, and About text, as the responsibility of `igapyon-github-writer`. Do not duplicate writing rules in this skill. Use that skill only when it is explicitly requested and within its supported workflow contract.
+- Handle only the documented public GitHub Issue rewrite handoff in this skill. Treat commit-message composition and other SCM-facing writing, including GitHub PR, Release, and About text, as the responsibility of `igapyon-github-writer`. Use that skill only when it is explicitly requested and within its supported workflow contract.
 - Use `igapyon-repo-conventions` for repository layout and repository-side convention work when that skill is explicitly requested.
 - Keep SCM policy and SCM execution rules in this skill.
 

--- a/skills/igapyon-miku-scm/index.json
+++ b/skills/igapyon-miku-scm/index.json
@@ -3,10 +3,14 @@
  "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
  "basePath": ".",
  "files": [
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":2427,"description":"Use only when the user explicitly names `igapyon-miku-scm`, explicitly asks to apply the miku SCM workflow, or explicitly asks to perform Git, GitHub, GitHub Release, or version-management work under miku-soft SCM rules. Do not activate for generic Git ...","summary":"igapyon-miku-scm"},
-  {"name":"github-anonymous-readonly.md","path":"references/github-anonymous-readonly.md","ext":"md","dir":"references","size":1925,"summary":"GitHub Anonymous READONLY"},
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":3628,"description":"Use only when the user explicitly names `igapyon-miku-scm`, explicitly asks to apply the miku SCM workflow, or explicitly asks to perform Git, GitHub, GitHub Release, or version-management work under miku-soft SCM rules. Supports date-based and Semantic...","summary":"igapyon-miku-scm"},
+  {"name":"github-anonymous-readonly.md","path":"references/github-anonymous-readonly.md","ext":"md","dir":"references","size":2166,"summary":"GitHub Anonymous READONLY"},
+  {"name":"github-issue-rewrite-handoff.md","path":"references/github-issue-rewrite-handoff.md","ext":"md","dir":"references","size":2004,"summary":"GitHub Issue Rewrite Handoff"},
+  {"name":"github-repository-url.md","path":"references/github-repository-url.md","ext":"md","dir":"references","size":1361,"summary":"GitHub Repository URL"},
   {"name":"local-git-readonly.md","path":"references/local-git-readonly.md","ext":"md","dir":"references","size":2154,"summary":"Local Git READONLY"},
   {"name":"scm-rules.md","path":"references/scm-rules.md","ext":"md","dir":"references","size":7736,"summary":"SCM Rules"},
-  {"name":"version-increment-confirmation.md","path":"references/version-increment-confirmation.md","ext":"md","dir":"references","size":1283,"summary":"Version Increment Confirmation Before Add or Commit"}
+  {"name":"version-increment-confirmation.md","path":"references/version-increment-confirmation.md","ext":"md","dir":"references","size":3234,"summary":"Version Increment Check Before Add or Commit"},
+  {"name":"version-increment.md","path":"references/version-increment.md","ext":"md","dir":"references","size":4020,"summary":"Version Increment"},
+  {"name":"version-tag-release-audit.md","path":"references/version-tag-release-audit.md","ext":"md","dir":"references","size":4893,"summary":"Version, Tag, Release, and Asset Audit"}
  ]
 }

--- a/skills/igapyon-miku-scm/references/github-anonymous-readonly.md
+++ b/skills/igapyon-miku-scm/references/github-anonymous-readonly.md
@@ -22,6 +22,8 @@ Use `https://api.github.com` with these `GET` endpoint patterns:
 /repos/{owner}/{repo}/contents/{path}?ref={branch-or-commit}
 /repos/{owner}/{repo}/branches
 /repos/{owner}/{repo}/branches/{branch}
+/repos/{owner}/{repo}/commits/{branch-or-tag}
+/repos/{owner}/{repo}/tags?per_page=100
 /repos/{owner}/{repo}/issues?state=all&per_page=100
 /repos/{owner}/{repo}/issues/{issue_number}
 /repos/{owner}/{repo}/issues/{issue_number}/comments
@@ -36,6 +38,7 @@ Use only `GET` or `HEAD`. Follow pagination when the response includes a next-pa
 ## Interpretation Rules
 
 - Treat a response containing a `pull_request` field from an Issues endpoint as a Pull Request rather than an Issue.
+- Resolve version files at the exact branch commit or tag commit being audited. Do not compare a historical tag only with the current default-branch file.
 - Treat anonymous `404` as unresolved: the repository or resource may not exist, may be private, or may not be anonymously visible.
 - On `403` or `429`, inspect rate-limit response headers and report the limit. Do not silently authenticate or repeatedly retry.
 - Anonymous access cannot inspect private repositories or non-public resources such as draft Releases.

--- a/skills/igapyon-miku-scm/references/github-issue-rewrite-handoff.md
+++ b/skills/igapyon-miku-scm/references/github-issue-rewrite-handoff.md
@@ -1,0 +1,37 @@
+# GitHub Issue Rewrite Handoff
+
+Retrieve public GitHub Issues, rewrite their title and body, and return text for a human to paste into GitHub. Keep the entire workflow READONLY against GitHub.
+
+## Workflow
+
+1. Resolve the exact public repository and Issue number. When the user requests multiple Issues, resolve each number before drafting.
+2. Retrieve the current Issue and its comments with anonymous REST API `GET` requests according to the anonymous READONLY workflow.
+3. Reject an item containing a `pull_request` field as a Pull Request rather than an Issue.
+4. Preserve the Issue's intent, constraints, and established terminology. Incorporate relevant clarification from comments.
+5. Rewrite the title and body so the purpose, background, scope, and completion conditions are clear when those sections are supported by the source or the user's direction.
+6. Distinguish new proposals or inferences from confirmed facts. Do not invent decisions, dependencies, or acceptance criteria and present them as already agreed.
+7. Return the draft to the user for human transfer. If the user corrects the intent, revise the draft rather than defending the first interpretation.
+
+## Output
+
+For each Issue, provide:
+
+- the Issue number and link
+- `タイトル案`
+- `本文案` as copyable Markdown
+- a short note identifying any material assumption or newly proposed detail
+
+Keep the draft ready to paste. Do not save it to a local file unless the user asks.
+
+## Human Handoff Boundary
+
+End after returning the rewritten text. The human opens the GitHub Issue and performs the update.
+
+Do not:
+
+- update the Issue through an API, browser, `gh`, or another tool
+- request authentication or credentials
+- add comments, labels, assignees, milestones, or state changes
+- imply that the Issue was updated
+
+This human-paste Issue workflow belongs to `igapyon-miku-scm`. Continue to delegate PR, Release, About, and commit-message writing to `igapyon-github-writer` only when that skill is explicitly requested.

--- a/skills/igapyon-miku-scm/references/github-repository-url.md
+++ b/skills/igapyon-miku-scm/references/github-repository-url.md
@@ -1,0 +1,40 @@
+# GitHub Repository URL
+
+Answer requests for the GitHub URL of a local repository without changing Git configuration or accessing the network.
+
+## Resolve the Remote
+
+Confirm the target repository, then prefer its `origin` remote:
+
+```sh
+git rev-parse --show-toplevel
+git remote get-url origin
+```
+
+If `origin` does not exist, inspect configured remotes with `git remote -v`.
+
+- Use the only GitHub remote when exactly one exists.
+- When multiple GitHub remotes are plausible, show their names and URLs and ask which remote the user means.
+- When no GitHub remote exists, report that no GitHub URL is configured. Do not guess from the directory name.
+
+## Format the Answer
+
+Recognize common GitHub remote forms, including:
+
+```text
+git@github.com:OWNER/REPOSITORY.git
+ssh://git@github.com/OWNER/REPOSITORY.git
+https://github.com/OWNER/REPOSITORY.git
+```
+
+Convert the selected remote to this canonical browser URL:
+
+```text
+https://github.com/OWNER/REPOSITORY
+```
+
+Strip only the transport-specific prefix and a trailing `.git`. Preserve the owner and repository path exactly. Report the canonical browser URL first and the configured remote URL second. Do not expose embedded credentials or tokens; redact them if present.
+
+## Boundary
+
+Do not run `git remote set-url`, access GitHub, fetch, pull, or push for a URL query. URL resolution is local and READONLY.

--- a/skills/igapyon-miku-scm/references/version-increment-confirmation.md
+++ b/skills/igapyon-miku-scm/references/version-increment-confirmation.md
@@ -1,8 +1,35 @@
-# Version Increment Confirmation Before Add or Commit
+# Version Increment Check Before Add or Commit
 
-Treat version-increment confirmation as a mandatory human gate before running `git add` or `git commit` under the miku SCM workflow.
+Check for a required version increment before running `git add` or `git commit` under the miku SCM workflow. Do not repeatedly remind the human when an increment already completed in the same continuous session remains valid.
 
-## Confirmation Gate
+## Session Increment Record
+
+After performing or verifying a version increment, retain this session-scoped record in the working context:
+
+- repository top-level path
+- current branch
+- authoritative and coupled version-source paths
+- the verified value in each source
+- the alignment, build, or package check that succeeded
+
+Do not create a repository file solely to persist this record. The record applies only to the current continuous agent session.
+
+## Reuse an Existing Session Check
+
+Before `git add` or `git commit`, treat the version check as already satisfied without asking the reminder when all of these conditions hold:
+
+1. A session increment record exists for the same repository and branch.
+2. Every recorded authoritative or coupled version source still contains its recorded value and remains mutually aligned.
+3. No PR workflow, pull, push/publication boundary, merge, rebase, cherry-pick, reset, branch switch, or checkout that could replace versioned content has occurred since the record was established.
+4. There is no evidence that repository version policy or the authoritative version source changed.
+
+Use read-only checks such as `git rev-parse --show-toplevel`, `git branch --show-current`, `git status -sb`, direct reads of the version sources, and the repository's alignment command. Use known actions in the current session to evaluate invalidating operations; do not rely on `git reflog` alone because it cannot reveal remote PR activity.
+
+Unrelated working-tree changes, staging, or an ordinary local commit do not invalidate a verified session increment record. A new add or commit batch alone does not require another reminder. If a version value changed after the record, revalidate it against repository policy and refresh the record when the new value is valid; otherwise ask the reminder.
+
+## Reminder Gate
+
+When no reusable session record can be verified:
 
 1. Inspect the intended staging or commit scope and preserve unrelated changes.
 2. Before the first `git add` or `git commit` in that batch, ask the human explicitly:
@@ -15,6 +42,6 @@ Treat version-increment confirmation as a mandatory human gate before running `g
 4. Proceed only after the human confirms that no required increment was forgotten, or after any required version change has been handled and the human confirms it.
 5. If the human says an increment is needed, stop the add/commit sequence. Do not change a version automatically unless a separately documented workflow and explicit instruction authorize it.
 
-An explicit version confirmation already given for the same unchanged batch satisfies this gate. Ask again if the intended diff changes after confirmation or a new add/commit batch begins.
+An explicit human confirmation satisfies the current batch even when no version increment is required. Ask again for a later batch unless a valid session increment record exists.
 
 This gate governs whether staging and committing may proceed. Continue to use `igapyon-github-writer` for commit-message composition when its workflow is explicitly requested.

--- a/skills/igapyon-miku-scm/references/version-increment.md
+++ b/skills/igapyon-miku-scm/references/version-increment.md
@@ -1,0 +1,52 @@
+# Version Increment
+
+Increment a project's version only when the user explicitly requests it. Resolve the repository's version policy and authoritative files before editing; do not choose a rule from the numeric shape alone.
+
+## Common Workflow
+
+1. Inspect `git status -sb` and preserve unrelated staged and unstaged changes.
+2. Read repository documentation, build files, manifests, and recent version history to identify the authoritative version source, coupled version files, format, timezone, and validation command.
+3. Classify the version as repository-defined date-based versioning or Semantic Versioning. If the convention is ambiguous, stop and ask which convention applies.
+4. Derive the candidate version using the matching rule below and show the current and proposed values when human input is required.
+5. Update every repository-defined coupled version source in one batch. Do not update dependency or tool versions that merely appear in the same manifest.
+6. Run the repository's version-alignment check, build, or package command and confirm any versioned artifact name.
+7. Review the relevant diff and run `git status -sb`. Record the verified repository, branch, version-source paths and values, and successful validation in the current session so a later add or commit need not repeat the reminder. Leave the changes unstaged unless the user separately requests staging or committing.
+
+## Date-Based Versions
+
+Use the repository's documented date, timezone, prefix, separators, sequence, and coupled-file mapping. Do not treat every version containing eight digits as date-based.
+
+For the miku-soft form `1.YYYYMMDD.N`:
+
+- Use the maintenance date in the repository's configured or documented local timezone.
+- When the date differs from the existing version date, replace `YYYYMMDD` and reset `N` to `1`.
+- When the date is unchanged, keep `YYYYMMDD` and increment `N` by one.
+- Preserve the leading `1.` unless the repository explicitly defines another prefix.
+- Check current committed versions and relevant existing tags or Releases before finalizing when a collision is possible.
+
+When the repository couples `1.YYYYMMDD.N` to `YYYYMMDDx`, keep the date equal and map the positive sequence number using `1=a`, `2=b`, through `26=z`, then `27=aa`, `28=ab`, and so on. Therefore:
+
+```text
+1.20260718.3 / 20260718c
+  -> 1.20260719.1 / 20260719a  # first update on a new date
+  -> 1.20260719.2 / 20260719b  # next update on the same date
+```
+
+If the repository uses a different date form or suffix mapping, follow its documented rule instead of this example.
+
+## Semantic Versions
+
+Treat `MAJOR.MINOR.PATCH` and a tag such as `vMAJOR.MINOR.PATCH` as Semantic Versioning only when repository policy or consistent history supports that interpretation.
+
+- Increment `PATCH` for a backward-compatible fix and reset no higher component: `1.2.3` to `1.2.4`.
+- Increment `MINOR` for backward-compatible functionality and reset `PATCH` to zero: `1.2.3` to `1.3.0`.
+- Increment `MAJOR` for a breaking change and reset `MINOR` and `PATCH` to zero: `1.2.3` to `2.0.0`.
+- Follow the repository's explicit pre-release and build-metadata policy; do not invent one.
+
+An instruction that only says "increment the version" is insufficient for Semantic Versioning unless the repository explicitly defines a default increment level. Ask the user to choose major, minor, or patch. Do not infer the level solely from the current diff.
+
+Keep a tag prefix such as `v` separate from the manifest value unless the repository explicitly stores the prefix in its authoritative version source. For example, a manifest value `1.2.4` may correspond to tag `v1.2.4`.
+
+## Boundaries
+
+A version increment does not authorize `git add`, `git commit`, tag creation, push, or GitHub Release publication. Before a separately requested add or commit, apply [version-increment-confirmation.md](version-increment-confirmation.md). Perform tag, push, or Release work only under a separately documented workflow with explicit authorization.

--- a/skills/igapyon-miku-scm/references/version-tag-release-audit.md
+++ b/skills/igapyon-miku-scm/references/version-tag-release-audit.md
@@ -1,0 +1,89 @@
+# Version, Tag, Release, and Asset Audit
+
+Check whether committed project versions, Git tags, GitHub Releases, and downloadable distribution assets correspond without changing the repository or GitHub.
+
+## Resolve the Version Source
+
+1. Resolve the exact repository and target branch. For a public GitHub repository, use the repository's default branch unless the user names another branch.
+2. Find the authoritative version source from repository documentation and build files.
+3. Read the top-level `version` from `package.json` or the effective project version represented by `pom.xml`. Resolve a simple Maven version property when its value is present in the repository; otherwise report it as unresolved rather than guessing.
+4. When multiple authoritative manifests exist, compare them and report any mismatch.
+
+## Determine the Tag Convention
+
+Prefer, in order:
+
+1. an explicit repository rule
+2. a consistent pattern in recent tags and Releases whose tagged commits contain matching versions
+3. the common miku-soft default `v<VERSION>`
+
+Known miku-soft patterns include:
+
+- common version form: `0.4.3` becomes `v0.4.3`
+- date-identifier form: `1.20260719.3` becomes `v20260719c`, using `1=a`, `2=b`, `3=c`, and so on
+- repository-specific direct date tags such as `20260719` or `20260719a`
+
+Use the date-identifier form for repositories whose versions primarily identify when a build was made rather than express a meaningful semantic version. Do not select it from the numeric shape alone; require repository rules or consistent history. Preserve the observed prefix. If the convention is ambiguous, report it as unresolved and do not label a tag incorrect. Do not extrapolate an alphabetic sequence beyond its documented or observed range.
+
+## Run Two Independent Checks
+
+### Existing Tag Integrity
+
+For each relevant tag:
+
+1. Resolve the commit identified by the tag.
+2. Read the authoritative version file from that exact commit.
+3. Derive the expected tag using the resolved repository convention.
+4. Compare the expected tag with the actual tag.
+5. Confirm that a GitHub Release exists whose `tag_name` is that tag.
+
+Never validate a historical tag only against the current branch version.
+
+### Current Release Status
+
+1. Resolve the latest commit SHA of the target branch.
+2. Read the authoritative version from that exact commit.
+3. Derive the expected tag.
+4. Check whether the tag exists, whether it identifies that commit, and whether a corresponding GitHub Release exists.
+5. When the tag exists at an older commit but the branch has advanced without a version change, report that code changed after the tag while the version stayed the same.
+
+A newer committed version without its tag or Release can be normal work in progress. Report it as unreleased, not automatically as an error.
+
+## Check Distribution Assets
+
+Determine the expected Release assets from repository documentation, build configuration, release scripts, and consistent recent Releases.
+
+- For an Agent Skill distribution, expect the installable distribution ZIP, such as `igapyon-miku-m365-agent-builder-skills-0.4.3.zip`.
+- For a Node.js module or CLI distributed as a single-file runtime, expect its `.mjs` asset.
+- For a Java module or CLI, expect its `.jar` asset.
+- When a project intentionally distributes multiple runtimes, require every artifact named by its build or release contract.
+
+Inspect the selected Release's `assets[]` or assets endpoint. For each expected asset, check:
+
+- exact asset name according to the repository's naming convention
+- `state` is `uploaded`
+- `size` is greater than zero
+- digest or companion checksum asset when the repository produces one
+- browser download URL is present
+
+Do not count GitHub's automatic source-code ZIP or tarball as a project distribution asset. Do not require both `.mjs` and `.jar` unless the repository actually publishes both. Report unexpected assets separately without treating them as a failure by default.
+
+## Report
+
+Show the evidence and conclusion separately. Include:
+
+- target branch and latest commit SHA
+- version source path and committed version
+- inferred tag convention and its evidence
+- expected tag and actual matching tag
+- tag commit SHA and version at that commit
+- corresponding GitHub Release state
+- expected distribution asset type and name
+- each asset's presence, upload state, size, checksum or digest when available, and download URL
+- one of: aligned, unreleased, version mismatch, tag target mismatch, Release missing, distribution asset missing, distribution asset invalid, manifest mismatch, or convention unresolved
+
+State whether the result is about historical tag integrity or current release status.
+
+## Boundary
+
+Keep this audit READONLY. Do not edit a version, create or move a tag, publish a Release, push, or request credentials. A detected mismatch is a report, not authorization to repair it.

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260718c
+Version: 20260719a
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

`igapyon-miku-scm` に、ローカルリポジトリのGitHub URL解決、公開Issueの人手更新用リライト、バージョン・タグ・Release・配布物のREADONLY監査、バージョン番号インクリメントの手順を追加します。

あわせて、リポジトリ全体のバージョンを `1.20260719.1`、みくくの連動バージョンを `20260719a` に更新します。

## 変更内容

- `origin` などのローカルremoteから、認証情報を露出せずGitHubのブラウザURLを解決する手順を追加
- 公開GitHub Issueとコメントを匿名REST APIで確認し、人が貼り付けるタイトル・本文案を作るREADONLY handoffを追加
- version source、タグ、GitHub Release、配布assetを、対象commit単位で照合する監査手順を追加
- 日付型 `1.YYYYMMDD.N` とSemantic Versioningを分岐し、連番リセットやmajor・minor・patchの選択を扱うインクリメント手順を追加
- 同一セッションで検証済みのバージョン更新について、PR、pull、履歴統合などの無効化操作がなければadd・commit前の再リマインドを省略する判定を追加
- `SKILL.md` の導線と `index.json` を更新

## 検証

- `mvn clean package`
- Skill validation
- `git diff --check`