### PR TITLE
外部同梱skillの追加と更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,8 +361,9 @@ release staging に全 skill をそろえた後、同梱した index generator �
 - `miku-repo-bundle-skills` `v0.5.0.1` (experimental): `skills/igapyon-miku-repo-bundle/`
 - `miku-grep-skills` `v0.10.1.1` (experimental): `skills/igapyon-miku-grep/`
 - `miku-prompt-lint-skills` `v0.5.0`: `skills/igapyon-miku-prompt-lint/`
-- `miku-ai-assistant-builder-skills` `v0.7.1`: `skills/igapyon-miku-ai-assistant-builder/`
+- `miku-ai-assistant-builder-skills` `v0.10.0`: `skills/igapyon-miku-ai-assistant-builder/`
 - `miku-ms-office-skills` `v0.6.2`: `skills/igapyon-miku-ms-office/`
+- `miku-json2xlsx-skills` `v0.3.0`: `skills/igapyon-miku-json2xlsx/`
 - `miku-readfile-skills` `v0.5.0.2`: `skills/miku-readfile/`
 - `mikuproject-skills` `v0.8.1.1`: `skills/mikuproject/`
 - `mikuscore-skills` `v0.1.0`: `skills/mikuscore/`

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>jp.igapyon</groupId>
   <artifactId>igapyon-agent-skills</artifactId>
-  <version>1.20260725.6</version>
+  <version>1.20260725.7</version>
   <packaging>pom</packaging>
 
   <name>igapyon-agent-skills</name>
@@ -27,11 +27,14 @@
     <external.miku-prompt-lint-skills.ref>v0.5.0</external.miku-prompt-lint-skills.ref>
     <external.miku-prompt-lint-skills.skillName>igapyon-miku-prompt-lint</external.miku-prompt-lint-skills.skillName>
     <external.miku-ai-assistant-builder-skills.repo>https://github.com/igapyon/miku-ai-assistant-builder-skills.git</external.miku-ai-assistant-builder-skills.repo>
-    <external.miku-ai-assistant-builder-skills.ref>v0.8.1</external.miku-ai-assistant-builder-skills.ref>
+    <external.miku-ai-assistant-builder-skills.ref>v0.10.0</external.miku-ai-assistant-builder-skills.ref>
     <external.miku-ai-assistant-builder-skills.skillName>igapyon-miku-ai-assistant-builder</external.miku-ai-assistant-builder-skills.skillName>
     <external.miku-ms-office-skills.repo>https://github.com/igapyon/miku-ms-office-skills.git</external.miku-ms-office-skills.repo>
     <external.miku-ms-office-skills.ref>v0.6.2</external.miku-ms-office-skills.ref>
     <external.miku-ms-office-skills.skillName>igapyon-miku-ms-office</external.miku-ms-office-skills.skillName>
+    <external.miku-json2xlsx-skills.repo>https://github.com/igapyon/miku-json2xlsx-skills.git</external.miku-json2xlsx-skills.repo>
+    <external.miku-json2xlsx-skills.ref>v0.3.0</external.miku-json2xlsx-skills.ref>
+    <external.miku-json2xlsx-skills.skillName>igapyon-miku-json2xlsx</external.miku-json2xlsx-skills.skillName>
     <external.miku-readfile-skills.repo>https://github.com/igapyon/miku-readfile-skills.git</external.miku-readfile-skills.repo>
     <external.miku-readfile-skills.ref>v0.5.0.2</external.miku-readfile-skills.ref>
     <external.miku-readfile-skills.skillName>miku-readfile</external.miku-readfile-skills.skillName>
@@ -114,6 +117,9 @@
                 <argument>${external.miku-ms-office-skills.repo}</argument>
                 <argument>${external.miku-ms-office-skills.ref}</argument>
                 <argument>${external.miku-ms-office-skills.skillName}</argument>
+                <argument>${external.miku-json2xlsx-skills.repo}</argument>
+                <argument>${external.miku-json2xlsx-skills.ref}</argument>
+                <argument>${external.miku-json2xlsx-skills.skillName}</argument>
                 <argument>${external.miku-readfile-skills.repo}</argument>
                 <argument>${external.miku-readfile-skills.ref}</argument>
                 <argument>${external.miku-readfile-skills.skillName}</argument>

--- a/skills/igapyon-mikuku-agent/references/VERSION.md
+++ b/skills/igapyon-mikuku-agent/references/VERSION.md
@@ -1,6 +1,6 @@
 # みくく Version
 
-Version: 20260725f
+Version: 20260725g
 
 ## Version Rule
 


### PR DESCRIPTION
## 概要

release archiveへ同梱する外部skillを追加・更新し、リポジトリの保守バージョンを更新します。

## 変更内容

- `miku-json2xlsx-skills` v0.3.0を`igapyon-miku-json2xlsx`として外部同梱対象へ追加
- `miku-ai-assistant-builder-skills`の固定バージョンをv0.10.0へ更新
- READMEの外部同梱skill一覧を現在の固定バージョンへ整合
- リポジトリバージョンを`1.20260725.7`へ更新
- みくくバージョンを`20260725g`へ更新

## 検証

- `mvn clean package`
- release archive内の外部skill、runtime、`EXTERNAL_SKILLS.lock`を確認