### PR TITLE
Release時のindex drift検査を見直しSCM報告を改善

### DIFF
--- a/.github/workflows/release-archive.yml
+++ b/.github/workflows/release-archive.yml
@@ -26,9 +26,6 @@ jobs:
       - name: Build release archive
         run: mvn clean package
 
-      - name: Check generated index drift
-        run: sh scripts/check-generated-indexes.sh
-
       - name: Upload release asset
         uses: softprops/action-gh-release@v2
         with:

--- a/README.md
+++ b/README.md
@@ -329,8 +329,9 @@ mvn clean package
 sh scripts/check-generated-indexes.sh
 ```
 
-release workflow でも `mvn clean package` の後に同じ検査を行い、生成結果が commit
-済みの `index.json` と一致しない場合は release を停止します。
+この drift 確認は、タグ作成前のローカル確認や通常の開発フローで利用します。
+release workflow は `mvn clean package` で archive 内の `index.json` を再生成するため、
+commit 済み index との差分だけを理由に release を停止しません。
 
 ## Release archive
 
@@ -367,8 +368,8 @@ release staging に全 skill をそろえた後、同梱した index generator �
 - `mikuscore-skills` `v0.1.0`: `skills/mikuscore/`
 
 GitHub では `v*` tag が push されたときに GitHub Actions で `mvn clean package` を実行し、
-生成 index の drift がないことを確認してから、生成された zip を GitHub Release asset
-として添付します。
+生成された zip を GitHub Release asset として添付します。archive 内の `index.json` は
+package 処理で再生成されます。
 
 ## 厳選 text bundle
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260719.3</version>
+  <version>1.20260719.4</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>

--- a/skills/igapyon-miku-scm/index.json
+++ b/skills/igapyon-miku-scm/index.json
@@ -3,9 +3,9 @@
  "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
  "basePath": ".",
  "files": [
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":4858,"description":"Use only when the user explicitly names `igapyon-miku-scm`, explicitly asks to apply the miku SCM workflow, or explicitly asks to perform Git, GitHub writing, GitHub Release, or version-management work under miku-soft SCM rules. Supports PR, Release, an...","summary":"igapyon-miku-scm"},
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":5007,"description":"Use only when the user explicitly names `igapyon-miku-scm`, explicitly asks to apply the miku SCM workflow, or explicitly asks to perform Git, GitHub writing, GitHub Release, or version-management work under miku-soft SCM rules. Supports PR, Release, an...","summary":"igapyon-miku-scm"},
   {"name":"github-about-writing.md","path":"references/github-about-writing.md","ext":"md","dir":"references","size":1131,"summary":"GitHub About Writing"},
-  {"name":"github-anonymous-readonly.md","path":"references/github-anonymous-readonly.md","ext":"md","dir":"references","size":2166,"summary":"GitHub Anonymous READONLY"},
+  {"name":"github-anonymous-readonly.md","path":"references/github-anonymous-readonly.md","ext":"md","dir":"references","size":2948,"summary":"GitHub Anonymous READONLY"},
   {"name":"github-backup-branch.md","path":"references/github-backup-branch.md","ext":"md","dir":"references","size":2430,"summary":"Backup Branch"},
   {"name":"github-branch-status.md","path":"references/github-branch-status.md","ext":"md","dir":"references","size":2672,"summary":"GitHub Branch Status"},
   {"name":"github-issue-rewrite-handoff.md","path":"references/github-issue-rewrite-handoff.md","ext":"md","dir":"references","size":1977,"summary":"GitHub Issue Rewrite Handoff"},
@@ -15,9 +15,9 @@
   {"name":"github-repository-url.md","path":"references/github-repository-url.md","ext":"md","dir":"references","size":1361,"summary":"GitHub Repository URL"},
   {"name":"github-writing-rules.md","path":"references/github-writing-rules.md","ext":"md","dir":"references","size":5864,"summary":"GitHub Writing Rules"},
   {"name":"local-git-readonly.md","path":"references/local-git-readonly.md","ext":"md","dir":"references","size":2154,"summary":"Local Git READONLY"},
-  {"name":"scm-rules.md","path":"references/scm-rules.md","ext":"md","dir":"references","size":8419,"summary":"SCM Rules"},
+  {"name":"scm-rules.md","path":"references/scm-rules.md","ext":"md","dir":"references","size":8830,"summary":"SCM Rules"},
   {"name":"version-increment-confirmation.md","path":"references/version-increment-confirmation.md","ext":"md","dir":"references","size":3738,"summary":"Version Increment Check Before Add or Commit"},
   {"name":"version-increment.md","path":"references/version-increment.md","ext":"md","dir":"references","size":4020,"summary":"Version Increment"},
-  {"name":"version-tag-release-audit.md","path":"references/version-tag-release-audit.md","ext":"md","dir":"references","size":4893,"summary":"Version, Tag, Release, and Asset Audit"}
+  {"name":"version-tag-release-audit.md","path":"references/version-tag-release-audit.md","ext":"md","dir":"references","size":5549,"summary":"Version, Tag, Release, and Asset Audit"}
  ]
 }

--- a/skills/igapyon-miku-scm/references/github-anonymous-readonly.md
+++ b/skills/igapyon-miku-scm/references/github-anonymous-readonly.md
@@ -10,6 +10,7 @@ Use anonymous REST API requests for:
 - branches
 - Issues and Issue comments
 - Releases and release assets
+- GitHub Actions runs, jobs, and step conclusions
 
 Do not use `gh`, request login, read a token, or send an `Authorization` header for these public READONLY operations.
 
@@ -31,6 +32,8 @@ Use `https://api.github.com` with these `GET` endpoint patterns:
 /repos/{owner}/{repo}/releases/latest
 /repos/{owner}/{repo}/releases/{release_id}
 /repos/{owner}/{repo}/releases/{release_id}/assets
