### PR TITLE
miku-soft SCMの起動時安全確認と版数表示を強化

### DIFF
--- a/skills/igapyon-miku-scm/SKILL.md
+++ b/skills/igapyon-miku-scm/SKILL.md
@@ -28,20 +28,21 @@ Do not perform remote mutations, history rewrites, tag changes, release publicat
 ## Core Workflow
 
 1. Identify the requested SCM area and exact target repository.
-2. Inspect repository state before proposing or performing work.
-3. Read [references/scm-rules.md](references/scm-rules.md).
-4. Treat general repository or branch status requests, including `リポジトリ状態`, `このリポジトリの状態`, `ブランチ状況`, `repository state`, and `branch status`, as remote-freshness checks unless the user explicitly asks for local-only inspection. Read [references/local-git-readonly.md](references/local-git-readonly.md); for the fuller branch-status report, also read [references/github-branch-status.md](references/github-branch-status.md).
-5. For the integrated GitHub writing modes, read [references/github-writing-rules.md](references/github-writing-rules.md), then the requested mode: [references/github-pr-writing.md](references/github-pr-writing.md), [references/github-release-writing.md](references/github-release-writing.md), or [references/github-about-writing.md](references/github-about-writing.md).
-6. For PR soft-reset recommit, read [references/github-pr-soft-reset-recommit.md](references/github-pr-soft-reset-recommit.md) and [references/github-backup-branch.md](references/github-backup-branch.md), then use [scripts/pr-soft-reset-recommit-preflight.mjs](scripts/pr-soft-reset-recommit-preflight.mjs); for standalone backup or branch-status work, read [references/github-backup-branch.md](references/github-backup-branch.md) or [references/github-branch-status.md](references/github-branch-status.md).
-7. For a local repository GitHub URL query, read [references/github-repository-url.md](references/github-repository-url.md).
-8. For a public GitHub Issue rewrite that a human will paste into GitHub, read [references/github-anonymous-readonly.md](references/github-anonymous-readonly.md) and [references/github-issue-rewrite-handoff.md](references/github-issue-rewrite-handoff.md).
-9. Treat a request about GitHub tag status, including short phrases such as `タグ状況` or `tag status`, as a version, tag, Release, and distribution-asset consistency audit unless the user explicitly narrows the scope. Read [references/github-anonymous-readonly.md](references/github-anonymous-readonly.md) and [references/version-tag-release-audit.md](references/version-tag-release-audit.md).
-10. For a requested version increment, read [references/version-increment.md](references/version-increment.md).
-11. For other public GitHub source, branch, Issue, or Release inspection, read [references/github-anonymous-readonly.md](references/github-anonymous-readonly.md).
-12. Before any requested `git add` or `git commit`, read and follow [references/version-increment-confirmation.md](references/version-increment-confirmation.md).
-13. Preserve unrelated user changes.
-14. Separate local preparation from remote GitHub operations.
-15. Report what was inspected, changed, and left pending.
+2. Read [references/scm-rules.md](references/scm-rules.md).
+3. Immediately inspect the current branch with `git branch --show-current`. If it ends in `-done`, apply the Startup Frozen Branch Guard before continuing.
+4. Inspect repository state before proposing or performing work.
+5. Treat general repository or branch status requests, including `リポジトリ状態`, `このリポジトリの状態`, `ブランチ状況`, `repository state`, and `branch status`, as remote-freshness checks unless the user explicitly asks for local-only inspection. Read [references/local-git-readonly.md](references/local-git-readonly.md); for the fuller branch-status report, also read [references/github-branch-status.md](references/github-branch-status.md).
+6. For the integrated GitHub writing modes, read [references/github-writing-rules.md](references/github-writing-rules.md), then the requested mode: [references/github-pr-writing.md](references/github-pr-writing.md), [references/github-release-writing.md](references/github-release-writing.md), or [references/github-about-writing.md](references/github-about-writing.md).
+7. For PR soft-reset recommit, read [references/github-pr-soft-reset-recommit.md](references/github-pr-soft-reset-recommit.md) and [references/github-backup-branch.md](references/github-backup-branch.md), then use [scripts/pr-soft-reset-recommit-preflight.mjs](scripts/pr-soft-reset-recommit-preflight.mjs); for standalone backup or branch-status work, read [references/github-backup-branch.md](references/github-backup-branch.md) or [references/github-branch-status.md](references/github-branch-status.md).
+8. For a local repository GitHub URL query, read [references/github-repository-url.md](references/github-repository-url.md).
+9. For a public GitHub Issue rewrite that a human will paste into GitHub, read [references/github-anonymous-readonly.md](references/github-anonymous-readonly.md) and [references/github-issue-rewrite-handoff.md](references/github-issue-rewrite-handoff.md).
+10. Treat a request about GitHub tag status, including short phrases such as `タグ状況` or `tag status`, as a version, tag, Release, and distribution-asset consistency audit unless the user explicitly narrows the scope. Read [references/github-anonymous-readonly.md](references/github-anonymous-readonly.md) and [references/version-tag-release-audit.md](references/version-tag-release-audit.md).
+11. For a requested version increment, read [references/version-increment.md](references/version-increment.md).
+12. For other public GitHub source, branch, Issue, or Release inspection, read [references/github-anonymous-readonly.md](references/github-anonymous-readonly.md).
+13. Before any requested `git add` or `git commit`, read and follow [references/version-increment-confirmation.md](references/version-increment-confirmation.md). Read [references/github-anonymous-readonly.md](references/github-anonymous-readonly.md) when resolving the latest public GitHub version tag for the confirmation display.
+14. Preserve unrelated user changes.
+15. Separate local preparation from remote GitHub operations.
+16. Report what was inspected, changed, and left pending.
 
 ## Boundaries
 

