### PR TITLE
miku-scmの起動時初期化を必要時まで延期

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260720.1</version>
+  <version>1.20260720.2</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>

--- a/skills/igapyon-miku-scm/SKILL.md
+++ b/skills/igapyon-miku-scm/SKILL.md
@@ -25,6 +25,16 @@ Support documented workflows and read-only inspection for:
 
 Do not perform remote mutations, history rewrites, tag changes, release publication, or version changes until the relevant workflow is explicitly documented under `references/` and the user explicitly requests the operation.
 
+## Activation-Only Fast Path
+
+When the user explicitly activates `igapyon-miku-scm` but does not yet identify a concrete SCM task, repository question, or operation:
+
+1. Acknowledge that the skill is active and ask what SCM work the user wants to perform.
+2. Do not yet read [references/scm-rules.md](references/scm-rules.md) or inspect the repository branch and working tree.
+3. After the user supplies a concrete request, resume at Core Workflow step 1 and complete all required reading and repository checks before inspecting further or making changes.
+
+This fast path only defers initialization until there is enough information to classify the workflow. It does not waive any safety check or authorize local or remote mutation.
+
 ## Core Workflow
 
 1. Identify the requested SCM area and exact target repository.

--- a/skills/igapyon-miku-scm/references/scm-rules.md
+++ b/skills/igapyon-miku-scm/references/scm-rules.md
@@ -23,14 +23,14 @@ Use the least-authorized level sufficient for the request. A lower level never i
 
 ## Startup Work Branch Checkout
 
-Immediately after activating `igapyon-miku-scm` for a local repository, inspect the current branch before beginning any requested workflow:
+After the user identifies a concrete SCM task for a local repository, inspect the current branch before beginning that workflow:
 
 ```sh
 git branch --show-current
 git status --porcelain
 ```
 
-Activation alone does not authorize branch creation or switching. Apply this section only when the user's requested workflow explicitly requires modifying tracked content or creating an ordinary commit and no more specific branch/history workflow owns the operation.
+Activation alone does not require repository inspection and does not authorize branch creation or switching. Apply this section only when the user's requested workflow explicitly requires modifying tracked content or creating an ordinary commit and no more specific branch/history workflow owns the operation.
 
 Do not apply Startup Work Branch Checkout for:
 
@@ -68,7 +68,7 @@ Use `switch` as the preferred modern Git term for this operation. The resulting 
 
 ## Startup Frozen Branch Guard
 
-Immediately after activating `igapyon-miku-scm` for a local repository, inspect the current branch with `git branch --show-current` before beginning the requested workflow. Classify the workflow before deciding whether the frozen branch blocks it.
+After the user identifies a concrete SCM task for a local repository, inspect the current branch with `git branch --show-current` before beginning the requested workflow. Classify the workflow before deciding whether the frozen branch blocks it.
 
 When the branch name ends in `-done`:
 

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260720a
+Version: 20260720b
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

`igapyon-miku-scm` を起動しただけの段階では、具体的なSCM作業が指定されるまで共通規則の読み込みとGit状態確認を延期する高速経路を追加します。

## 変更内容

- 具体的なSCM作業が未指定の場合に適用する `Activation-Only Fast Path` を追加
- 具体的な依頼を受けた後は、従来のCore Workflowへ戻り、必要な規則読み込みと安全確認をすべて実施することを明記
- Startup Work Branch CheckoutとStartup Frozen Branch Guardの開始条件を、スキル起動時から具体的なSCM作業の指定時へ変更
- リポジトリ版数を `1.20260720.2`、みくく版数を `20260720b` に更新

## 確認内容

- `mvn validate`
- 版数整合性: `1.20260720.2 / 20260720b`