### PR TITLE
コンテンツリポジトリ向け VERSION.md タグ規則を追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260725.5</version>
+  <version>1.20260725.6</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>

--- a/skills/igapyon-miku-scm/index.json
+++ b/skills/igapyon-miku-scm/index.json
@@ -27,7 +27,7 @@
   {"name":"repository-precommit-checks.md","path":"references/repository-precommit-checks.md","ext":"md","dir":"references","size":3171,"summary":"Repository-Declared Pre-Commit Checks"},
   {"name":"scm-rules.md","path":"references/scm-rules.md","ext":"md","dir":"references","size":28227,"summary":"SCM Rules"},
   {"name":"version-increment-confirmation.md","path":"references/version-increment-confirmation.md","ext":"md","dir":"references","size":5846,"summary":"Version Increment Check Before Add or Commit"},
-  {"name":"version-increment.md","path":"references/version-increment.md","ext":"md","dir":"references","size":4020,"summary":"Version Increment"},
-  {"name":"version-tag-release-audit.md","path":"references/version-tag-release-audit.md","ext":"md","dir":"references","size":5551,"summary":"Version, Tag, Release, and Asset Audit"}
+  {"name":"version-increment.md","path":"references/version-increment.md","ext":"md","dir":"references","size":5889,"summary":"Version Increment"},
+  {"name":"version-tag-release-audit.md","path":"references/version-tag-release-audit.md","ext":"md","dir":"references","size":6289,"summary":"Version, Tag, Release, and Asset Audit"}
  ]
 }

--- a/skills/igapyon-miku-scm/references/version-increment.md
+++ b/skills/igapyon-miku-scm/references/version-increment.md
@@ -34,6 +34,35 @@ When the repository couples `1.YYYYMMDD.N` to `YYYYMMDDx`, keep the date equal a
 
 If the repository uses a different date form or suffix mapping, follow its documented rule instead of this example.
 
+## Content-Repository `VERSION.md` Date Versions
+
+For a repository that is neither an application nor an Agent Skill and whose primary deliverable is content, the repository may explicitly adopt a root `VERSION.md` as its authoritative version source. Do not infer this convention merely because a repository happens to contain a file named `VERSION.md`; repository documentation or established history must identify it as the version source.
+
+The value is one date identifier in this form:
+
+```text
+YYYYMMDD<suffix>
+```
+
+`YYYYMMDD` is the repository's documented local maintenance date. `<suffix>` is a lowercase alphabetic sequence where `a` is the first update of the date, followed by `b` through `z`, then `aa`, `ab`, and so on. The suffix resets when the maintenance date changes:
+
+```text
+20260721a
+  -> 20260721b   # next update on the same date
+  -> 20260721z
+  -> 20260721aa  # same date: continue past z
+  -> 20260722a   # first update on a new date: reset the suffix
+```
+
+When this convention is explicitly adopted, increment it as follows:
+
+1. Determine the maintenance date in the repository's documented timezone.
+2. If it differs from the date in the current `VERSION.md`, replace the date and set the suffix to `a`.
+3. If it is the same date, retain the date and advance the alphabetic suffix using `a` through `z`, then `aa`, `ab`, and so on.
+4. Keep `VERSION.md` as a single authoritative value unless the repository explicitly documents coupled version sources.
+
+The matching release-tag convention is `v<VERSION>`. For example, `VERSION.md` value `20260721a` corresponds to tag `v20260721a`, and `20260721z` corresponds to `v20260721z`. A new-day value `20260722a` corresponds to `v20260722a`; do not carry `z` into the next day's tag. Apply this tag derivation only where the repository has explicitly adopted this content-repository convention.
+
 ## Semantic Versions
 
 Treat `MAJOR.MINOR.PATCH` and a tag such as `vMAJOR.MINOR.PATCH` as Semantic Versioning only when repository policy or consistent history supports that interpretation.