--- a/skills/igapyon-miku-scm/index.json
+++ b/skills/igapyon-miku-scm/index.json
@@ -3,7 +3,7 @@
  "generation": {"schemaVersion":1,"inputPath":".","markdownOutput":false,"recursive":true,"includeExtensions":["md","json"],"inputEncoding":"utf8","outputEncoding":"utf8","includeGeneratorMetadata":true},
  "basePath": ".",
  "files": [
-  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":5365,"description":"Use only when the user explicitly names `igapyon-miku-scm`, explicitly asks to apply the miku SCM workflow, or explicitly asks to perform Git, GitHub writing, GitHub Release, or version-management work under miku-soft SCM rules. Supports PR, Release, an...","summary":"igapyon-miku-scm"},
+  {"name":"SKILL.md","path":"SKILL.md","ext":"md","dir":"","size":5692,"description":"Use only when the user explicitly names `igapyon-miku-scm`, explicitly asks to apply the miku SCM workflow, or explicitly asks to perform Git, GitHub writing, GitHub Release, or version-management work under miku-soft SCM rules. Supports PR, Release, an...","summary":"igapyon-miku-scm"},
   {"name":"github-about-writing.md","path":"references/github-about-writing.md","ext":"md","dir":"references","size":1131,"summary":"GitHub About Writing"},
   {"name":"github-anonymous-readonly.md","path":"references/github-anonymous-readonly.md","ext":"md","dir":"references","size":2948,"summary":"GitHub Anonymous READONLY"},
   {"name":"github-backup-branch.md","path":"references/github-backup-branch.md","ext":"md","dir":"references","size":2430,"summary":"Backup Branch"},
@@ -15,8 +15,8 @@
   {"name":"github-repository-url.md","path":"references/github-repository-url.md","ext":"md","dir":"references","size":1361,"summary":"GitHub Repository URL"},
   {"name":"github-writing-rules.md","path":"references/github-writing-rules.md","ext":"md","dir":"references","size":5864,"summary":"GitHub Writing Rules"},
   {"name":"local-git-readonly.md","path":"references/local-git-readonly.md","ext":"md","dir":"references","size":2870,"summary":"Local Git READONLY"},
-  {"name":"scm-rules.md","path":"references/scm-rules.md","ext":"md","dir":"references","size":10732,"summary":"SCM Rules"},
-  {"name":"version-increment-confirmation.md","path":"references/version-increment-confirmation.md","ext":"md","dir":"references","size":4396,"summary":"Version Increment Check Before Add or Commit"},
+  {"name":"scm-rules.md","path":"references/scm-rules.md","ext":"md","dir":"references","size":12144,"summary":"SCM Rules"},
+  {"name":"version-increment-confirmation.md","path":"references/version-increment-confirmation.md","ext":"md","dir":"references","size":5846,"summary":"Version Increment Check Before Add or Commit"},
   {"name":"version-increment.md","path":"references/version-increment.md","ext":"md","dir":"references","size":4020,"summary":"Version Increment"},
   {"name":"version-tag-release-audit.md","path":"references/version-tag-release-audit.md","ext":"md","dir":"references","size":5549,"summary":"Version, Tag, Release, and Asset Audit"}
  ]

--- a/skills/igapyon-miku-scm/references/scm-rules.md
+++ b/skills/igapyon-miku-scm/references/scm-rules.md
@@ -21,6 +21,20 @@ Do not treat SCM safety as a single READONLY-versus-write boundary. Classify eac
 
 Use the least-authorized level sufficient for the request. A lower level never implies authorization for a higher one. Preserve stricter workflow-specific prohibitions and confirmation gates when they apply.
 