+/repos/{owner}/{repo}/actions/runs?per_page=100
+/repos/{owner}/{repo}/actions/runs/{run_id}/jobs?per_page=100
 ```
 
 Use only `GET` or `HEAD`. Follow pagination when the response includes a next-page link.
@@ -43,6 +46,12 @@ Use only `GET` or `HEAD`. Follow pagination when the response includes a next-pa
 - On `403` or `429`, inspect rate-limit response headers and report the limit. Do not silently authenticate or repeatedly retry.
 - Anonymous access cannot inspect private repositories or non-public resources such as draft Releases.
 - Keep downloaded content in memory or local scratch space unless the user asks to save it.
+
+## GitHub Actions Log Handoff
+
+Use anonymous Actions run and job endpoints to identify the failing workflow, job, and step. If downloading the raw job log is rejected because authentication or repository permissions are required, do not request a token, login, or elevated GitHub access.
+
+Ask the human to open the failed step in the GitHub Actions UI and copy and paste the relevant error log into the conversation. Treat the pasted log as the evidence for the exact failure message. Local reproduction and repository comparison may continue while waiting, but clearly label conclusions inferred without the pasted log.
 
 ## Boundary
 

--- a/skills/igapyon-miku-scm/references/scm-rules.md
+++ b/skills/igapyon-miku-scm/references/scm-rules.md
@@ -77,6 +77,8 @@ git status -sb
 
 Run the selected push, remote verification, rename, and status steps in order and stop immediately if any step fails. Do not treat earlier approval to run PR Soft Reset Recommit as approval to publish. Require the human's OK after displaying the new commit log. If push or remote verification fails, do not rename the branch. Do not create a Pull Request in this sequence.
 
+After a successful push, remote verification, and local `-done` rename, derive the recommended tag name from the committed authoritative version and the repository's resolved tag convention. Include `推奨タグ名: <tag>` in the push completion report. If the convention cannot be resolved, report `推奨タグ名: 未解決` instead of guessing. This report does not authorize creating or pushing the tag.
+
 ## Next Work Branch After PR Completion
 
 Run this workflow when the human explicitly reports that the Pull Request was merged. Treat a clear report such as `GitHubでマージした`, `PRをマージした`, or `マージ完了` as both confirmation of the merge and authorization to refresh the base and create the next work branch; do not require a second instruction to create it. Do not infer merge completion from local Git state, push output, or branch naming. Do not create the next work branch immediately after push or local `-done` rename while the PR is still open or its merge is unconfirmed.

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260719c
+Version: 20260719d
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

Release archiveの作成時に、commit済みの生成indexとの差分だけを理由としてReleaseを停止しないようworkflowを変更します。あわせて、`igapyon-miku-scm` のpush完了報告とGitHub Actions障害調査の運用を明文化し、次のリリース版数へ更新します。

## 変更内容

- Release workflowからブロッキングな生成index drift検査を削除し、`mvn clean package` によるarchive内indexの再生成とReleaseアセットのアップロードを維持
- READMEのRelease workflow説明を新しい動作に更新
- push完了報告に、版数とタグ規則から導出した推奨タグ名を表示する規則を追加
- GitHub Actionsの匿名調査で生ログを取得できない場合、人間が失敗stepのログをコピー＆ペーストする引き渡し規則を追加
- `igapyon-miku-scm` の生成indexを同期
- リポジトリ版数を `1.20260719.4`、みくく版数を `20260719d` に更新

## 検証

- `mvn generate-resources`
- `sh scripts/check-generated-indexes.sh`
- `mvn validate`