--- a/skills/igapyon-miku-scm/references/version-tag-release-audit.md
+++ b/skills/igapyon-miku-scm/references/version-tag-release-audit.md
@@ -12,8 +12,9 @@ Do not stop after listing tags or comparing tag commit SHAs. Report the authorit
 
 1. Resolve the exact repository and target branch. For a public GitHub repository, use the repository's default branch unless the user names another branch.
 2. Find the authoritative version source from repository documentation and build files.
-3. Read the top-level `version` from `package.json` or the effective project version represented by `pom.xml`. Resolve a simple Maven version property when its value is present in the repository; otherwise report it as unresolved rather than guessing.
-4. When multiple authoritative manifests exist, compare them and report any mismatch.
+3. Read the top-level `version` from `package.json`, the effective project version represented by `pom.xml`, or the root `VERSION.md` when repository policy explicitly adopts it for a content repository. Resolve a simple Maven version property when its value is present in the repository; otherwise report it as unresolved rather than guessing.
+4. For an explicitly adopted content-repository `VERSION.md`, require exactly one `YYYYMMDD<suffix>` value, where the suffix is lowercase alphabetic. Confirm that its documented history resets the suffix to `a` on a new maintenance date; do not reinterpret it as the application form `1.YYYYMMDD.N`.
+5. When multiple authoritative version sources exist, compare them and report any mismatch.
 
 ## Determine the Tag Convention
 
@@ -27,9 +28,10 @@ Known miku-soft patterns include:
 
 - common version form: `0.4.3` becomes `v0.4.3`
 - date-identifier form: `1.20260719.3` becomes `v20260719c`, using `1=a`, `2=b`, `3=c`, and so on
+- content-repository `VERSION.md` form: `20260719c` becomes `v20260719c`; on a new date the version and tag use suffix `a`, such as `20260720a`
 - repository-specific direct date tags such as `20260719` or `20260719a`
 
-Use the date-identifier form for repositories whose versions primarily identify when a build was made rather than express a meaningful semantic version. Do not select it from the numeric shape alone; require repository rules or consistent history. Preserve the observed prefix. If the convention is ambiguous, report it as unresolved and do not label a tag incorrect. Do not extrapolate an alphabetic sequence beyond its documented or observed range.
+Use the date-identifier form for repositories whose versions primarily identify when a build was made rather than express a meaningful semantic version. The root-`VERSION.md` content convention is a separate explicitly adopted form: it uses `v<VERSION>`, advances its suffix only within a date, and resets it to `a` when the date changes. Do not select either form from the numeric shape alone; require repository rules or consistent history. Preserve the observed prefix. If the convention is ambiguous, report it as unresolved and do not label a tag incorrect. Do not extrapolate an alphabetic sequence beyond its documented or observed range.
 
 ## Run Two Independent Checks
 

