### PR TITLE
AI assistant builder skillへの同梱を切り替え

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ release staging に全 skill をそろえた後、同梱した index generator �
 - `miku-repo-bundle-skills` `v0.5.0.1` (experimental): `skills/igapyon-miku-repo-bundle/`
 - `miku-grep-skills` `v0.10.1.1` (experimental): `skills/igapyon-miku-grep/`
 - `miku-prompt-lint-skills` `v0.5.0`: `skills/igapyon-miku-prompt-lint/`
-- `miku-m365-agent-builder-skills` `v0.4.3`: `skills/igapyon-miku-m365-agent-builder/`
+- `miku-ai-assistant-builder-skills` `v0.7.1`: `skills/igapyon-miku-ai-assistant-builder/`
 - `miku-ms-office-skills` `v0.6.2`: `skills/igapyon-miku-ms-office/`
 - `miku-readfile-skills` `v0.5.0.2`: `skills/miku-readfile/`
 - `mikuproject-skills` `v0.8.1.1`: `skills/mikuproject/`

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260719.8</version>
+  <version>1.20260719.9</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>
@@ -26,9 +26,9 @@
     <external.miku-prompt-lint-skills.repo>https://github.com/igapyon/miku-prompt-lint-skills.git</external.miku-prompt-lint-skills.repo>
     <external.miku-prompt-lint-skills.ref>v0.5.0</external.miku-prompt-lint-skills.ref>
     <external.miku-prompt-lint-skills.skillName>igapyon-miku-prompt-lint</external.miku-prompt-lint-skills.skillName>
-    <external.miku-m365-agent-builder-skills.repo>https://github.com/igapyon/miku-m365-agent-builder-skills.git</external.miku-m365-agent-builder-skills.repo>
-    <external.miku-m365-agent-builder-skills.ref>v0.4.3</external.miku-m365-agent-builder-skills.ref>
-    <external.miku-m365-agent-builder-skills.skillName>igapyon-miku-m365-agent-builder</external.miku-m365-agent-builder-skills.skillName>
+    <external.miku-ai-assistant-builder-skills.repo>https://github.com/igapyon/miku-ai-assistant-builder-skills.git</external.miku-ai-assistant-builder-skills.repo>
+    <external.miku-ai-assistant-builder-skills.ref>v0.7.1</external.miku-ai-assistant-builder-skills.ref>
+    <external.miku-ai-assistant-builder-skills.skillName>igapyon-miku-ai-assistant-builder</external.miku-ai-assistant-builder-skills.skillName>
     <external.miku-ms-office-skills.repo>https://github.com/igapyon/miku-ms-office-skills.git</external.miku-ms-office-skills.repo>
     <external.miku-ms-office-skills.ref>v0.6.2</external.miku-ms-office-skills.ref>
     <external.miku-ms-office-skills.skillName>igapyon-miku-ms-office</external.miku-ms-office-skills.skillName>
@@ -108,9 +108,9 @@
                 <argument>${external.miku-prompt-lint-skills.repo}</argument>
                 <argument>${external.miku-prompt-lint-skills.ref}</argument>
                 <argument>${external.miku-prompt-lint-skills.skillName}</argument>
-                <argument>${external.miku-m365-agent-builder-skills.repo}</argument>
-                <argument>${external.miku-m365-agent-builder-skills.ref}</argument>
-                <argument>${external.miku-m365-agent-builder-skills.skillName}</argument>
+                <argument>${external.miku-ai-assistant-builder-skills.repo}</argument>
+                <argument>${external.miku-ai-assistant-builder-skills.ref}</argument>
+                <argument>${external.miku-ai-assistant-builder-skills.skillName}</argument>
                 <argument>${external.miku-ms-office-skills.repo}</argument>
                 <argument>${external.miku-ms-office-skills.ref}</argument>
                 <argument>${external.miku-ms-office-skills.skillName}</argument>

--- a/skills/igapyon-miku-scm/index.json
+++ b/skills/igapyon-miku-scm/index.json
@@ -20,6 +20,6 @@
   {"name":"scm-rules.md","path":"references/scm-rules.md","ext":"md","dir":"references","size":14863,"summary":"SCM Rules"},
   {"name":"version-increment-confirmation.md","path":"references/version-increment-confirmation.md","ext":"md","dir":"references","size":5846,"summary":"Version Increment Check Before Add or Commit"},
   {"name":"version-increment.md","path":"references/version-increment.md","ext":"md","dir":"references","size":4020,"summary":"Version Increment"},
-  {"name":"version-tag-release-audit.md","path":"references/version-tag-release-audit.md","ext":"md","dir":"references","size":5549,"summary":"Version, Tag, Release, and Asset Audit"}
+  {"name":"version-tag-release-audit.md","path":"references/version-tag-release-audit.md","ext":"md","dir":"references","size":5551,"summary":"Version, Tag, Release, and Asset Audit"}
  ]
 }

--- a/skills/igapyon-miku-scm/references/version-tag-release-audit.md
+++ b/skills/igapyon-miku-scm/references/version-tag-release-audit.md
@@ -59,7 +59,7 @@ A newer committed version without its tag or Release can be normal work in progr
 
 Determine the expected Release assets from repository documentation, build configuration, release scripts, and consistent recent Releases.
 
-- For an Agent Skill distribution, expect the installable distribution ZIP, such as `igapyon-miku-m365-agent-builder-skills-0.4.3.zip`.
+- For an Agent Skill distribution, expect the installable distribution ZIP, such as `igapyon-miku-ai-assistant-builder-skills-0.7.1.zip`.
 - For a Node.js module or CLI distributed as a single-file runtime, expect its `.mjs` asset.
 - For a Java module or CLI, expect its `.jar` asset.
 - When a project intentionally distributes multiple runtimes, require every artifact named by its build or release contract.

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260719h
+Version: 20260719i
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

廃止された `igapyon-miku-m365-agent-builder` の外部同梱設定を、名称変更後の `igapyon-miku-ai-assistant-builder` に切り替えます。

## 変更内容

- 外部取得元を `miku-ai-assistant-builder-skills` の `v0.7.1` に変更
- release staging の同梱対象を `skills/igapyon-miku-ai-assistant-builder/` に変更
- README と配布アセット監査例を新名称に更新
- SCM skill の `index.json` を再生成
- リポジトリ版数を `1.20260719.9`、みくく版数を `20260719i` に更新

## 検証

- `mvn clean package`
- 生成ZIP内に新skillが含まれ、旧skillが含まれないことを確認
- `EXTERNAL_SKILLS.lock` に新しい取得元、`v0.7.1`、skill名が記録されることを確認