+## Startup Frozen Branch Guard
+
+Immediately after activating `igapyon-miku-scm` for a local repository, inspect the current branch with `git branch --show-current` before beginning the requested workflow.
+
+When the branch name ends in `-done`:
+
+- Treat it as frozen. Do not edit files, stage, commit, reset, recommit, or begin other new work on that branch.
+- Treat `-done` only as evidence that the post-recommit publication flow probably reached its local rename. It does not prove that GitHub received a Pull Request or that the Pull Request was merged.
+- If the user's activating message explicitly reports that the Pull Request was merged, run the Next Work Branch After PR Completion workflow before doing any new work.
+- If merge completion has not been explicitly reported, stop before any mutating workflow and ask `GitHubのPRはマージ済みですか？` Do not infer the answer from local Git state, remote branch state, or the `-done` suffix.
+- If the user says the Pull Request is not merged, keep the branch frozen. Allow read-only inspection and reporting, but require an explicitly documented recovery path before applying a correction.
+
+After the human confirms that the Pull Request was merged, treat that confirmation as authorization to refresh the base and create the next work branch under the documented workflow. Continue other requested work only after switching to that new branch.
+
 ## PR Soft Reset Recommit Delegation
 
 - Treat `pr soft reset recommit` and `pr reset recommit` as explicit requests to run the PR Soft Reset Recommit workflow built into `igapyon-miku-scm`.

--- a/skills/igapyon-miku-scm/references/version-increment-confirmation.md
+++ b/skills/igapyon-miku-scm/references/version-increment-confirmation.md
@@ -35,15 +35,25 @@ Unrelated working-tree changes, staging, or an ordinary local commit do not inva
 When no reusable session record can be verified:
 
 1. Inspect the intended staging or commit scope and preserve unrelated changes.
-2. Before the first `git add` or `git commit` in that batch, ask the human explicitly:
+2. Read the repository's authoritative and coupled version sources. Derive the corresponding tag candidate only when the repository convention is already resolved; otherwise report it as `未解決` instead of guessing.
+3. For a public GitHub repository, use the anonymous REST API workflow in [github-anonymous-readonly.md](github-anonymous-readonly.md) to list tags. Filter out tags that do not match the resolved version-tag convention, then identify the greatest version tag using the repository-defined ordering. For date-identifier tags, compare the date and decoded alphabetic sequence; for Semantic Versions, compare semantic version components. Do not use API response order, tagger date, or unrelated operational tags to decide which version tag is latest.
+4. If the GitHub repository or tag list cannot be resolved anonymously, show the latest GitHub version tag as `未確認`. A failed lookup does not by itself block the human confirmation gate.
+5. Before the first `git add` or `git commit` in that batch, show the current version information and ask the human explicitly. Use repository-defined labels when available; for the `igapyon-agent-skills` coupled versions, use this shape:
 
 ```text
+現在のバージョン:
+- リポジトリ: <authoritative-version>
+- みくく: <coupled-version>
+- 対応タグ候補: <tag-or-未解決>
+- GitHub最新バージョンタグ: <tag-or-未確認>
+
 バージョンのインクリメント忘れはありませんか？
 ```
 
-3. Wait for the human's answer. Do not run `git add` or `git commit` while the answer is pending.
-4. Proceed only after the human confirms that no required increment was forgotten, or after any required version change has been handled and the human confirms it.
-5. If the human says an increment is needed, stop the add/commit sequence. Do not change a version automatically unless a separately documented workflow and explicit instruction authorize it.
+6. If a version source cannot be read, show that value as `未確認`. Do not omit the current-version block or substitute a guessed value.
+7. Wait for the human's answer. Do not run `git add` or `git commit` while the answer is pending.
+8. Proceed only after the human confirms that no required increment was forgotten, or after any required version change has been handled and the human confirms it.
+9. If the human says an increment is needed, stop the add/commit sequence. Do not change a version automatically unless a separately documented workflow and explicit instruction authorize it.
 
 An explicit human confirmation satisfies the current batch even when no version increment is required. It also satisfies a later PR Soft Reset Recommit of that same confirmed content when the session record remains valid. Ask again for other later batches unless a reusable session version check record exists.
 


### PR DESCRIPTION
## 概要

`igapyon-miku-scm` の起動時に `-done` ブランチ上で新しい作業を始める事故を防ぐガードを追加します。あわせて、コミット前のバージョン確認で現在版、対応タグ候補、GitHub上の最新バージョンタグを判断材料として表示します。

## 変更内容

- Skill起動直後に現在ブランチを確認し、`-done` ブランチを凍結状態として扱う手順を追加
- `-done` 上でマージ報告がなければ、変更操作を開始せずGitHub PRのマージ状況を確認する規則を追加
- マージ済みと明示された場合は、最新baseから次作業ブランチを作成してから作業を続ける規則を追加
- コミット前確認にリポジトリ版数、みくく版数、対応タグ候補を表示
- 匿名GitHub APIからversion tagを取得し、リポジトリ規則に基づく最新バージョンタグを表示
- API応答順、tagger date、無関係な運用タグを最新version tagの判定に使わない境界を追加
- miku-scmのdiscovery用 `index.json` を更新

## 検証

- `mvn generate-resources`
- Skill構造検証
- 匿名GitHub APIによるタグ一覧取得
- `git diff --check`