### PR TITLE
公開完了レポートにGitHubリポジトリURLを追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260719.4</version>
+  <version>1.20260719.5</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>

--- a/skills/igapyon-miku-scm/index.json
+++ b/skills/igapyon-miku-scm/index.json
@@ -15,7 +15,7 @@
   {"name":"github-repository-url.md","path":"references/github-repository-url.md","ext":"md","dir":"references","size":1361,"summary":"GitHub Repository URL"},
   {"name":"github-writing-rules.md","path":"references/github-writing-rules.md","ext":"md","dir":"references","size":5864,"summary":"GitHub Writing Rules"},
   {"name":"local-git-readonly.md","path":"references/local-git-readonly.md","ext":"md","dir":"references","size":2870,"summary":"Local Git READONLY"},
-  {"name":"scm-rules.md","path":"references/scm-rules.md","ext":"md","dir":"references","size":10423,"summary":"SCM Rules"},
+  {"name":"scm-rules.md","path":"references/scm-rules.md","ext":"md","dir":"references","size":10732,"summary":"SCM Rules"},
   {"name":"version-increment-confirmation.md","path":"references/version-increment-confirmation.md","ext":"md","dir":"references","size":4396,"summary":"Version Increment Check Before Add or Commit"},
   {"name":"version-increment.md","path":"references/version-increment.md","ext":"md","dir":"references","size":4020,"summary":"Version Increment"},
   {"name":"version-tag-release-audit.md","path":"references/version-tag-release-audit.md","ext":"md","dir":"references","size":5549,"summary":"Version, Tag, Release, and Asset Audit"}

--- a/skills/igapyon-miku-scm/references/scm-rules.md
+++ b/skills/igapyon-miku-scm/references/scm-rules.md
@@ -88,7 +88,12 @@ git status -sb
 
 Run the selected push, remote verification, rename, and status steps in order and stop immediately if any step fails. Do not treat earlier approval to run PR Soft Reset Recommit as approval to publish. Require the human's OK after displaying the new commit log. If push or remote verification fails, do not rename the branch. Do not create a Pull Request in this sequence.
 
-After a successful push, remote verification, and local `-done` rename, derive the recommended tag name from the committed authoritative version and the repository's resolved tag convention. Include `推奨タグ名: <tag>` in the push completion report. If the convention cannot be resolved, report `推奨タグ名: 未解決` instead of guessing. This report does not authorize creating or pushing the tag.
+After a successful push, remote verification, and local `-done` rename:
+
+- Resolve the canonical GitHub browser URL from the selected repository remote under [github-repository-url.md](github-repository-url.md). Include `GitHubリポジトリ: <url>` in the push completion report. If it cannot be resolved safely, report `GitHubリポジトリ: 未解決` instead of guessing.
+- Derive the recommended tag name from the committed authoritative version and the repository's resolved tag convention. Include `推奨タグ名: <tag>` in the push completion report. If the convention cannot be resolved, report `推奨タグ名: 未解決` instead of guessing.
+
+This report does not authorize creating or pushing the tag.
 
 ## Next Work Branch After PR Completion
 

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260719d
+Version: 20260719e
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

miku-soft SCMのpush完了レポートに、対象GitHubリポジトリのcanonical browser URLを含める規則を追加します。あわせて、リポジトリとみくくの版数を同日内の次版へ更新します。

## 変更内容

- push、リモート一致確認、ローカルブランチの `-done` 化が完了したレポートに `GitHubリポジトリ: <url>` を追加
- URLは選択済みremoteからGitHubリポジトリURL解決規則に従って正規化し、安全に解決できない場合は `未解決` と報告
- miku-scmのdiscovery用 `index.json` を更新
- リポジトリ版数を `1.20260719.5`、みくく版数を `20260719e` に更新

## 検証

- `mvn clean package`
- `mvn package`
- `mvn generate-resources`
- `git diff --check`