### PR TITLE
fix(miku-scm): Issueクローズ理由の検証をGitHub CLI形式に合わせる

### DIFF
--- a/skills/igapyon-miku-scm/scripts/github-issue-close.mjs
+++ b/skills/igapyon-miku-scm/scripts/github-issue-close.mjs
@@ -113,7 +113,7 @@ function operationSha256(options) {
 }
 
 function expectedStateReason(reason) {
-  return reason === "not planned" ? "not_planned" : reason;
+  return reason.replaceAll(" ", "_").toUpperCase();
 }
 
 function issueSnapshotSha256(issue) {

--- a/skills/igapyon-miku-scm/tests/github-issue-close.test.mjs
+++ b/skills/igapyon-miku-scm/tests/github-issue-close.test.mjs
@@ -116,12 +116,12 @@ test("duplicate target changes after review are a conflict", async (t) => {
   assert.equal(calls, 0);
 });
 
-test("apply invokes one exact close and verifies state and reason", async (t) => {
+test("apply invokes one exact close and verifies GitHub's uppercase state reason", async (t) => {
   const state = await scenario(t);
   const preflight = await runIssueClose(optionsFor(state), {
     readIssue: async () => ISSUE,
   });
-  const reads = [ISSUE, { ...ISSUE, state: "CLOSED", stateReason: "completed" }];
+  const reads = [ISSUE, { ...ISSUE, state: "CLOSED", stateReason: "COMPLETED" }];
   const calls = [];
   const result = await runIssueClose(applyOptions(state, preflight), {
     readIssue: async () => reads.shift(),
@@ -135,7 +135,7 @@ test("apply invokes one exact close and verifies state and reason", async (t) =>
     "issue", "close", "42", "--repo", "igapyon/example", "--reason", "completed",
   ]);
   assert.equal(result.status, "closed");
-  assert.equal(result.verified_state_reason, "completed");
+  assert.equal(result.verified_state_reason, "COMPLETED");
   const record = JSON.parse(await readFile(path.join(state.root, result.attempt_record), "utf8"));
   assert.equal(record.status, "closed");
 });
@@ -144,7 +144,7 @@ test("already closed or changed Issue is rejected before gh", async (t) => {
   const state = await scenario(t);
   await assert.rejects(
     runIssueClose(optionsFor(state), {
-      readIssue: async () => ({ ...ISSUE, state: "CLOSED", stateReason: "completed" }),
+      readIssue: async () => ({ ...ISSUE, state: "CLOSED", stateReason: "COMPLETED" }),
     }),
     /Only an Open Issue/,
   );
@@ -168,7 +168,7 @@ test("post-close verification retries reads but never repeats close", async (t) 
   const reads = [
     ISSUE,
     ISSUE,
-    { ...ISSUE, state: "CLOSED", stateReason: "completed" },
+    { ...ISSUE, state: "CLOSED", stateReason: "COMPLETED" },
   ];
   const delays = [];
   let calls = 0;


### PR DESCRIPTION
## 概要

Issueクローズ後の検証が、GitHub CLIの`stateReason`の大文字列挙値を正しく受け入れられるようにします。

## 変更内容

- クローズ理由をアンダースコア区切りの大文字形式へ正規化して検証するように変更
- `COMPLETED`を返すGitHub CLI応答を使用する回帰テストへ更新

## 確認

- `npm run test:miku-scm`
- `mvn generate-resources`