--- a/skills/igapyon-miku-scm/scripts/post-merge-next-work.mjs
+++ b/skills/igapyon-miku-scm/scripts/post-merge-next-work.mjs
@@ -37,7 +37,12 @@ function branchName(base, date = new Date()) {
   return `${base}-tiga${String(date.getMonth() + 1).padStart(2, "0")}${String(date.getDate()).padStart(2, "0")}${abc(date.getHours())}${abc(Math.floor(date.getMinutes() / 10))}${abc(date.getMinutes() % 10)}`;
 }
 async function version(root, commit, git = runner) {
-  const pom = git(root, ["show", `${commit}:pom.xml`]).out;
+  const standalone = git(root, ["show", `${commit}:VERSION.md`], true);
+  const standaloneValue = standalone.ok ? standalone.out.trim() : "";
+  if (/^\d{8}[a-z]+$/.test(standaloneValue)) {
+    return { source: "VERSION.md", value: standaloneValue, tag: `v${standaloneValue}`, commit };
+  }
+  const pom = git(root, ["show", `${commit}:pom.xml`], true).out;
   const value = pom.match(/<project\b[\s\S]*?<version>([^<]+)<\/version>/)?.[1]?.trim() ?? "unresolved";
   const m = value.match(/^1\.(\d{8})\.([1-9]\d*)$/);
   return { source: "pom.xml", value, tag: m ? `v${m[1]}${String.fromCharCode(96 + Number(m[2]))}` : "unresolved", commit };

--- a/skills/igapyon-miku-scm/scripts/post-recommit-publish.mjs
+++ b/skills/igapyon-miku-scm/scripts/post-recommit-publish.mjs
@@ -247,6 +247,12 @@ function chooseUniqueConvention(candidates) {
 async function resolveRecommendedTag(root, git) {
   let version = "";
   try {
+    const standalone = (await readFile(path.join(root, "VERSION.md"), "utf8")).trim();
+    if (/^\d{8}[a-z]+$/.test(standalone)) return { version: standalone, tag: `v${standalone}` };
+  } catch {
+    // VERSION.md is optional.
+  }
+  try {
     const packageJson = JSON.parse(await readFile(path.join(root, "package.json"), "utf8"));
     if (typeof packageJson.version === "string") version = packageJson.version;
   } catch {

--- a/skills/igapyon-miku-scm/tests/post-recommit-publish.test.mjs
+++ b/skills/igapyon-miku-scm/tests/post-recommit-publish.test.mjs
@@ -124,6 +124,39 @@ test("post-merge helper creates the next work branch from refreshed devel", asyn
   assert.equal(git(state.repo, "branch", "--show-current"), "devel-tiga0725ief");
 });
 
+test("content VERSION.md derives a v-prefixed tag and resets to a on a new date", async (t) => {
+  const state = await scenario(t);
+  await writeFile(path.join(state.repo, "VERSION.md"), "20260726a\n", "utf8");
+  git(state.repo, "add", "VERSION.md");
+  git(state.repo, "commit", "-m", "add content version");
+  state.expectedHead = git(state.repo, "rev-parse", "HEAD");
+
+  const result = await runPublish(
+    optionsFor(state, "--expect-new-remote-branch", "--apply"),
+    applyDependencies,
+  );
+
+  assert.equal(result.version, "20260726a");
+  assert.equal(result.recommended_tag, "v20260726a");
+});
+
+test("post-merge helper derives a content VERSION.md tag after same-day overflow", async (t) => {
+  const state = await scenario(t);
+  await writeFile(path.join(state.repo, "VERSION.md"), "20260725aa\n", "utf8");
+  git(state.repo, "add", "VERSION.md");
+  git(state.repo, "commit", "-m", "add content version");
+  git(state.repo, "push", "origin", "HEAD:devel");
+  git(state.repo, "branch", "-m", state.branch, `${state.branch}-done`);
+
+  const result = await runNextWork({ repo: state.repo, remote: "origin", base: "devel", confirmedMerged: true, apply: true }, {
+    now: () => new Date("2026-07-25T08:45:00+09:00"),
+  });
+
+  assert.equal(result.version_source, "VERSION.md");
+  assert.equal(result.version, "20260725aa");
+  assert.equal(result.recommended_tag, "v20260725aa");
+});
+
 test("apply rejects a changed reviewed local HEAD before push", async (t) => {
   const state = await scenario(t);
   const wrongHead = "0".repeat(40);

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260725e
+Version: 20260725f
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

アプリ本体や Agent Skill ではないコンテンツ中心リポジトリで、root `VERSION.md` をバージョン情報源として運用するための規則を追加します。

## 変更内容

- `YYYYMMDD<suffix>` 形式を定義し、同日内は `a` から `z`、続いて `aa` 以降へ進め、日付変更時は `a` に戻す規則を追加
- `VERSION.md` の値から `v<VERSION>` 形式の推奨タグを導出する監査・インクリメント規則を追加
- push 後と PR マージ後の静的 Node ヘルパーで `VERSION.md` を読み取り、推奨タグを返すよう更新
- 同日 `aa` と新日付 `a` のタグ導出を検証する回帰テストを追加
- リポジトリ版を `1.20260725.6`、みくく連動版を `20260725f` に更新

## 確認

- `npm run test:miku-scm`
- `mvn generate-resources`